### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-03-29
+
+### Fixed
+
+- `drt --version` now correctly displays the installed package version (e.g. `0.1.1`) instead of the stale hardcoded value `0.1.0.dev0`. Version is now read dynamically via `importlib.metadata`.
+
 ## [0.1.0] - 2026-03-28
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "drt-core"
-version = "0.1.0"
+version = "0.1.1"
 description = "Reverse ETL for the code-first data stack"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- Bump version to `0.1.1` in `pyproject.toml`
- Add `v0.1.1` entry to `CHANGELOG.md`

Fixes `drt --version` displaying `0.1.0.dev0` (introduced in #21, needs a new PyPI release to take effect).

## Test plan

- [ ] CI passes
- [ ] merge → tag `v0.1.1` → publish workflow runs → `pip install drt-core` → `drt --version` shows `0.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)