### PR TITLE
feat: v0.1.0 release prep

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # for Trusted Publishing (no API token needed)
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Python](https://img.shields.io/pypi/pyversions/drt-core)](https://pypi.org/project/drt-core/)
 
-**drt** syncs data from your data warehouse (BigQuery) to external services — declaratively, via YAML and CLI.
+**drt** syncs data from your data warehouse to external services — declaratively, via YAML and CLI.
 Think `dbt run` → `drt run`. Same developer experience, opposite data direction.
 
 ```bash
-pip install drt-core[bigquery]
+pip install drt-core          # core (DuckDB included)
+pip install drt-core[bigquery]  # + BigQuery
 drt init
 drt run --dry-run
 drt run
@@ -54,9 +55,11 @@ This creates:
 
 ```
 my-drt-project/
-├── drt_project.yml   # project config (source: BigQuery)
+├── drt_project.yml   # project config
 └── syncs/            # put your sync definitions here
 ```
+
+`drt init` prompts for source type: **bigquery**, **duckdb**, or **postgres**.
 
 ### 3. Create a sync
 
@@ -106,15 +109,28 @@ drt status                  # show recent sync status
 
 ---
 
+## Connectors
+
+| Type | Name | Install |
+|------|------|---------|
+| **Source** | BigQuery | `pip install drt-core[bigquery]` |
+| **Source** | DuckDB | `pip install drt-core[duckdb]` |
+| **Source** | PostgreSQL | `pip install drt-core[postgres]` |
+| **Destination** | REST API | (core) |
+| **Destination** | Slack Incoming Webhook | (core) |
+| **Destination** | GitHub Actions (workflow_dispatch) | (core) |
+| **Destination** | HubSpot (Contacts / Deals / Companies) | (core) |
+
+---
+
 ## Roadmap
 
 | Version | Focus |
 |---------|-------|
-| **v0.1** | BigQuery source + REST API destination, CLI skeleton, dry-run |
-| v0.2 | Incremental sync, upsert/delete, state persistence |
-| v0.3 | Slack / Google Sheets connectors, scheduling |
+| **v0.1** ✅ | BigQuery / DuckDB / Postgres sources · REST API / Slack / GitHub Actions / HubSpot destinations · CLI · dry-run |
+| v0.2 | Incremental sync, state persistence improvements |
+| v0.3 | Scheduling (cron-style), Google Sheets connector |
 | v0.4 | MCP Server (`uvx drt mcp run`), AI Skills |
-| v0.5+ | CRM connectors (HubSpot, Salesforce) |
 | v1.x | Rust engine (PyO3) |
 
 ---

--- a/drt/cli/init_wizard.py
+++ b/drt/cli/init_wizard.py
@@ -16,17 +16,33 @@ from typing import Literal
 import typer
 from jinja2 import Environment, PackageLoader
 
-from drt.config.credentials import BigQueryProfile, save_profile
+from drt.config.credentials import (
+    BigQueryProfile,
+    DuckDBProfile,
+    PostgresProfile,
+    ProfileConfig,
+    save_profile,
+)
 
 
 @dataclass
 class InitAnswers:
     project_name: str
     profile_name: str
-    gcp_project: str
-    dataset: str
-    auth_method: Literal["application_default", "keyfile"]
+    source_type: Literal["bigquery", "duckdb", "postgres"]
+    # BigQuery
+    gcp_project: str = ""
+    dataset: str = ""
+    auth_method: Literal["application_default", "keyfile"] = "application_default"
     keyfile: str | None = None
+    # DuckDB
+    duckdb_database: str = ":memory:"
+    # Postgres
+    pg_host: str = "localhost"
+    pg_port: int = 5432
+    pg_dbname: str = ""
+    pg_user: str = ""
+    pg_password_env: str = "PG_PASSWORD"
 
 
 def run_wizard() -> InitAnswers:
@@ -35,47 +51,55 @@ def run_wizard() -> InitAnswers:
     typer.echo("  Welcome to drt! Let's set up your project.")
     typer.echo("")
 
-    project_name = typer.prompt(
-        "  Project name",
-        default=Path.cwd().name,
-    )
-    profile_name = typer.prompt(
-        "  Profile name",
-        default="dev",
-    )
-    source_type = typer.prompt(
-        "  Source type",
+    project_name = typer.prompt("  Project name", default=Path.cwd().name)
+    profile_name = typer.prompt("  Profile name", default="dev")
+    raw_source = typer.prompt(
+        "  Source type [bigquery/duckdb/postgres]",
         default="bigquery",
     )
+    source_type: Literal["bigquery", "duckdb", "postgres"] = (
+        raw_source if raw_source in ("bigquery", "duckdb", "postgres") else "bigquery"
+    )
 
-    gcp_project = ""
-    dataset = ""
-    auth_method: Literal["application_default", "keyfile"] = "application_default"
-    keyfile: str | None = None
+    answers = InitAnswers(
+        project_name=project_name,
+        profile_name=profile_name,
+        source_type=source_type,
+    )
 
     if source_type == "bigquery":
-        gcp_project = typer.prompt("  GCP project ID")
-        dataset = typer.prompt("  BigQuery dataset")
+        answers.gcp_project = typer.prompt("  GCP project ID")
+        answers.dataset = typer.prompt("  BigQuery dataset")
         raw_method = typer.prompt(
             "  Auth method [application_default/keyfile]",
             default="application_default",
         )
-        auth_method = "keyfile" if raw_method == "keyfile" else "application_default"
-        if auth_method == "keyfile":
-            keyfile = typer.prompt(
+        answers.auth_method = (
+            "keyfile" if raw_method == "keyfile" else "application_default"
+        )
+        if answers.auth_method == "keyfile":
+            answers.keyfile = typer.prompt(
                 "  Path to service account keyfile",
                 default="~/.config/gcloud/service_account.json",
             )
 
+    elif source_type == "duckdb":
+        answers.duckdb_database = typer.prompt(
+            "  DuckDB database path (:memory: for in-memory)",
+            default=":memory:",
+        )
+
+    elif source_type == "postgres":
+        answers.pg_host = typer.prompt("  Host", default="localhost")
+        answers.pg_port = int(typer.prompt("  Port", default="5432"))
+        answers.pg_dbname = typer.prompt("  Database name")
+        answers.pg_user = typer.prompt("  User")
+        answers.pg_password_env = typer.prompt(
+            "  Env var for password", default="PG_PASSWORD"
+        )
+
     typer.echo("")
-    return InitAnswers(
-        project_name=project_name,
-        profile_name=profile_name,
-        gcp_project=gcp_project,
-        dataset=dataset,
-        auth_method=auth_method,
-        keyfile=keyfile,
-    )
+    return answers
 
 
 def scaffold_project(answers: InitAnswers, project_dir: Path) -> list[str]:
@@ -121,13 +145,29 @@ def scaffold_project(answers: InitAnswers, project_dir: Path) -> list[str]:
         created.append(str(drt_gitignore))
 
     # --- ~/.drt/profiles.yml ---
-    profile = BigQueryProfile(
-        type="bigquery",
-        project=answers.gcp_project,
-        dataset=answers.dataset,
-        method=answers.auth_method,
-        keyfile=answers.keyfile,
-    )
+    profile: ProfileConfig
+    if answers.source_type == "bigquery":
+        profile = BigQueryProfile(
+            type="bigquery",
+            project=answers.gcp_project,
+            dataset=answers.dataset,
+            method=answers.auth_method,
+            keyfile=answers.keyfile,
+        )
+    elif answers.source_type == "duckdb":
+        profile = DuckDBProfile(
+            type="duckdb",
+            database=answers.duckdb_database,
+        )
+    else:
+        profile = PostgresProfile(
+            type="postgres",
+            host=answers.pg_host,
+            port=answers.pg_port,
+            dbname=answers.pg_dbname,
+            user=answers.pg_user,
+            password_env=answers.pg_password_env,
+        )
     profiles_path = save_profile(answers.profile_name, profile)
     created.append(str(profiles_path))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "drt-core"
-version = "0.1.0.dev0"
+version = "0.1.0"
 description = "Reverse ETL for the code-first data stack"
 readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "drt-hub", email = "masukai9612kf@gmail.com" }]
 keywords = ["reverse-etl", "data-engineering", "dbt", "bigquery", "cli"]
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 3 - Alpha",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
## Summary

- `drt init` に DuckDB・Postgres のソースタイプ選択を追加（従来は BigQuery のみ）
- README: コネクタ一覧テーブルとロードマップを実装済み内容に更新
- `pyproject.toml`: バージョン `0.1.0`・クラシファイア `3-Alpha` に更新
- `.github/workflows/publish.yml`: `v*` タグ push 時に PyPI へ Trusted Publishing で自動 publish

## Test plan

- [ ] CI が全グリーンであることを確認
- [ ] `drt init` で `duckdb` を選択し、`profiles.yml` にDuckDBプロファイルが書き込まれることを確認
- [ ] PyPI の Trusted Publishing 設定（GitHub Environment `pypi`）を完了後、`v0.1.0` タグを push して publish を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)