### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-03-30
+
+### Fixed
+
+- **BigQuery location**: `profiles.yml` now supports a `location` field (e.g. `"EU"`, `"asia-northeast1"`); passed to `bigquery.Client()` so queries route to the correct regional endpoint. Defaults to `"US"` for backwards compatibility. ([#54](https://github.com/drt-hub/drt/issues/54))
+- `drt init` wizard now prompts for dataset location when configuring a BigQuery profile.
+
 ## [0.3.0] - 2026-03-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "drt-core"
-version = "0.3.0"
+version = "0.3.1"
 description = "Reverse ETL for the code-first data stack"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Patch release for BigQuery location support.

- Bumps version `0.3.0` → `0.3.1`
- Updates CHANGELOG with v0.3.1 entry

The only code change in this release is the BigQuery `location` field (merged via #55, closes #54).

🤖 Generated with [Claude Code](https://claude.com/claude-code)