### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-03-30
+
+### Added
+
+#### Incremental Sync
+- `sync.mode: incremental` — watermark-based incremental sync using a `cursor_field`
+- Saves `last_cursor_value` in `.drt/state.json` after each run
+- Injects `WHERE {cursor_field} > '{last_cursor_value}'` automatically on next run
+- Works with both `ref('table')` and raw SQL models
+
+#### Retry Configuration
+- `sync.retry` is now fully configurable per-sync in YAML (`max_attempts`, `initial_backoff`, `backoff_multiplier`, `max_backoff`, `retryable_status_codes`)
+- Previously used a hardcoded default; now reads from `SyncOptions.retry`
+
+### Fixed
+- Removed duplicate `RetryConfig` dataclass from `destinations/retry.py` (was shadowing the Pydantic model in `config/models.py`)
+
+### Tests
+- 6 new unit tests for incremental sync (resolver + engine)
+- Integration test suite cleaned up: removed monkey-patching of internal `_DEFAULT_RETRY`
+
 ## [0.1.1] - 2026-03-29
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "drt-core"
-version = "0.1.1"
+version = "0.2.0"
 description = "Reverse ETL for the code-first data stack"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- Bump version `0.1.1` → `0.2.0` in `pyproject.toml`
- Add v0.2.0 CHANGELOG entry (incremental sync, retry config, test improvements)

## Included in this release (from #27)

- **Incremental sync**: `cursor_field` watermark, `WHERE` injection, state persistence
- **Retry from config**: `SyncOptions.retry` fully configurable per-sync YAML
- **RetryConfig dedup fix**: removed shadowing dataclass from `destinations/retry.py`
- **6 new unit tests** + cleaned-up integration suite

## Test plan
- [ ] CI passes (all Python versions)
- [ ] After merge, tag `v0.2.0` and publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)