### PR TITLE
feat: LLM-readable docs + AI Skills for Claude Code (v0.3)

### DIFF
--- a/.claude/commands/drt-create-sync.md
+++ b/.claude/commands/drt-create-sync.md
@@ -1,0 +1,32 @@
+Create a drt sync YAML configuration file for the user.
+
+## Steps
+
+1. Ask the user for the following (or infer from context if already provided):
+   - **Source table or SQL**: what data to sync (e.g. `ref('new_users')` or a SQL query)
+   - **Destination**: where to send it (Slack, REST API, HubSpot, GitHub Actions, or other)
+   - **Sync mode**: full (every run) or incremental (watermark-based, needs a cursor column)
+   - **Frequency intent**: helps set `batch_size` and `rate_limit`
+
+2. Generate a valid sync YAML using the exact field names from `docs/llm/API_REFERENCE.md`.
+
+3. Output the YAML in a code block and suggest where to save it: `syncs/<name>.yml`
+
+4. Show the command to validate and run it:
+   ```bash
+   drt validate
+   drt run --select <name> --dry-run
+   drt run --select <name>
+   ```
+
+## Rules
+
+- Use `type: bearer` + `token_env` (never hardcode tokens)
+- Default `on_error: skip` for Slack/webhooks, `on_error: fail` for critical syncs
+- For incremental mode, always include `cursor_field`
+- Use `ref('table_name')` when the source is a single DWH table; raw SQL when filtering or joining
+- Jinja2 templates use `{{ row.<column_name> }}` — column names must come from the user
+
+## Reference
+
+See `docs/llm/API_REFERENCE.md` for all fields, types, and defaults.

--- a/.claude/commands/drt-debug.md
+++ b/.claude/commands/drt-debug.md
@@ -1,0 +1,48 @@
+Debug a failing drt sync.
+
+## Steps
+
+1. Ask the user to share (or read from context):
+   - The error output from `drt run` or `drt status`
+   - The sync YAML (`syncs/<name>.yml`)
+   - The `drt_project.yml` if relevant
+
+2. Diagnose the root cause using the patterns below.
+
+3. Suggest a concrete fix with the corrected YAML or command.
+
+## Common Error Patterns
+
+### Auth errors (401, 403)
+- **Cause**: `token_env` or `value_env` env var not set, or token has wrong permissions
+- **Fix**: Check `echo $MY_TOKEN`, verify token scopes. For HubSpot, confirm Private App has CRM write scope. For GitHub, confirm `actions: write`.
+
+### Rate limit (429)
+- **Cause**: Sending too fast for the destination's limits
+- **Fix**: Lower `sync.rate_limit.requests_per_second`. HubSpot max: 9 req/s. GitHub Actions: 5 req/s.
+- **Also**: Add retry config — 429 is retryable by default.
+
+### Connection errors / timeouts
+- **Cause**: Wrong URL, network issue, or destination is down
+- **Fix**: Verify `url` with `curl -X POST <url>` manually. Check `drt run --dry-run` to confirm config parses correctly.
+
+### Template errors
+- **Cause**: `{{ row.field_name }}` references a column that doesn't exist in the source
+- **Fix**: Run `drt run --dry-run` to preview rows, confirm column names match the template.
+
+### Incremental sync not filtering
+- **Cause**: `mode: incremental` set but no saved cursor yet (first run syncs all rows)
+- **Fix**: This is expected on the first run. Check `drt status` after first run — `last_cursor_value` should be set.
+
+### `on_error: fail` stopping early
+- **Cause**: Default behavior — first failure stops the sync
+- **Fix**: Change to `on_error: skip` to continue past failures and see full error count.
+
+### Profile not found
+- **Cause**: `~/.drt/profiles.yml` missing or profile name mismatch
+- **Fix**: Check `cat ~/.drt/profiles.yml`, verify the profile name matches `drt_project.yml`.
+
+## Reference
+
+See `docs/llm/CONTEXT.md` for architecture and key concepts.
+See `docs/llm/API_REFERENCE.md` for all config fields.

