### PR TITLE
chore: bump version to 0.3.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "drt",
       "source": "./skills/drt",
       "description": "Create syncs, debug failures, initialize projects, and migrate from Census/Hightouch to drt",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "homepage": "https://github.com/drt-hub/drt",
       "repository": "https://github.com/drt-hub/drt",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "drt-hub",
   "description": "Skills for drt — Reverse ETL for the code-first data stack",
-  "version": "0.3.2"
+  "version": "0.3.3"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-03-30
+
+### Fixed
+
+- **SQL injection** (#42): `cursor_field` now validated as a safe SQL identifier; `last_cursor_value` escaped with standard `''` quoting in incremental WHERE clauses
+- **row_errors lost** (#43): `run_sync()` now aggregates `row_errors` across all batches
+- **Numeric cursor comparison** (#44): Incremental cursor uses numeric comparison (`float()`) when possible — fixes `"9" > "10"` regression for integer/timestamp cursors
+- **HTTP timeout** (#45): `httpx.Client(timeout=30.0)` added to all destinations (REST API, Slack, HubSpot, GitHub Actions) — prevents indefinite hangs
+- **BasicAuth empty credentials** (#46): `BasicAuth` now raises `ValueError` when `username_env`/`password_env` are not set (was silently sending empty credentials)
+- **Corrupted state.json** (#47): `JSONDecodeError` on corrupted `.drt/state.json` is caught; prints warning to stderr and resets to empty state instead of crashing all syncs
+- **Slack retry** (#48): `SlackDestination` now uses `with_retry` — 429 rate limit responses are retried with backoff
+- **Incremental cursor_field validation** (#49): `SyncOptions` raises `ValidationError` if `mode: incremental` is set without `cursor_field`
+- **RateLimiter ZeroDivisionError** (#50): `RateLimiter.acquire()` returns immediately when `requests_per_second <= 0`
+
+### Added
+
+- **Destination unit tests** (#51): 10 new unit tests for `SlackDestination`, `HubSpotDestination`, `GitHubActionsDestination` (84 tests total)
+
+### Refactored
+
+- **DetailedSyncResult unification** (#52): Slack, HubSpot, and GitHub Actions destinations now use `DetailedSyncResult` + `RowError` — consistent row-level error reporting across all destinations
+
 ## [0.3.2] - 2026-03-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "drt-core"
-version = "0.3.2"
+version = "0.3.3"
 description = "Reverse ETL for the code-first data stack"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/skills/drt/.claude-plugin/plugin.json
+++ b/skills/drt/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drt",
   "description": "Skills for drt — create syncs, debug failures, initialize projects, and migrate from Census/Hightouch",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": {
     "name": "drt-hub"
   },


### PR DESCRIPTION
## Summary

Patch release for security and stability fixes from PR #61.

- Bumps version `0.3.2` → `0.3.3`
- Updates CHANGELOG with v0.3.3 entry
- Bumps plugin.json versions to match

Notable fixes included in this release:
- SQL injection fix in incremental cursor (#42)
- HTTP timeout on all destinations (#45)
- BasicAuth empty credential protection (#46)
- Corrupted state.json recovery (#47)

🤖 Generated with [Claude Code](https://claude.com/claude-code)