### PR TITLE
chore: update roadmap and docs for v0.3 planning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,11 @@ make fmt      # ruff format + fix
 
 ## Current Status
 
-- **Phase 1 in progress** — CLI skeleton, config models, BigQuery source stub, REST API destination, State Manager
-- Core protocols are defined but not fully wired in CLI yet
-- No real BigQuery/HTTP calls in tests (use mocks)
+- **v0.2 released** — Incremental sync, retry config, 53 tests passing
+- CLI fully wired: `init`, `run`, `list`, `validate`, `status`
+- Sources: BigQuery, DuckDB, PostgreSQL
+- Destinations: REST API, Slack, GitHub Actions, HubSpot
+- Integration tests use `pytest-httpserver` (no real HTTP mocking)
 
 ## What NOT to do
 
@@ -64,6 +66,7 @@ make fmt      # ruff format + fix
 ## Roadmap Reference
 
 See the roadmap table in README.md. The short version:
-- v0.1: BigQuery → REST API working end-to-end
-- v0.4: MCP Server via FastMCP
+- v0.1 ✅: BigQuery → REST API working end-to-end
+- v0.2 ✅: Incremental sync + retry from config
+- v0.3: MCP Server (`uvx drt mcp run`) + AI Skills for Claude Code + LLM-readable docs
 - v1.x: Rust engine via PyO3

--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ drt status                  # show recent sync status
 | Version | Focus |
 |---------|-------|
 | **v0.1** ✅ | BigQuery / DuckDB / Postgres sources · REST API / Slack / GitHub Actions / HubSpot destinations · CLI · dry-run |
-| v0.2 | Incremental sync (`updated_at` watermark), retry logic, row-level error details |
-| v0.3 | MCP Server (`uvx drt mcp run`), AI Skills |
-| v0.4 | Dagster / Airflow integration, Google Sheets connector, Snowflake source |
+| **v0.2** ✅ | Incremental sync (`cursor_field` watermark) · retry config per-sync · 53 tests |
+| v0.3 | MCP Server (`uvx drt mcp run`) · AI Skills for Claude Code · LLM-readable docs · row-level error details |
+| v0.4 | Dagster / Airflow integration · Google Sheets connector · Snowflake source |
 | v1.x | Rust engine (PyO3) |
 
 ---


### PR DESCRIPTION
## Summary

- Mark v0.2 ✅ in README roadmap with accurate scope
- Update v0.3 scope: MCP Server + AI Skills + LLM docs + row-level errors
- Update CLAUDE.md: current status (v0.2 released), roadmap reference fixed

## Issues updated (separately)
- #24 title updated (v0.2 → v0.3)
- #30 created: AI Skills for Claude Code
- #31 created: LLM-readable docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)