### PR TITLE
chore: reorder roadmap — MCP to v0.3, dagster-drt to v0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ drt status                  # show recent sync status
 | **Destination** | Slack Incoming Webhook | ✅ v0.1 | (core) |
 | **Destination** | GitHub Actions (workflow_dispatch) | ✅ v0.1 | (core) |
 | **Destination** | HubSpot (Contacts / Deals / Companies) | ✅ v0.1 | (core) |
-| **Destination** | Google Sheets | 🗓 v0.3 | (core) |
+| **Destination** | Google Sheets | 🗓 v0.4 | (core) |
 | **Destination** | Salesforce | 🗓 planned | (core) |
 | **Destination** | Notion | 🗓 planned | (core) |
 | **Destination** | Linear | 🗓 planned | (core) |
@@ -144,9 +144,9 @@ drt status                  # show recent sync status
 | Version | Focus |
 |---------|-------|
 | **v0.1** ✅ | BigQuery / DuckDB / Postgres sources · REST API / Slack / GitHub Actions / HubSpot destinations · CLI · dry-run |
-| v0.2 | Incremental sync (`updated_at` watermark), state persistence improvements |
-| v0.3 | Scheduling (cron-style), Google Sheets connector, Snowflake source |
-| v0.4 | MCP Server (`uvx drt mcp run`), AI Skills |
+| v0.2 | Incremental sync (`updated_at` watermark), retry logic, row-level error details |
+| v0.3 | MCP Server (`uvx drt mcp run`), AI Skills |
+| v0.4 | Dagster / Airflow integration, Google Sheets connector, Snowflake source |
 | v1.x | Rust engine (PyO3) |
 
 ---


### PR DESCRIPTION
## Summary

Reorder v0.3 and v0.4 based on strategy doc recommendation:

> MCP Server is strategically important as the LLM-native differentiator — no competitor has it.

| Before | After |
|--------|-------|
| v0.3: cron + Google Sheets | v0.3: MCP Server (`uvx drt mcp run`) |
| v0.4: MCP Server | v0.4: Dagster/Airflow integration + Google Sheets + Snowflake |

Also updated issue labels: #17 (MCP) → v0.3, #16 (dagster-drt) + #18 (Snowflake) → v0.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)