### PR TITLE
fix: P0/P1/P2 bug fixes — closes #42-#52

### DIFF
--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 # ---------------------------------------------------------------------------
 # Auth (shared across destination types)
@@ -136,6 +136,14 @@ class SyncOptions(BaseModel):
     rate_limit: RateLimitConfig = Field(default_factory=RateLimitConfig)
     retry: RetryConfig = Field(default_factory=RetryConfig)
     on_error: Literal["skip", "fail"] = "fail"
+
+    @model_validator(mode="after")
+    def _check_incremental_cursor(self) -> "SyncOptions":
+        if self.mode == "incremental" and not self.cursor_field:
+            raise ValueError(
+                "cursor_field is required when mode is 'incremental'."
+            )
+        return self
 
 
 class SyncConfig(BaseModel):

--- a/drt/destinations/auth.py
+++ b/drt/destinations/auth.py
@@ -52,6 +52,14 @@ class AuthHandler:
         if isinstance(auth, BasicAuth):
             username = os.environ.get(auth.username_env, "")
             password = os.environ.get(auth.password_env, "")
+            if not username:
+                raise ValueError(
+                    f"BasicAuth: env var '{auth.username_env}' is not set."
+                )
+            if not password:
+                raise ValueError(
+                    f"BasicAuth: env var '{auth.password_env}' is not set."
+                )
             encoded = base64.b64encode(f"{username}:{password}".encode()).decode()
             return {"Authorization": f"Basic {encoded}"}
 

--- a/drt/destinations/github_actions.py
+++ b/drt/destinations/github_actions.py
@@ -41,6 +41,7 @@ from drt.config.models import GitHubActionsDestinationConfig, RetryConfig, SyncO
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter
 from drt.destinations.retry import with_retry
+from drt.destinations.row_errors import DetailedSyncResult, RowError
 from drt.templates.renderer import render_template
 
 _GITHUB_API = "https://api.github.com"
@@ -77,14 +78,14 @@ class GitHubActionsDestination:
             "X-GitHub-Api-Version": "2022-11-28",
         }
 
-        result = SyncResult()
+        result = DetailedSyncResult()
         # GitHub rate limit: 1000 workflow_dispatch/hour per repo — be conservative
         rate_limiter = RateLimiter(
             min(sync_options.rate_limit.requests_per_second, 5)
         )
 
-        with httpx.Client() as client:
-            for record in records:
+        with httpx.Client(timeout=30.0) as client:
+            for i, record in enumerate(records):
                 rate_limiter.acquire()
 
                 inputs: dict[str, Any] = {}
@@ -94,7 +95,14 @@ class GitHubActionsDestination:
                         inputs = json.loads(rendered)
                     except (ValueError, json.JSONDecodeError) as e:
                         result.failed += 1
-                        result.errors.append(f"inputs_template error: {e}")
+                        result.row_errors.append(
+                            RowError(
+                                batch_index=i,
+                                record_preview=json.dumps(record)[:200],
+                                http_status=None,
+                                error_message=f"inputs_template error: {e}",
+                            )
+                        )
                         continue
 
                 payload: dict[str, Any] = {"ref": config.ref}
@@ -115,11 +123,23 @@ class GitHubActionsDestination:
                     result.success += 1
                 except httpx.HTTPStatusError as e:
                     result.failed += 1
-                    result.errors.append(
-                        f"HTTP {e.response.status_code}: {e.response.text[:200]}"
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=e.response.status_code,
+                            error_message=e.response.text[:500],
+                        )
                     )
                 except Exception as e:
                     result.failed += 1
-                    result.errors.append(str(e))
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=None,
+                            error_message=str(e),
+                        )
+                    )
 
-        return result
+        return result  # type: ignore[return-value]

--- a/drt/destinations/hubspot.py
+++ b/drt/destinations/hubspot.py
@@ -52,6 +52,7 @@ from drt.config.models import HubSpotDestinationConfig, RetryConfig, SyncOptions
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter
 from drt.destinations.retry import with_retry
+from drt.destinations.row_errors import DetailedSyncResult, RowError
 from drt.templates.renderer import render_template
 
 _HUBSPOT_API = "https://api.hubapi.com/crm/v3/objects"
