### PR TITLE
docs: add MCP Server and AI Skills to README and LLM docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,61 @@ drt list                    # list sync definitions
 drt run                     # run all syncs
 drt run --select <name>     # run a specific sync
 drt run --dry-run           # dry run
+drt run --verbose           # show row-level error details
 drt validate                # validate sync YAML configs
 drt status                  # show recent sync status
+drt status --verbose        # show per-row error details
+drt mcp run                 # start MCP server (requires drt-core[mcp])
 ```
+
+---
+
+## MCP Server
+
+Connect drt to Claude, Cursor, or any MCP-compatible client so you can run syncs, check status, and validate configs without leaving your AI environment.
+
+```bash
+pip install drt-core[mcp]
+drt mcp run
+```
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "drt": {
+      "command": "drt",
+      "args": ["mcp", "run"]
+    }
+  }
+}
+```
+
+**Available MCP tools:**
+
+| Tool | What it does |
+|------|-------------|
+| `drt_list_syncs` | List all sync definitions |
+| `drt_run_sync` | Run a sync (supports `dry_run`) |
+| `drt_get_status` | Get last run result(s) |
+| `drt_validate` | Validate sync YAML configs |
+| `drt_get_schema` | Return JSON Schema for config files |
+
+---
+
+## AI Skills for Claude Code
+
+Install the official Claude Code skills to generate YAML, debug failures, and migrate from other tools — all from the chat interface.
+
+The skills live in `.claude/commands/` in this repo. Copy them to your drt project or reference them directly.
+
+| Skill | Trigger | What it does |
+|-------|---------|-------------|
+| `/drt-create-sync` | "create a sync" | Generates valid sync YAML from your intent |
+| `/drt-debug` | "sync failed" | Diagnoses errors and suggests fixes |
+| `/drt-init` | "set up drt" | Guides through project initialization |
+| `/drt-migrate` | "migrate from Census" | Converts existing configs to drt YAML |
 
 ---
 

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -83,8 +83,43 @@ drt validate                      # validate all sync YAMLs
 drt run                           # run all syncs
 drt run --select <sync-name>      # run one sync
 drt run --dry-run                 # preview without writing data
+drt run --verbose                 # show row-level error details on failure
 drt status                        # show recent sync results
+drt status --verbose              # show per-row error details
+drt mcp run                       # start MCP server (requires drt-core[mcp])
 ```
+
+## MCP Server
+
+drt exposes its operations as MCP tools so LLMs can trigger syncs, check status, and validate configs without a terminal.
+
+```bash
+pip install drt-core[mcp]
+drt mcp run   # starts stdio MCP server
+```
+
+### Available MCP tools
+
+| Tool | Description |
+|------|-------------|
+| `drt_list_syncs` | Returns all sync definitions (name, model, destination type, mode) |
+| `drt_run_sync(sync_name, dry_run=False)` | Runs a sync; returns success/failed counts and errors |
+| `drt_get_status(sync_name=None)` | Returns last run result(s); omit sync_name for all |
+| `drt_validate()` | Validates all sync YAMLs; returns valid list and errors dict |
+| `drt_get_schema(schema_type="sync")` | Returns JSON Schema for "sync" or "project" config |
+
+The MCP server reads from the current working directory (the drt project root).
+
+## AI Skills for Claude Code
+
+Four official slash commands in `.claude/commands/`:
+
+| Skill | File | Purpose |
+|-------|------|---------|
+| `/drt-create-sync` | `drt-create-sync.md` | Generate sync YAML from user intent |
+| `/drt-debug` | `drt-debug.md` | Diagnose and fix failing syncs |
+| `/drt-init` | `drt-init.md` | Guide through project initialization |
+| `/drt-migrate` | `drt-migrate.md` | Migrate from Census/Hightouch to drt |
 
 ## Key Concepts
 


### PR DESCRIPTION
## Summary

- **README**: MCP Server quickstart section (install, Claude Desktop config, tools table) + AI Skills table + `--verbose` / `mcp run` in CLI Reference
- **docs/llm/CONTEXT.md**: MCP Server tools with signatures, AI Skills slash commands

## Why

`docs/llm/` was created before MCP was implemented (#17). Anyone (or any LLM) reading the docs had no way to know `drt mcp run` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)