--- a/.claude/commands/drt-init.md
+++ b/.claude/commands/drt-init.md
@@ -1,0 +1,51 @@
+Guide the user through initializing a new drt project.
+
+## Steps
+
+1. Confirm the user has drt installed:
+   ```bash
+   pip install drt-core[bigquery]   # BigQuery
+   # or
+   uv add drt-core[bigquery]
+   ```
+
+2. Create and enter a project directory:
+   ```bash
+   mkdir my-drt-project && cd my-drt-project
+   drt init
+   ```
+   `drt init` will prompt for:
+   - Project name
+   - Source type (bigquery / duckdb / postgres)
+   - GCP project + dataset (if BigQuery)
+   - Auth method (Application Default Credentials or keyfile)
+
+3. This creates:
+   ```
+   my-drt-project/
+   ├── drt_project.yml
+   └── syncs/
+       └── example_sync.yml
+   ```
+   And writes credentials to `~/.drt/profiles.yml`.
+
+4. For BigQuery, ensure credentials are set up:
+   ```bash
+   gcloud auth application-default login
+   # or set GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
+   ```
+
+5. Validate the setup:
+   ```bash
+   drt validate
+   drt list
+   ```
+
+6. Offer to create a first sync using `/drt-create-sync`.
+
+## Tips
+
+- `drt_project.yml` selects which profile from `~/.drt/profiles.yml` to use
+- Put each sync in a separate `syncs/<name>.yml` file
+- Use `drt run --dry-run` to test without writing data
+- Use `drt status` to check recent run results

--- a/.claude/commands/drt-migrate.md
+++ b/.claude/commands/drt-migrate.md
@@ -1,0 +1,60 @@
+Help the user migrate from an existing Reverse ETL tool (Census, Hightouch, Polytomic, or custom scripts) to drt.
+
+## Steps
+
+1. Ask the user to share their existing sync configuration (screenshot, YAML, JSON, or description).
+
+2. Map their existing config to drt equivalents using the table below.
+
+3. Generate a valid `syncs/<name>.yml` for each sync.
+
+4. Note any features that need manual setup (auth env vars, profiles.yml).
+
+## Concept Mapping
+
+### Census / Hightouch → drt
+
+| Census / Hightouch concept | drt equivalent |
+|---------------------------|----------------|
+| Source (BigQuery model) | `model: ref('table')` or raw SQL |
+| Destination connection | `destination.type` + auth config |
+| Sync behavior: Full | `sync.mode: full` |
+| Sync behavior: Append | `sync.mode: incremental` + `cursor_field` |
+| Field mappings | `body_template` / `properties_template` (Jinja2) |
+| Run schedule | `drt run` via cron or CI |
+| Error notifications | `on_error: skip` + `drt status` |
+
+### Auth migration
+
+| Old tool style | drt equivalent |
+|---------------|----------------|
+| Stored API key in UI | `token_env: MY_TOKEN` + `export MY_TOKEN=...` |
+| OAuth app | Use token from OAuth flow → `token_env` |
+| Service account JSON | Set `GOOGLE_APPLICATION_CREDENTIALS` for BigQuery source |
+
+## Output Format
+
+For each sync, output:
+
+```yaml
+# syncs/<name>.yml
+name: <name>
+description: "Migrated from <tool>"
+model: ref('<table>')   # or raw SQL
+
+destination:
+  type: <type>
+  # ... fields
+
+sync:
+  mode: full   # or incremental
+  # ...
+```
+
+Then summarize:
+- What manual steps are needed (env vars, `~/.drt/profiles.yml`)
+- Any features the old tool had that drt doesn't support yet (flag these clearly)
+
+## Reference
+
+See `docs/llm/API_REFERENCE.md` for all destination types and fields.

