### PR TITLE
chore: GitHub setup (CODEOWNERS, uv docs, connector roadmap)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Default owner for everything
+* @drt-hub
+
+# CLI and config
+drt/cli/ @drt-hub
+drt/config/ @drt-hub
+
+# Sources
+drt/sources/ @drt-hub
+
+# Destinations
+drt/destinations/ @drt-hub
+
+# Engine (Rust rewrite candidate — review carefully)
+drt/engine/ @drt-hub
+
+# CI/CD and release
+.github/ @drt-hub
+pyproject.toml @drt-hub

--- a/README.md
+++ b/README.md
@@ -16,8 +16,14 @@
 Think `dbt run` → `drt run`. Same developer experience, opposite data direction.
 
 ```bash
+# pip
 pip install drt-core          # core (DuckDB included)
 pip install drt-core[bigquery]  # + BigQuery
+
+# uv (recommended)
+uv add drt-core
+uv add drt-core[bigquery]
+
 drt init
 drt run --dry-run
 drt run
@@ -42,6 +48,8 @@ drt run
 
 ```bash
 pip install drt-core[bigquery]
+# or
+uv add drt-core[bigquery]
 ```
 
 ### 2. Initialize a project
@@ -111,15 +119,23 @@ drt status                  # show recent sync status
 
 ## Connectors
 
-| Type | Name | Install |
-|------|------|---------|
-| **Source** | BigQuery | `pip install drt-core[bigquery]` |
-| **Source** | DuckDB | `pip install drt-core[duckdb]` |
-| **Source** | PostgreSQL | `pip install drt-core[postgres]` |
-| **Destination** | REST API | (core) |
-| **Destination** | Slack Incoming Webhook | (core) |
-| **Destination** | GitHub Actions (workflow_dispatch) | (core) |
-| **Destination** | HubSpot (Contacts / Deals / Companies) | (core) |
+| Type | Name | Status | Install |
+|------|------|--------|---------|
+| **Source** | BigQuery | ✅ v0.1 | `pip install drt-core[bigquery]` |
+| **Source** | DuckDB | ✅ v0.1 | (core) |
+| **Source** | PostgreSQL | ✅ v0.1 | `pip install drt-core[postgres]` |
+| **Source** | Snowflake | 🗓 planned | `pip install drt-core[snowflake]` |
+| **Source** | Redshift | 🗓 planned | `pip install drt-core[redshift]` |
+| **Source** | MySQL | 🗓 planned | `pip install drt-core[mysql]` |
+| **Destination** | REST API | ✅ v0.1 | (core) |
+| **Destination** | Slack Incoming Webhook | ✅ v0.1 | (core) |
+| **Destination** | GitHub Actions (workflow_dispatch) | ✅ v0.1 | (core) |
+| **Destination** | HubSpot (Contacts / Deals / Companies) | ✅ v0.1 | (core) |
+| **Destination** | Google Sheets | 🗓 v0.3 | (core) |
+| **Destination** | Salesforce | 🗓 planned | (core) |
+| **Destination** | Notion | 🗓 planned | (core) |
+| **Destination** | Linear | 🗓 planned | (core) |
+| **Destination** | SendGrid | 🗓 planned | (core) |
 
 ---
 
@@ -128,8 +144,8 @@ drt status                  # show recent sync status
 | Version | Focus |
 |---------|-------|
 | **v0.1** ✅ | BigQuery / DuckDB / Postgres sources · REST API / Slack / GitHub Actions / HubSpot destinations · CLI · dry-run |
-| v0.2 | Incremental sync, state persistence improvements |
-| v0.3 | Scheduling (cron-style), Google Sheets connector |
+| v0.2 | Incremental sync (`updated_at` watermark), state persistence improvements |
+| v0.3 | Scheduling (cron-style), Google Sheets connector, Snowflake source |
 | v0.4 | MCP Server (`uvx drt mcp run`), AI Skills |
 | v1.x | Rust engine (PyO3) |
 


### PR DESCRIPTION
## Summary

- Add `.github/CODEOWNERS` for code ownership (required by branch protection)
- Add `uv` installation instructions alongside `pip` in README (dlt-style)
- Expand Connectors table with planned sources/destinations (Snowflake, Redshift, MySQL, Salesforce, Notion, Linear, SendGrid)
- Update Roadmap: Snowflake in v0.3, incremental sync watermark detail in v0.2

## Also done (via gh CLI, no PR needed)

- Set repository topics: `reverse-etl`, `dbt`, `bigquery`, `duckdb`, `python`, `cli`, `etl`, `data-engineering`, `postgres`
- Set branch protection on `main`: PR required, CI checks must pass, no force push

## Test plan

- [ ] README renders correctly on GitHub
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)