### PR TITLE
chore: labels.yml, sync-labels workflow, Makefile targets

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,86 @@
+# Issue / PR labels managed as code.
+# Apply with: make sync-labels
+
+# ── Type ─────────────────────────────────────────────────────────────────────
+- name: "bug"
+  color: "d73a4a"
+  description: "Something isn't working"
+
+- name: "feat"
+  color: "0075ca"
+  description: "New feature or request"
+
+- name: "docs"
+  color: "0075ca"
+  description: "Improvements or additions to documentation"
+
+- name: "chore"
+  color: "e4e669"
+  description: "Build process, CI, or tooling changes"
+
+- name: "refactor"
+  color: "e4e669"
+  description: "Code change that neither fixes a bug nor adds a feature"
+
+- name: "test"
+  color: "bfd4f2"
+  description: "Adding or improving tests"
+
+# ── Area ─────────────────────────────────────────────────────────────────────
+- name: "cli"
+  color: "c5def5"
+  description: "CLI commands"
+
+- name: "engine"
+  color: "c5def5"
+  description: "Sync engine (future Rust core)"
+
+- name: "source"
+  color: "c5def5"
+  description: "Source connectors (BigQuery, DuckDB, Postgres…)"
+
+- name: "destination"
+  color: "c5def5"
+  description: "Destination connectors (REST API, Slack, HubSpot…)"
+
+- name: "config"
+  color: "c5def5"
+  description: "Config models, YAML parsing, profiles"
+
+- name: "state"
+  color: "c5def5"
+  description: "State management and persistence"
+
+# ── Status ───────────────────────────────────────────────────────────────────
+- name: "good first issue"
+  color: "7057ff"
+  description: "Good for newcomers"
+
+- name: "help wanted"
+  color: "008672"
+  description: "Extra attention is needed"
+
+- name: "wontfix"
+  color: "ffffff"
+  description: "This will not be worked on"
+
+- name: "duplicate"
+  color: "cfd3d7"
+  description: "This issue or pull request already exists"
+
+# ── Version ──────────────────────────────────────────────────────────────────
+- name: "v0.1-prep"
+  color: "fbca04"
+  description: "v0.1.0 release preparation"
+
+- name: "v0.2"
+  color: "fbca04"
+  description: "Targeted for v0.2"
+
+- name: "v0.3"
+  color: "fbca04"
+  description: "Targeted for v0.3"
+
+- name: "v0.4"
+  color: "fbca04"
+  description: "Targeted for v0.4"

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,21 @@
+name: Sync labels
+
+on:
+  push:
+    branches: [main]
+    paths: [".github/labels.yml"]
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          yaml-file: .github/labels.yml
+          skip-delete: false
+          dry-run: false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install dev lint fmt test clean
+.PHONY: install dev lint fmt test clean topics sync-labels
 
 install:
 	uv pip install -e .
@@ -21,3 +21,20 @@ clean:
 	rm -rf dist build .eggs *.egg-info
 	find . -type d -name __pycache__ -exec rm -rf {} +
 	find . -type d -name .pytest_cache -exec rm -rf {} +
+
+# ── Repo maintenance (maintainer only) ───────────────────────────────────────
+
+topics:  ## Sync repository topics to GitHub
+	gh repo edit drt-hub/drt \
+	  --add-topic reverse-etl \
+	  --add-topic dbt \
+	  --add-topic bigquery \
+	  --add-topic duckdb \
+	  --add-topic python \
+	  --add-topic cli \
+	  --add-topic etl \
+	  --add-topic data-engineering \
+	  --add-topic postgres
+
+sync-labels:  ## Trigger label sync workflow on GitHub
+	gh workflow run sync-labels.yml --repo drt-hub/drt


### PR DESCRIPTION
## Summary

- Add `.github/labels.yml` — issue/PR labels managed as code (type / area / status / version)
- Add `.github/workflows/sync-labels.yml` — auto-syncs labels on push to main when `labels.yml` changes, or via `workflow_dispatch`
- Add `make topics` and `make sync-labels` Makefile targets for maintainers

## Usage

```bash
# Add a topic
make topics   # re-run after editing Makefile topics list

# Sync labels to GitHub
make sync-labels   # triggers GHA workflow
# or: edit .github/labels.yml and push to main
```

## Test plan

- [ ] CI passes
- [ ] merge → sync-labels workflow runs and creates labels on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)