--- a/docs/llm/API_REFERENCE.md
+++ b/docs/llm/API_REFERENCE.md
@@ -1,0 +1,311 @@
+# drt API Reference
+
+Single-file reference for all configuration fields. Optimized for LLM use — use this to generate valid drt YAML without hallucinating field names.
+
+---
+
+## `drt_project.yml`
+
+```yaml
+name: my-project          # required: project identifier
+version: "0.1"            # optional, default: "0.1"
+profile: default          # optional, default: "default" — maps to ~/.drt/profiles.yml
+```
+
+---
+
+## `~/.drt/profiles.yml`
+
+```yaml
+default:
+  type: bigquery            # "bigquery" | "duckdb" | "postgres"
+  project: my-gcp-project   # BigQuery: GCP project ID
+  dataset: analytics        # BigQuery: dataset name
+  method: application_default  # "application_default" | "keyfile"
+  keyfile: ~/.drt/sa.json   # only when method=keyfile
+
+# DuckDB example:
+duckdb_local:
+  type: duckdb
+  database: ./data/local.duckdb
+  dataset: main
+
+# PostgreSQL example:
+prod_pg:
+  type: postgres
+  connection_string_env: DATABASE_URL   # env var with postgres:// URL
+  dataset: public
+```
+
+---
+
+## `syncs/<name>.yml` — Full Schema
+
+```yaml
+name: notify_slack          # required: unique sync identifier (matches filename)
+description: "..."          # optional: human-readable description
+model: ref('new_users')     # required: ref('table') | raw SQL | path to .sql file
+
+destination:                # required: see Destination Configs below
+  type: rest_api
+  # ... destination-specific fields
+
+sync:                       # optional: all fields have defaults
+  mode: full                # "full" (default) | "incremental"
+  cursor_field: updated_at  # required when mode=incremental — column name for watermark
+  batch_size: 100           # default: 100 — rows per destination call
+  on_error: fail            # "fail" (default) | "skip"
+  rate_limit:
+    requests_per_second: 10 # default: 10
+  retry:
+    max_attempts: 3         # default: 3
+    initial_backoff: 1.0    # default: 1.0 seconds
+    backoff_multiplier: 2.0 # default: 2.0
+    max_backoff: 60.0       # default: 60.0 seconds
+    retryable_status_codes: [429, 500, 502, 503, 504]  # default as shown
+```
+
+---
+
+## Destination Configs
+
+### `type: rest_api`
+
+```yaml
+destination:
+  type: rest_api
+  url: "https://hooks.example.com/webhook"   # required
+  method: POST                               # "GET"|"POST"|"PUT"|"PATCH"|"DELETE", default: POST
+  headers:                                   # optional dict
+    Content-Type: "application/json"
+    X-Custom-Header: "value"
+  body_template: |                           # optional Jinja2 template → request body
+    {
+      "user_id": "{{ row.id }}",
+      "email": "{{ row.email }}"
+    }
+  auth:                                      # optional — see Auth Configs
+    type: bearer
+    token_env: MY_API_TOKEN
+```
+
+### `type: slack`
+
+```yaml
+destination:
+  type: slack
+  webhook_url: "https://hooks.slack.com/..."   # provide webhook_url OR webhook_url_env
+  webhook_url_env: SLACK_WEBHOOK_URL           # env var name
+  message_template: "New user: {{ row.name }} ({{ row.email }})"  # Jinja2, default: "{{ row }}"
+  block_kit: false                             # true = message_template is Block Kit JSON
+```
+
+Block Kit example:
+```yaml
+  block_kit: true
+  message_template: |
+    {
+      "blocks": [
+        {
+          "type": "section",
+          "text": {"type": "mrkdwn", "text": "*New user:* {{ row.name }}"}
+        }
+      ]
+    }
+```
+
+### `type: github_actions`
+
+```yaml
+destination:
+  type: github_actions
+  owner: myorg                    # required: GitHub org or user
+  repo: myapp                     # required: repository name
+  workflow_id: deploy.yml         # required: workflow filename or numeric ID
+  ref: main                       # default: "main" — branch/tag to run on
+  inputs_template: |              # optional Jinja2 template → JSON object for workflow inputs
+    {
+      "environment": "{{ row.env }}",
+      "version": "{{ row.version }}"
+    }
+  auth:
+    type: bearer
+    token_env: GITHUB_TOKEN       # needs actions:write permission
+```
+
+### `type: hubspot`
+
+```yaml
+destination:
+  type: hubspot
+  object_type: contacts           # "contacts" | "deals" | "companies", default: "contacts"
+  id_property: email              # default: "email" — upsert deduplication key
+  properties_template: |          # optional Jinja2 template → JSON object of HubSpot properties
+    {
+      "email": "{{ row.email }}",
+      "firstname": "{{ row.first_name }}",
+      "lastname": "{{ row.last_name }}",
+      "company": "{{ row.company }}"
+    }
+  auth:
+    type: bearer
+    token_env: HUBSPOT_TOKEN      # Private App token with CRM write scope
+```
+
+---
+
+## Auth Configs
+
+Auth configs are used inside destination configs under the `auth:` key.
+
+### Bearer Token
+
+```yaml
+auth:
+  type: bearer
+  token_env: MY_TOKEN     # recommended: name of env var containing the token
+  token: "sk-..."         # not recommended: hardcoded token (use token_env instead)
+```
+
+→ Sends `Authorization: Bearer <token>` header.
+
+### API Key
+
+```yaml
+auth:
+  type: api_key
+  header: X-API-Key       # default: "X-API-Key" — header name
+  value_env: MY_API_KEY   # recommended: env var name
+  value: "abc123"         # not recommended: hardcoded value
+```
+
+→ Sends `<header>: <value>` header.
+
+### Basic Auth
+
+```yaml
+auth:
+  type: basic
+  username_env: API_USERNAME   # required: env var name
+  password_env: API_PASSWORD   # required: env var name
+```
+
+→ Sends `Authorization: Basic <base64(username:password)>` header.
+
+---
+
+## Complete Examples
+
+### Slack notification — incremental
+
+```yaml
+name: new_user_slack
+description: "Notify Slack when new users sign up"
+model: ref('users')
+
+destination:
+  type: slack
+  webhook_url_env: SLACK_WEBHOOK_URL
+  message_template: ":wave: New user: *{{ row.name }}* ({{ row.email }})"
+
+sync:
+  mode: incremental
+  cursor_field: created_at
+  batch_size: 50
+  on_error: skip
+  rate_limit:
+    requests_per_second: 5
+```
+
+### HubSpot contacts upsert — full
+
+```yaml
+name: sync_contacts_hubspot
+description: "Keep HubSpot contacts in sync with DWH"
+model: ref('active_customers')
+
+destination:
+  type: hubspot
+  object_type: contacts
+  id_property: email
+  properties_template: |
+    {
+      "email": "{{ row.email }}",
+      "firstname": "{{ row.first_name }}",
+      "lastname": "{{ row.last_name }}",
+      "company": "{{ row.company_name }}",
+      "lifecyclestage": "customer"
+    }
+  auth:
+    type: bearer
+    token_env: HUBSPOT_TOKEN
+
+sync:
+  mode: full
+  batch_size: 100
+  on_error: skip
+  retry:
+    max_attempts: 5
+    initial_backoff: 2.0
+```
+
+### GitHub Actions deploy trigger
+
+```yaml
+name: trigger_deploy
+description: "Trigger deploy workflow for approved releases"
+model: "SELECT env, version FROM releases WHERE approved = true AND deployed = false"
+
+destination:
+  type: github_actions
+  owner: myorg
+  repo: myapp
+  workflow_id: deploy.yml
+  ref: main
+  inputs_template: |
+    {
+      "environment": "{{ row.env }}",
+      "version": "{{ row.version }}"
+    }
+  auth:
+    type: bearer
+    token_env: GITHUB_TOKEN
+
+sync:
+  mode: incremental
+  cursor_field: approved_at
+  on_error: fail
+```
+
+### REST API with custom auth header
+
+```yaml
+name: push_to_webhook
+model: ref('events')
+
+destination:
+  type: rest_api
+  url: "https://api.example.com/events"
+  method: POST
+  headers:
+    Content-Type: "application/json"
+  body_template: |
+    {
+      "event_id": "{{ row.id }}",
+      "type": "{{ row.event_type }}",
+      "occurred_at": "{{ row.created_at }}"
+    }
+  auth:
+    type: api_key
+    header: X-API-Key
+    value_env: EXAMPLE_API_KEY
+
+sync:
+  batch_size: 50
+  rate_limit:
+    requests_per_second: 20
+  retry:
+    max_attempts: 3
+    retryable_status_codes: [429, 500, 502, 503, 504]
+  on_error: skip
+```

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -1,0 +1,157 @@
+# drt — LLM Context
+
+This document is optimized for LLM consumption. It gives you the full context needed to help users configure, debug, and extend drt.
+
+## What is drt?
+
+**drt** (data reverse tool) is a CLI tool that syncs data from a data warehouse to external services, declaratively via YAML.
+
+```
+dlt (load into DWH) → dbt (transform) → drt (activate out of DWH)
+```
+
+- **Category:** Reverse ETL
+- **Tagline:** "Reverse ETL for the code-first data stack"
+- **Install:** `pip install drt-core` or `uv add drt-core`
+- **Package name:** `drt-core` (PyPI) — CLI command is `drt`
+
+## What drt is NOT
+
+- Not a data loader (that's dlt)
+- Not a transformer (that's dbt)
+- Not a scheduler — it runs via CLI or cron, not a built-in scheduler
+- Not a SaaS — fully self-hosted OSS (Apache 2.0)
+
+## Architecture
+
+```
+drt_project.yml          # project config (source profile)
+syncs/*.yml              # one file per sync definition
+
+CLI (drt run)
+  → Config Parser        # parse + validate YAML via Pydantic
+  → Source               # extract rows from DWH
+  → Engine (sync.py)     # batch, orchestrate, track cursor
+  → Destination          # load rows to external service
+  → State Manager        # persist last run result to .drt/state.json
+```
+
+## Project Structure
+
+```
+my-project/
+├── drt_project.yml       # required: project name + source profile
+├── syncs/
+│   ├── notify_slack.yml  # one sync per file
+│   └── update_hubspot.yml
+└── syncs/models/
+    └── active_users.sql  # optional: custom SQL (overrides ref())
+```
+
+## Sources (where data comes from)
+
+| Source | Extra | Notes |
+|--------|-------|-------|
+| BigQuery | `drt-core[bigquery]` | Uses ADC or keyfile |
+| DuckDB | (core) | Local `.duckdb` file |
+| PostgreSQL | `drt-core[postgres]` | Connection string via env |
+
+Source is configured in `~/.drt/profiles.yml` (dbt-style):
+
+```yaml
+default:
+  type: bigquery
+  project: my-gcp-project
+  dataset: analytics
+```
+
+## Destinations (where data goes)
+
+| Destination | `type` value | Notes |
+|-------------|-------------|-------|
+| REST API (generic) | `rest_api` | Any HTTP endpoint |
+| Slack Webhook | `slack` | Incoming webhook |
+| GitHub Actions | `github_actions` | workflow_dispatch trigger |
+| HubSpot CRM | `hubspot` | Contacts / Deals / Companies upsert |
+
+## CLI Commands
+
+```bash
+drt init                          # interactive project wizard
+drt list                          # list sync definitions
+drt validate                      # validate all sync YAMLs
+drt run                           # run all syncs
+drt run --select <sync-name>      # run one sync
+drt run --dry-run                 # preview without writing data
+drt status                        # show recent sync results
+```
+
+## Key Concepts
+
+### Sync Modes
+
+**Full sync** (default): Extract all rows and send to destination on every run.
+
+**Incremental sync**: Extract only new/updated rows using a watermark column.
+- Set `sync.mode: incremental` and `sync.cursor_field: <column>`
+- drt saves `last_cursor_value` in `.drt/state.json` after each run
+- Next run automatically injects `WHERE <cursor_field> > '<last_value>'`
+
+### Model Reference
+
+The `model` field in a sync can be:
+- `ref('table_name')` — expands to `SELECT * FROM <dataset>.<table_name>`
+- Raw SQL — `SELECT id, email FROM analytics.users WHERE active = true`
+- drt checks `syncs/models/<name>.sql` first; if found, uses that file's content
+
+### Jinja2 Templates
+
+Destination configs support Jinja2 templating with `{{ row.<field> }}`:
+
+```yaml
+body_template: |
+  {"text": "New user: {{ row.name }} ({{ row.email }})"}
+```
+
+The `row` variable contains all columns from the current record as a dict.
+
+### Error Handling
+
+- `on_error: fail` (default) — stop the entire sync on first failure
+- `on_error: skip` — log the error, continue with remaining records
+
+### Rate Limiting
+
+```yaml
+sync:
+  rate_limit:
+    requests_per_second: 10  # default: 10
+```
+
+### Retry
+
+```yaml
+sync:
+  retry:
+    max_attempts: 3           # default: 3
+    initial_backoff: 1.0      # seconds
+    backoff_multiplier: 2.0   # exponential: 1s, 2s, 4s...
+    max_backoff: 60.0         # cap at 60s
+    retryable_status_codes: [429, 500, 502, 503, 504]
+```
+
+## State File
+
+`.drt/state.json` stores the result of the last run per sync:
+
+```json
+{
+  "notify_slack": {
+    "sync_name": "notify_slack",
+    "last_run_at": "2026-03-30T12:00:00",
+    "records_synced": 42,
+    "status": "success",
+    "last_cursor_value": "2026-03-30T11:59:00"
+  }
+}
+```


### PR DESCRIPTION
## Summary

- `docs/llm/CONTEXT.md` — architecture, key concepts, state file format
- `docs/llm/API_REFERENCE.md` — all config fields with types, defaults, full YAML examples
- `.claude/commands/drt-create-sync.md` — `/drt-create-sync` skill
- `.claude/commands/drt-debug.md` — `/drt-debug` skill
- `.claude/commands/drt-init.md` — `/drt-init` skill
- `.claude/commands/drt-migrate.md` — `/drt-migrate` skill (from Census/Hightouch)

Closes #30, closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)