### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-03-30
+
+### Added
+
+#### MCP Server
+- `drt mcp run` — start a FastMCP server (stdio transport) for Claude Desktop, Cursor, and any MCP-compatible client
+- 5 MCP tools: `drt_list_syncs`, `drt_run_sync`, `drt_get_status`, `drt_validate`, `drt_get_schema`
+- Install: `pip install drt-core[mcp]`
+
+#### AI Skills for Claude Code
+- `.claude/commands/drt-create-sync.md` — `/drt-create-sync` skill: generate sync YAML from user intent
+- `.claude/commands/drt-debug.md` — `/drt-debug` skill: diagnose and fix failing syncs
+- `.claude/commands/drt-init.md` — `/drt-init` skill: guide through project initialization
+- `.claude/commands/drt-migrate.md` — `/drt-migrate` skill: migrate from Census/Hightouch to drt
+
+#### LLM-readable Docs
+- `docs/llm/CONTEXT.md` — architecture, key concepts, state file format (optimized for LLM consumption)
+- `docs/llm/API_REFERENCE.md` — all config fields with types, defaults, and full YAML examples
+
+#### Row-level Error Details
+- `RowError` dataclass: `batch_index`, `record_preview` (200-char PII-safe), `http_status`, `error_message`, `timestamp`
+- `drt run --verbose` and `drt status --verbose` show per-row error details
+- `RestApiDestination` now populates `row_errors` on each failure
+
+### Tests
+- 82 tests total (up from 53 in v0.2)
+- MCP server tests auto-skip when `fastmcp` not installed
+
 ## [0.2.0] - 2026-03-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,10 +50,11 @@ make fmt      # ruff format + fix
 
 ## Current Status
 
-- **v0.2 released** — Incremental sync, retry config, 53 tests passing
-- CLI fully wired: `init`, `run`, `list`, `validate`, `status`
+- **v0.3 released** — MCP Server, AI Skills, LLM docs, row-level errors, 82 tests passing
+- CLI fully wired: `init`, `run`, `list`, `validate`, `status`, `mcp run`
 - Sources: BigQuery, DuckDB, PostgreSQL
 - Destinations: REST API, Slack, GitHub Actions, HubSpot
+- MCP Server: `drt mcp run` via `drt-core[mcp]` (FastMCP)
 - Integration tests use `pytest-httpserver` (no real HTTP mocking)
 
 ## What NOT to do
@@ -68,5 +69,5 @@ make fmt      # ruff format + fix
 See the roadmap table in README.md. The short version:
 - v0.1 ✅: BigQuery → REST API working end-to-end
 - v0.2 ✅: Incremental sync + retry from config
-- v0.3: MCP Server (`uvx drt mcp run`) + AI Skills for Claude Code + LLM-readable docs
+- v0.3 ✅: MCP Server + AI Skills for Claude Code + LLM-readable docs + row-level errors
 - v1.x: Rust engine via PyO3

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ drt status                  # show recent sync status
 |---------|-------|
 | **v0.1** ✅ | BigQuery / DuckDB / Postgres sources · REST API / Slack / GitHub Actions / HubSpot destinations · CLI · dry-run |
 | **v0.2** ✅ | Incremental sync (`cursor_field` watermark) · retry config per-sync · 53 tests |
-| v0.3 | MCP Server (`uvx drt mcp run`) · AI Skills for Claude Code · LLM-readable docs · row-level error details |
+| **v0.3** ✅ | MCP Server (`drt mcp run`) · AI Skills for Claude Code · LLM-readable docs · row-level errors · 82 tests |
 | v0.4 | Dagster / Airflow integration · Google Sheets connector · Snowflake source |
 | v1.x | Rust engine (PyO3) |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "drt-core"
-version = "0.2.0"
+version = "0.3.0"
 description = "Reverse ETL for the code-first data stack"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- Bump version `0.2.0` → `0.3.0`
- Add v0.3.0 CHANGELOG entry
- Mark v0.3 ✅ in README roadmap
- Update CLAUDE.md current status

## Included in v0.3 (from merged PRs)
- MCP Server `drt mcp run` (#40)
- AI Skills for Claude Code (#33)
- LLM-readable docs (#33)
- Row-level errors + `--verbose` (#35)
- 82 tests total

🤖 Generated with [Claude Code](https://claude.com/claude-code)