@@ -83,14 +84,14 @@ class HubSpotDestination:
             "Content-Type": "application/json",
         }
         upsert_url = f"{_HUBSPOT_API}/{config.object_type}"
-        result = SyncResult()
+        result = DetailedSyncResult()
         # HubSpot rate limit: 100 req/10s for private apps
         rate_limiter = RateLimiter(
             min(sync_options.rate_limit.requests_per_second, 9)
         )
 
-        with httpx.Client() as client:
-            for record in records:
+        with httpx.Client(timeout=30.0) as client:
+            for i, record in enumerate(records):
                 rate_limiter.acquire()
 
                 # Build properties dict
@@ -100,7 +101,14 @@ class HubSpotDestination:
                         properties = json.loads(rendered)
                     except (ValueError, json.JSONDecodeError) as e:
                         result.failed += 1
-                        result.errors.append(f"properties_template error: {e}")
+                        result.row_errors.append(
+                            RowError(
+                                batch_index=i,
+                                record_preview=json.dumps(record)[:200],
+                                http_status=None,
+                                error_message=f"properties_template error: {e}",
+                            )
+                        )
                         continue
                 else:
                     properties = record
@@ -134,11 +142,23 @@ class HubSpotDestination:
                     result.success += 1
                 except httpx.HTTPStatusError as e:
                     result.failed += 1
-                    result.errors.append(
-                        f"HTTP {e.response.status_code}: {e.response.text[:200]}"
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=e.response.status_code,
+                            error_message=e.response.text[:500],
+                        )
                     )
                 except Exception as e:
                     result.failed += 1
-                    result.errors.append(str(e))
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=None,
+                            error_message=str(e),
+                        )
+                    )
 
-        return result
+        return result  # type: ignore[return-value]

--- a/drt/destinations/rate_limiter.py
+++ b/drt/destinations/rate_limiter.py
@@ -23,6 +23,8 @@ class RateLimiter:
 
     def acquire(self) -> None:
         """Block until the next request slot is available."""
+        if self.requests_per_second <= 0:
+            return  # no rate limiting
         min_interval = 1.0 / self.requests_per_second
         elapsed = time.monotonic() - self._last
         wait = min_interval - elapsed

--- a/drt/destinations/rest_api.py
+++ b/drt/destinations/rest_api.py
@@ -37,7 +37,7 @@ class RestApiDestination:
         headers = {**config.headers, **auth_headers}
         rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
 
-        with httpx.Client() as client:
+        with httpx.Client(timeout=30.0) as client:
             for i, record in enumerate(records):
                 rate_limiter.acquire()
 

--- a/drt/destinations/slack.py
+++ b/drt/destinations/slack.py
@@ -40,10 +40,18 @@ from typing import Any
 
 import httpx
 
-from drt.config.models import SlackDestinationConfig, SyncOptions
+from drt.config.models import RetryConfig, SlackDestinationConfig, SyncOptions
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter
+from drt.destinations.retry import with_retry
+from drt.destinations.row_errors import DetailedSyncResult, RowError
 from drt.templates.renderer import render_template
+
+_DEFAULT_RETRY = RetryConfig(
+    max_attempts=3,
+    initial_backoff=1.0,
+    retryable_status_codes=(429, 500, 502, 503, 504),
+)
 
 
 class SlackDestination:
@@ -63,11 +71,11 @@ class SlackDestination:
                 "Slack destination: provide 'webhook_url' or set 'webhook_url_env'."
             )
 
-        result = SyncResult()
+        result = DetailedSyncResult()
         rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
 
-        with httpx.Client() as client:
-            for record in records:
+        with httpx.Client(timeout=30.0) as client:
+            for i, record in enumerate(records):
                 rate_limiter.acquire()
                 try:
                     rendered = render_template(config.message_template, record)
@@ -76,11 +84,35 @@ class SlackDestination:
                     else:
                         payload = {"text": rendered}
 
-                    response = client.post(webhook_url, json=payload)
-                    response.raise_for_status()
+                    def do_post(
+                        _url: str = webhook_url,  # type: ignore[assignment]
+                        _payload: dict[str, Any] = payload,
+                    ) -> httpx.Response:
+                        response = client.post(_url, json=_payload)
+                        response.raise_for_status()
+                        return response
+
+                    with_retry(do_post, _DEFAULT_RETRY)
                     result.success += 1
