### PR TITLE
feat: BigQuery location support (closes #54)

### DIFF
--- a/drt/cli/init_wizard.py
+++ b/drt/cli/init_wizard.py
@@ -33,6 +33,7 @@ class InitAnswers:
     # BigQuery
     gcp_project: str = ""
     dataset: str = ""
+    location: str = "US"
     auth_method: Literal["application_default", "keyfile"] = "application_default"
     keyfile: str | None = None
     # DuckDB
@@ -70,6 +71,7 @@ def run_wizard() -> InitAnswers:
     if source_type == "bigquery":
         answers.gcp_project = typer.prompt("  GCP project ID")
         answers.dataset = typer.prompt("  BigQuery dataset")
+        answers.location = typer.prompt("  Dataset location", default="US")
         raw_method = typer.prompt(
             "  Auth method [application_default/keyfile]",
             default="application_default",

--- a/drt/cli/templates/profiles.yml.j2
+++ b/drt/cli/templates/profiles.yml.j2
@@ -3,6 +3,7 @@
 {% if source_type == "bigquery" %}
   project: {{ gcp_project }}
   dataset: {{ dataset }}
+  location: {{ location }}
   method: {{ auth_method }}
 {% if auth_method == "keyfile" %}
   keyfile: {{ keyfile }}

--- a/drt/config/credentials.py
+++ b/drt/config/credentials.py
@@ -44,6 +44,7 @@ class BigQueryProfile:
     dataset: str
     method: Literal["application_default", "keyfile"] = "application_default"
     keyfile: str | None = None
+    location: str = "US"  # e.g. "US", "EU", "asia-northeast1"
 
 
 @dataclass

--- a/drt/sources/bigquery.py
+++ b/drt/sources/bigquery.py
@@ -49,7 +49,11 @@ class BigQuerySource:
             creds = service_account.Credentials.from_service_account_file(
                 os.path.expanduser(config.keyfile)
             )
-            return bigquery.Client(project=config.project, credentials=creds)
+            return bigquery.Client(
+                project=config.project,
+                credentials=creds,
+                location=config.location,
+            )
 
         # Application Default Credentials (gcloud auth application-default login)
-        return bigquery.Client(project=config.project)
+        return bigquery.Client(project=config.project, location=config.location)


### PR DESCRIPTION
## Summary

- Adds `location` field to `BigQueryProfile` (default `"US"`)
- Passes `location` to `bigquery.Client()` for both ADC and keyfile auth paths
- `drt init` wizard now prompts for dataset location
- `profiles.yml.j2` template includes the `location` field

## Test plan

- [ ] All 72 existing tests pass (`make test`)
- [ ] `drt init` prompts for location with default `"US"`
- [ ] Generated `~/.drt/profiles.yml` contains `location` field
- [ ] BigQuery queries routed to correct regional endpoint when non-US location set

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)