### PR TITLE
fix: pass location from profiles.yml to BigQueryProfile

### DIFF
--- a/drt/config/credentials.py
+++ b/drt/config/credentials.py
@@ -128,6 +128,7 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             dataset=raw["dataset"],
             method=raw.get("method", "application_default"),
             keyfile=raw.get("keyfile"),
+            location=raw.get("location", "US"),
         )
     if source_type == "duckdb":
         return DuckDBProfile(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -140,6 +140,22 @@ def test_save_and_load_profile(tmp_path: Path) -> None:
     assert loaded.method == "application_default"
 
 
+def test_load_profile_bigquery_location(tmp_path: Path) -> None:
+    (tmp_path / "profiles.yml").write_text(
+        "dev:\n  type: bigquery\n  project: p\n  dataset: d\n  location: asia-northeast1\n"
+    )
+    loaded = load_profile("dev", config_dir=tmp_path)
+    assert loaded.location == "asia-northeast1"
+
+
+def test_load_profile_bigquery_location_default(tmp_path: Path) -> None:
+    (tmp_path / "profiles.yml").write_text(
+        "dev:\n  type: bigquery\n  project: p\n  dataset: d\n"
+    )
+    loaded = load_profile("dev", config_dir=tmp_path)
+    assert loaded.location == "US"
+
+
 def test_load_profile_missing_file(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError, match="profiles.yml not found"):
         load_profile("dev", config_dir=tmp_path)


### PR DESCRIPTION
## Summary

`load_profile()` was not reading the `location` field from `profiles.yml`, so `BigQueryProfile` always defaulted to `"US"` regardless of config.

## Changes

- `drt/config/credentials.py`: Add `location=raw.get("location", "US")` to BigQueryProfile constructor
- `tests/unit/test_config.py`: Add 2 tests for location parsing

## Test plan

- [x] `test_load_profile_bigquery_location` — custom location read correctly
- [x] `test_load_profile_bigquery_location_default` — default `"US"` when omitted
- [x] All 16 config tests pass

Fixes #58
Related: #54