### PR TITLE
fix: read version from package metadata (importlib.metadata)

### DIFF
--- a/drt/__init__.py
+++ b/drt/__init__.py
@@ -3,4 +3,9 @@
 Reverse ETL for the code-first data stack.
 """
 
-__version__ = "0.1.0.dev0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("drt-core")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"


### PR DESCRIPTION
## Summary

`drt --version` was showing `0.1.0.dev0` even after installing `drt-core==0.1.0` from PyPI.

**Root cause:** `drt/__init__.py` had a hardcoded `__version__ = "0.1.0.dev0"` that was never updated.

**Fix:** Use `importlib.metadata.version("drt-core")` so the displayed version always matches the installed package.

```python
from importlib.metadata import PackageNotFoundError, version

try:
    __version__ = version("drt-core")
except PackageNotFoundError:
    __version__ = "0.0.0+unknown"
```

## Test plan

- [ ] `pip install drt-core && drt --version` → `drt version 0.1.0`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)