### PR TITLE
feat: MCP Server — drt mcp run (v0.3)

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -203,6 +203,39 @@ def status(
 
 
 # ---------------------------------------------------------------------------
+# mcp
+# ---------------------------------------------------------------------------
+
+mcp_app = typer.Typer(name="mcp", help="MCP server commands.", no_args_is_help=True)
+app.add_typer(mcp_app)
+
+
+@mcp_app.command(name="run")
+def mcp_run() -> None:
+    """Start the drt MCP server (stdio transport).
+
+    Requires: pip install drt-core[mcp]
+
+    Add to Claude Desktop or Cursor:
+        {
+          "mcpServers": {
+            "drt": {
+              "command": "uvx",
+              "args": ["drt-core[mcp]", "mcp", "run"]
+            }
+          }
+        }
+    """
+    try:
+        from drt.mcp.server import run as mcp_server_run
+    except ImportError:
+        print_error("MCP server requires: pip install drt-core[mcp]")
+        raise typer.Exit(1)
+
+    mcp_server_run()
+
+
+# ---------------------------------------------------------------------------
 # Source / Destination factories
 # ---------------------------------------------------------------------------
 

--- a/drt/mcp/__init__.py
+++ b/drt/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP Server for drt — exposes sync operations as MCP tools."""

--- a/drt/mcp/server.py
+++ b/drt/mcp/server.py
@@ -1,0 +1,209 @@
+"""drt MCP Server — exposes drt operations as MCP tools.
+
+Start with:
+    uvx drt-core[mcp] mcp run          # from a drt project directory
+    drt mcp run                         # if drt-core[mcp] is installed
+
+Tools:
+    drt_list_syncs   — list all sync definitions
+    drt_run_sync     — run a specific sync (dry_run supported)
+    drt_get_status   — get last sync result for a sync
+    drt_validate     — validate all sync YAML configs
+    drt_get_schema   — return JSON Schema for drt_project.yml / sync.yml
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def create_server(project_dir: Path | None = None) -> Any:
+    """Create and return a configured FastMCP server instance."""
+    try:
+        from fastmcp import FastMCP
+    except ImportError as e:
+        raise ImportError(
+            "MCP server requires: pip install drt-core[mcp]"
+        ) from e
+
+    _project_dir = project_dir or Path(".")
+
+    mcp: Any = FastMCP(
+        "drt",
+        instructions=(
+            "drt is a Reverse ETL CLI tool. "
+            "Use these tools to list, run, validate, and monitor data syncs "
+            "from a data warehouse to external services."
+        ),
+    )
+
+    # -----------------------------------------------------------------------
+    # drt_list_syncs
+    # -----------------------------------------------------------------------
+
+    @mcp.tool()
+    def drt_list_syncs() -> list[dict[str, str]]:
+        """List all sync definitions in the current drt project.
+
+        Returns a list of sync summaries including name, description,
+        model reference, and destination type.
+        """
+        from drt.config.parser import load_syncs
+
+        syncs = load_syncs(_project_dir)
+        return [
+            {
+                "name": s.name,
+                "description": s.description,
+                "model": s.model,
+                "destination_type": s.destination.type,
+                "mode": s.sync.mode,
+            }
+            for s in syncs
+        ]
+
+    # -----------------------------------------------------------------------
+    # drt_run_sync
+    # -----------------------------------------------------------------------
+
+    @mcp.tool()
+    def drt_run_sync(sync_name: str, dry_run: bool = False) -> dict[str, Any]:
+        """Run a specific drt sync.
+
+        Args:
+            sync_name: Name of the sync to run (from drt_list_syncs).
+            dry_run: If True, extracts data but does not write to destination.
+
+        Returns:
+            Result summary with success count, failed count, and any errors.
+        """
+        from drt.cli.main import _get_destination, _get_source
+        from drt.config.credentials import load_profile
+        from drt.config.parser import load_project, load_syncs
+        from drt.engine.sync import run_sync
+        from drt.state.manager import StateManager
+
+        project = load_project(_project_dir)
+        profile = load_profile(project.profile)
+        syncs = load_syncs(_project_dir)
+
+        matched = [s for s in syncs if s.name == sync_name]
+        if not matched:
+            return {"error": f"No sync named '{sync_name}' found."}
+
+        sync = matched[0]
+        source = _get_source(profile)
+        dest = _get_destination(sync)
+        state_mgr = StateManager(_project_dir)
+
+        result = run_sync(
+            sync, source, dest, profile, _project_dir, dry_run, state_mgr  # type: ignore[arg-type]
+        )
+
+        return {
+            "sync_name": sync_name,
+            "dry_run": dry_run,
+            "success": result.success,
+            "failed": result.failed,
+            "errors": result.errors[:10],  # cap at 10 to avoid huge payloads
+        }
+
+    # -----------------------------------------------------------------------
+    # drt_get_status
+    # -----------------------------------------------------------------------
+
+    @mcp.tool()
+    def drt_get_status(sync_name: str | None = None) -> dict[str, Any]:
+        """Get the last sync run result(s).
+
+        Args:
+            sync_name: Name of a specific sync. If omitted, returns all syncs.
+
+        Returns:
+            Dict of sync_name → last run status (last_run_at, records_synced,
+            status, last_cursor_value).
+        """
+        from drt.state.manager import StateManager
+
+        states = StateManager(_project_dir).get_all()
+
+        if sync_name:
+            if sync_name not in states:
+                return {"error": f"No state found for sync '{sync_name}'."}
+            s = states[sync_name]
+            return {
+                sync_name: {
+                    "last_run_at": s.last_run_at,
+                    "records_synced": s.records_synced,
+                    "status": s.status,
+                    "last_cursor_value": s.last_cursor_value,
+                    "error": s.error,
+                }
+            }
+
+        return {
+            name: {
+                "last_run_at": s.last_run_at,
+                "records_synced": s.records_synced,
+                "status": s.status,
+                "last_cursor_value": s.last_cursor_value,
+                "error": s.error,
+            }
+            for name, s in states.items()
+        }
+
+    # -----------------------------------------------------------------------
+    # drt_validate
+    # -----------------------------------------------------------------------
+
+    @mcp.tool()
+    def drt_validate() -> dict[str, Any]:
+        """Validate all sync YAML configs in the current project.
+
+        Returns:
+            Dict with 'valid' list of sync names and 'errors' dict of
+            sync_name → error message for any invalid configs.
+        """
+        from drt.config.parser import load_syncs
+
+        try:
+            syncs = load_syncs(_project_dir)
+            return {
+                "valid": [s.name for s in syncs],
+                "errors": {},
+            }
+        except Exception as e:
+            return {
+                "valid": [],
+                "errors": {"_project": str(e)},
+            }
+
+    # -----------------------------------------------------------------------
+    # drt_get_schema
+    # -----------------------------------------------------------------------
+
+    @mcp.tool()
+    def drt_get_schema(schema_type: str = "sync") -> dict[str, Any]:
+        """Return the JSON Schema for drt configuration files.
+
+        Args:
+            schema_type: "sync" for sync YAML schema, "project" for
+                         drt_project.yml schema.
+
+        Returns:
+            JSON Schema as a dict.
+        """
+        from drt.config.schema import generate_project_schema, generate_sync_schema
+
+        if schema_type == "project":
+            return generate_project_schema()
+        return generate_sync_schema()
+
+    return mcp
+
+
+def run() -> None:
+    """Entry point for `drt mcp run`."""
+    server = create_server()
+    server.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 bigquery = ["google-cloud-bigquery>=3.0"]
 duckdb = ["duckdb>=0.10"]
 postgres = ["psycopg2-binary>=2.9"]
-mcp = ["fastmcp>=0.1"]
+mcp = ["fastmcp>=2.0"]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
@@ -67,6 +67,11 @@ select = ["E", "F", "I", "UP"]
 python_version = "3.10"
 strict = true
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# fastmcp decorators are untyped — skip strict checks for MCP server module
+module = "drt.mcp.server"
+disallow_untyped_decorators = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -1,0 +1,159 @@
+"""Unit tests for the drt MCP server tools.
+
+Requires: pip install drt-core[mcp]
+These tests are skipped automatically when fastmcp is not installed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastmcp", reason="requires drt-core[mcp]")
+
+from drt.mcp.server import create_server  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def call(server, tool_name: str, **kwargs):  # type: ignore[no-untyped-def]
+    """Call an MCP tool and return the structured result.
+
+    FastMCP wraps non-dict returns in {"result": value};
+    dict returns are passed through directly.
+    """
+    result = await server.call_tool(tool_name, kwargs)
+    sc = result.structured_content
+    # list / scalar returns are wrapped in {"result": ...}
+    if isinstance(sc, dict) and list(sc.keys()) == ["result"]:
+        return sc["result"]
+    return sc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def project_dir(tmp_path: Path) -> Path:
+    (tmp_path / "drt_project.yml").write_text("name: test-project\nprofile: default\n")
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    (syncs_dir / "notify.yml").write_text(
+        "name: notify\n"
+        "model: ref('users')\n"
+        "destination:\n"
+        "  type: rest_api\n"
+        "  url: https://example.com/hook\n"
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def server(project_dir: Path):  # type: ignore[no-untyped-def]
+    return create_server(project_dir)
+
+
+# ---------------------------------------------------------------------------
+# Server creation
+# ---------------------------------------------------------------------------
+
+def test_create_server_returns_fastmcp_instance() -> None:
+    from fastmcp import FastMCP
+    assert isinstance(create_server(), FastMCP)
+
+
+@pytest.mark.asyncio
+async def test_server_has_expected_tools() -> None:
+    srv = create_server()
+    tools = await srv._local_provider._list_tools()
+    tool_names = {t.name for t in tools}
+    expected = {
+        "drt_list_syncs", "drt_run_sync", "drt_get_status", "drt_validate", "drt_get_schema"
+    }
+    assert expected <= tool_names
+
+
+# ---------------------------------------------------------------------------
+# drt_list_syncs
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_syncs_returns_sync(server) -> None:  # type: ignore[no-untyped-def]
+    result = await call(server, "drt_list_syncs")
+    assert len(result) == 1
+    assert result[0]["name"] == "notify"
+    assert result[0]["destination_type"] == "rest_api"
+
+
+@pytest.mark.asyncio
+async def test_list_syncs_empty_project(tmp_path: Path) -> None:
+    (tmp_path / "drt_project.yml").write_text("name: empty\nprofile: default\n")
+    (tmp_path / "syncs").mkdir()
+    srv = create_server(tmp_path)
+    result = await call(srv, "drt_list_syncs")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# drt_validate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_validate_returns_valid_syncs(server) -> None:  # type: ignore[no-untyped-def]
+    result = await call(server, "drt_validate")
+    assert "notify" in result["valid"]
+    assert result["errors"] == {}
+
+
+# ---------------------------------------------------------------------------
+# drt_get_status
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_status_no_history(server) -> None:  # type: ignore[no-untyped-def]
+    result = await call(server, "drt_get_status")
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_get_status_specific_not_found(server) -> None:  # type: ignore[no-untyped-def]
+    result = await call(server, "drt_get_status", sync_name="nonexistent")
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_get_status_after_state_saved(server, project_dir: Path) -> None:
+    from drt.state.manager import StateManager, SyncState
+
+    StateManager(project_dir).save_sync(
+        SyncState(
+            sync_name="notify",
+            last_run_at="2026-03-30T12:00:00",
+            records_synced=42,
+            status="success",
+        )
+    )
+    result = await call(server, "drt_get_status", sync_name="notify")
+    assert result["notify"]["records_synced"] == 42
+    assert result["notify"]["status"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# drt_get_schema
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_schema_sync(server) -> None:  # type: ignore[no-untyped-def]
+    schema = await call(server, "drt_get_schema", schema_type="sync")
+    assert isinstance(schema, dict)
+    assert "$defs" in schema or "properties" in schema
+
+
+@pytest.mark.asyncio
+async def test_get_schema_project(server) -> None:  # type: ignore[no-untyped-def]
+    schema = await call(server, "drt_get_schema", schema_type="project")
+    assert isinstance(schema, dict)
+    assert "$defs" in schema or "properties" in schema


### PR DESCRIPTION
## Summary

- `drt/mcp/server.py` — FastMCP server with 5 tools
- `drt mcp run` CLI command
- 10 async unit tests (auto-skip when `fastmcp` not installed)

## Tools

| Tool | Description |
|------|-------------|
| `drt_list_syncs` | List all sync definitions |
| `drt_run_sync` | Run a specific sync (dry_run supported) |
| `drt_get_status` | Get last run result(s) |
| `drt_validate` | Validate all sync YAMLs |
| `drt_get_schema` | Return JSON Schema for project/sync config |

## Usage

```bash
# Install
pip install drt-core[mcp]

# Start server (from a drt project directory)
drt mcp run
```

Claude Desktop config:
```json
{
  "mcpServers": {
    "drt": {
      "command": "uvx",
      "args": ["drt-core[mcp]", "mcp", "run"]
    }
  }
}
```

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)