+                except httpx.HTTPStatusError as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=e.response.status_code,
+                            error_message=e.response.text[:500],
+                        )
+                    )
                 except Exception as e:
                     result.failed += 1
-                    result.errors.append(str(e))
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=None,
+                            error_message=str(e),
+                        )
+                    )
 
-        return result
+        return result  # type: ignore[return-value]

--- a/drt/engine/resolver.py
+++ b/drt/engine/resolver.py
@@ -79,9 +79,31 @@ def resolve_model_ref(
 
     # Inject incremental WHERE clause when cursor info is available
     if cursor_field and last_cursor_value:
+        safe_field = _validate_cursor_field(cursor_field)
+        safe_value = last_cursor_value.replace("'", "''")  # standard SQL escaping
         return (
             f"SELECT * FROM ({base_sql}) AS _drt_base"
-            f" WHERE {cursor_field} > '{last_cursor_value}'"
+            f" WHERE {safe_field} > '{safe_value}'"
         )
 
     return base_sql
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
+
+
+def _validate_cursor_field(field: str) -> str:
+    """Ensure cursor_field is a safe SQL identifier (letters/digits/underscore/dot).
+
+    Raises ValueError for anything that could enable SQL injection.
+    """
+    if not _SAFE_IDENTIFIER.match(field):
+        raise ValueError(
+            f"cursor_field {field!r} contains invalid characters. "
+            "Only letters, digits, underscores, and dots are allowed."
+        )
+    return field

--- a/drt/engine/sync.py
+++ b/drt/engine/sync.py
@@ -20,6 +20,14 @@ from drt.sources.base import Source
 from drt.state.manager import StateManager, SyncState
 
 
+def _cursor_gt(new: str, current: str) -> bool:
+    """Return True if new > current, using numeric comparison when both are numeric."""
+    try:
+        return float(new) > float(current)
+    except (ValueError, TypeError):
+        return new > current
+
+
 def batch(iterable: Iterator[Any], size: int) -> Iterator[list[Any]]:
     """Yield successive batches of `size` from an iterator."""
     chunk: list[Any] = []
@@ -80,7 +88,7 @@ def run_sync(
                 val = row.get(cursor_field)
                 if val is not None:
                     str_val = str(val)
-                    if new_cursor_value is None or str_val > new_cursor_value:
+                    if new_cursor_value is None or _cursor_gt(str_val, new_cursor_value):
                         new_cursor_value = str_val
 
         if dry_run:
@@ -92,6 +100,7 @@ def run_sync(
         total_result.failed += result.failed
         total_result.skipped += result.skipped
         total_result.errors.extend(result.errors)
+        total_result.row_errors.extend(getattr(result, "row_errors", []))
 
         if sync.sync.on_error == "fail" and result.failed > 0:
             break

--- a/drt/state/manager.py
+++ b/drt/state/manager.py
@@ -33,9 +33,17 @@ class StateManager:
     def _load_all(self) -> dict[str, Any]:
         if not self._state_file.exists():
             return {}
-        with self._state_file.open() as f:
-            result: dict[str, Any] = json.load(f)
-            return result
+        try:
+            with self._state_file.open() as f:
+                result: dict[str, Any] = json.load(f) or {}
+                return result
+        except (json.JSONDecodeError, ValueError):
+            import sys
+            print(
+                f"Warning: {self._state_file} is corrupted and will be reset.",
+                file=sys.stderr,
+            )
+            return {}
 
     def _save_all(self, data: dict[str, Any]) -> None:
         self._state_dir.mkdir(exist_ok=True)

--- a/tests/unit/test_destinations.py
+++ b/tests/unit/test_destinations.py
@@ -1,0 +1,193 @@
+"""Unit tests for Slack, HubSpot, and GitHub Actions destinations.
+
+Uses pytest-httpserver to spin up a local HTTP server — no mocking.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from drt.config.models import (
+    BearerAuth,
+    GitHubActionsDestinationConfig,
+    HubSpotDestinationConfig,
+    SlackDestinationConfig,
+    SyncOptions,
+)
+from drt.destinations.github_actions import GitHubActionsDestination
+from drt.destinations.hubspot import HubSpotDestination
+from drt.destinations.slack import SlackDestination
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _options() -> SyncOptions:
+    return SyncOptions()
+
+
+# ---------------------------------------------------------------------------
+# SlackDestination
+# ---------------------------------------------------------------------------
+
+
+class TestSlackDestination:
+    def test_success(self, httpserver: HTTPServer) -> None:
+        httpserver.expect_request("/webhook").respond_with_data("ok", status=200)
+        config = SlackDestinationConfig(
+            type="slack",
+            webhook_url=httpserver.url_for("/webhook"),
+            message_template="hello {{ row.name }}",
+        )
+        result = SlackDestination().load([{"name": "Alice"}], config, _options())
+        assert result.success == 1
+        assert result.failed == 0
+
+    def test_on_error_skip(self, httpserver: HTTPServer) -> None:
+        httpserver.expect_ordered_request("/webhook").respond_with_data("", status=500)
+        httpserver.expect_ordered_request("/webhook").respond_with_data("ok", status=200)
+        config = SlackDestinationConfig(
+            type="slack",
+            webhook_url=httpserver.url_for("/webhook"),
+            message_template="{{ row.msg }}",
+        )
+        opts = SyncOptions(on_error="skip")
+        result = SlackDestination().load(
+            [{"msg": "a"}, {"msg": "b"}], config, opts
+        )
+        assert result.failed == 1
+        assert result.success == 1
+
+    def test_missing_webhook_raises(self) -> None:
+        config = SlackDestinationConfig(type="slack", message_template="hi")
+        with pytest.raises(ValueError, match="webhook_url"):
+            SlackDestination().load([{"x": 1}], config, _options())
+
+    def test_block_kit_payload(self, httpserver: HTTPServer) -> None:
+        httpserver.expect_request("/webhook").respond_with_data("ok", status=200)
+        config = SlackDestinationConfig(
+            type="slack",
+            webhook_url=httpserver.url_for("/webhook"),
+            block_kit=True,
+            message_template=(
+                '{"blocks": [{"type": "section",'
+                ' "text": {"type": "mrkdwn", "text": "{{ row.msg }}"}}]}'
+            ),
+        )
+        result = SlackDestination().load([{"msg": "hello"}], config, _options())
+        assert result.success == 1
+
+
+# ---------------------------------------------------------------------------
+# HubSpotDestination
+# ---------------------------------------------------------------------------
+
+
+class TestHubSpotDestination:
+    def test_success_upsert(self, httpserver: HTTPServer, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HUBSPOT_TOKEN", "test-token")
+        httpserver.expect_request("/crm/v3/objects/contacts").respond_with_data(
+            '{"id": "1"}', status=200, content_type="application/json"
+        )
+        config = HubSpotDestinationConfig(
+            type="hubspot",
+            object_type="contacts",
+            id_property="email",
+            properties_template='{"email": "{{ row.email }}"}',
+            auth=BearerAuth(type="bearer", token_env="HUBSPOT_TOKEN"),
+        )
+        # Patch API base URL to point at test server
+        import drt.destinations.hubspot as hs_mod
+        monkeypatch.setattr(hs_mod, "_HUBSPOT_API", httpserver.url_for("/crm/v3/objects"))
+        result = HubSpotDestination().load(
+            [{"email": "alice@example.com"}], config, _options()
+        )
+        assert result.success == 1
+        assert result.failed == 0
+
+    def test_missing_token_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("HUBSPOT_TOKEN", raising=False)
+        config = HubSpotDestinationConfig(
+            type="hubspot",
+            object_type="contacts",
+            auth=BearerAuth(type="bearer", token_env="HUBSPOT_TOKEN"),
+        )
+        with pytest.raises(ValueError, match="HUBSPOT_TOKEN"):
+            HubSpotDestination().load([{"email": "x@x.com"}], config, _options())
+
+    def test_template_error_skipped(
+        self, httpserver: HTTPServer, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HUBSPOT_TOKEN", "test-token")
+        config = HubSpotDestinationConfig(
+            type="hubspot",
+            object_type="contacts",
+            properties_template="not valid json {{ row.email }}",
+            auth=BearerAuth(type="bearer", token_env="HUBSPOT_TOKEN"),
+        )
+        import drt.destinations.hubspot as hs_mod
+        monkeypatch.setattr(hs_mod, "_HUBSPOT_API", httpserver.url_for("/crm/v3/objects"))
+        result = HubSpotDestination().load(
+            [{"email": "x@x.com"}], config, _options()
+        )
+        assert result.failed == 1
+        assert result.success == 0
+
+
+# ---------------------------------------------------------------------------
+# GitHubActionsDestination
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubActionsDestination:
+    def test_success(self, httpserver: HTTPServer, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+        httpserver.expect_request(
+            "/repos/myorg/myapp/actions/workflows/deploy.yml/dispatches"
+        ).respond_with_data("", status=204)
+        config = GitHubActionsDestinationConfig(
+            type="github_actions",
+            owner="myorg",
+            repo="myapp",
+            workflow_id="deploy.yml",
+            ref="main",
+            auth=BearerAuth(type="bearer", token_env="GITHUB_TOKEN"),
+        )
+        import drt.destinations.github_actions as ga_mod
+        monkeypatch.setattr(ga_mod, "_GITHUB_API", httpserver.url_for(""))
+        result = GitHubActionsDestination().load(
+            [{"env": "prod", "version": "1.0"}], config, _options()
+        )
+        assert result.success == 1
+        assert result.failed == 0
+
+    def test_missing_token_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        config = GitHubActionsDestinationConfig(
+            type="github_actions",
+            owner="myorg",
+            repo="myapp",
+            workflow_id="deploy.yml",
+            auth=BearerAuth(type="bearer", token_env="GITHUB_TOKEN"),
+        )
+        with pytest.raises(ValueError, match="GITHUB_TOKEN"):
+            GitHubActionsDestination().load([{}], config, _options())
+
+    def test_inputs_template_error_skipped(
+        self, httpserver: HTTPServer, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+        config = GitHubActionsDestinationConfig(
+            type="github_actions",
+            owner="myorg",
+            repo="myapp",
+            workflow_id="deploy.yml",
+            inputs_template="not valid json {{ row.env }}",
+            auth=BearerAuth(type="bearer", token_env="GITHUB_TOKEN"),
+        )
+        import drt.destinations.github_actions as ga_mod
+        monkeypatch.setattr(ga_mod, "_GITHUB_API", httpserver.url_for(""))
+        result = GitHubActionsDestination().load([{"env": "prod"}], config, _options())
+        assert result.failed == 1
+        assert result.success == 0


### PR DESCRIPTION
## Summary

Addresses all P0/P1/P2 issues from the second-opinion code review.

### Security
- **#42** SQL injection in incremental cursor: `cursor_field` validated as safe SQL identifier; `last_cursor_value` escaped with `''`

### Engine
- **#43** `row_errors` now aggregated across batches in `run_sync()`
- **#44** Cursor comparison uses `float()` when possible — fixes `"9" > "10"` bug for numeric cursors

### Destinations
- **#45** `httpx.Client(timeout=30.0)` on all four destinations (REST API, Slack, HubSpot, GitHub Actions)
- **#46** `BasicAuth` raises `ValueError` when env vars are unset (was silently sending empty credentials)
- **#48** `SlackDestination` now uses `with_retry` — 429s no longer fail immediately
- **#52** Slack, HubSpot, GitHubActions migrated to `DetailedSyncResult` + `RowError`

### Config
- **#49** `SyncOptions` raises `ValidationError` if `mode="incremental"` and `cursor_field` is not set

### State
- **#47** Corrupted `state.json` caught with `JSONDecodeError` — prints warning to stderr, resets to `{}` instead of crashing

### Rate limiter
- **#50** `RateLimiter.acquire()` returns immediately when `requests_per_second <= 0`

### Tests
- **#51** 10 new unit tests for `SlackDestination`, `HubSpotDestination`, `GitHubActionsDestination`
- **Total: 84 tests passing** (was 74)

## Test plan
- [x] `make lint` passes
- [x] `make test` — 84 passed, 1 skipped

Closes #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)