### PR TITLE
feat: add Redshift source connector

### DIFF
--- a/drt/cli/init_wizard.py
+++ b/drt/cli/init_wizard.py
@@ -21,6 +21,7 @@ from drt.config.credentials import (
     DuckDBProfile,
     PostgresProfile,
     ProfileConfig,
+    RedshiftProfile,
     save_profile,
 )
 
@@ -29,7 +30,7 @@ from drt.config.credentials import (
 class InitAnswers:
     project_name: str
     profile_name: str
-    source_type: Literal["bigquery", "duckdb", "postgres"]
+    source_type: Literal["bigquery", "duckdb", "postgres", "redshift"]
     # BigQuery
     gcp_project: str = ""
     dataset: str = ""
@@ -44,6 +45,13 @@ class InitAnswers:
     pg_dbname: str = ""
     pg_user: str = ""
     pg_password_env: str = "PG_PASSWORD"
+    # Redshift
+    rs_host: str = ""
+    rs_port: int = 5439
+    rs_dbname: str = ""
+    rs_user: str = ""
+    rs_password_env: str = "REDSHIFT_PASSWORD"
+    rs_schema: str = "public"
 
 
 def run_wizard() -> InitAnswers:
@@ -55,11 +63,11 @@ def run_wizard() -> InitAnswers:
     project_name = typer.prompt("  Project name", default=Path.cwd().name)
     profile_name = typer.prompt("  Profile name", default="dev")
     raw_source = typer.prompt(
-        "  Source type [bigquery/duckdb/postgres]",
+        "  Source type [bigquery/duckdb/postgres/redshift]",
         default="bigquery",
     )
-    source_type: Literal["bigquery", "duckdb", "postgres"] = (
-        raw_source if raw_source in ("bigquery", "duckdb", "postgres") else "bigquery"
+    source_type: Literal["bigquery", "duckdb", "postgres", "redshift"] = (
+        raw_source if raw_source in ("bigquery", "duckdb", "postgres", "redshift") else "bigquery"
     )
 
     answers = InitAnswers(
@@ -99,6 +107,18 @@ def run_wizard() -> InitAnswers:
         answers.pg_password_env = typer.prompt(
             "  Env var for password", default="PG_PASSWORD"
         )
+
+    elif source_type == "redshift":
+        answers.rs_host = typer.prompt(
+            "  Host (e.g., my-cluster.xxx.us-east-1.redshift.amazonaws.com)"
+        )
+        answers.rs_port = int(typer.prompt("  Port", default="5439"))
+        answers.rs_dbname = typer.prompt("  Database name")
+        answers.rs_user = typer.prompt("  User")
+        answers.rs_password_env = typer.prompt(
+            "  Env var for password", default="REDSHIFT_PASSWORD"
+        )
+        answers.rs_schema = typer.prompt("  Schema", default="public")
 
     typer.echo("")
     return answers
@@ -161,7 +181,7 @@ def scaffold_project(answers: InitAnswers, project_dir: Path) -> list[str]:
             type="duckdb",
             database=answers.duckdb_database,
         )
-    else:
+    elif answers.source_type == "postgres":
         profile = PostgresProfile(
             type="postgres",
             host=answers.pg_host,
@@ -169,6 +189,16 @@ def scaffold_project(answers: InitAnswers, project_dir: Path) -> list[str]:
             dbname=answers.pg_dbname,
             user=answers.pg_user,
             password_env=answers.pg_password_env,
+        )
+    else:
+        profile = RedshiftProfile(
+            type="redshift",
+            host=answers.rs_host,
+            port=answers.rs_port,
+            dbname=answers.rs_dbname,
+            user=answers.rs_user,
+            password_env=answers.rs_password_env,
+            schema=answers.rs_schema,
         )
     profiles_path = save_profile(answers.profile_name, profile)
     created.append(str(profiles_path))

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -9,7 +9,12 @@ from typing import TYPE_CHECKING
 import typer
 
 if TYPE_CHECKING:
-    from drt.config.credentials import BigQueryProfile, DuckDBProfile, PostgresProfile
+    from drt.config.credentials import (
+        BigQueryProfile,
+        DuckDBProfile,
+        PostgresProfile,
+        RedshiftProfile,
+    )
     from drt.config.models import SyncConfig
     from drt.destinations.github_actions import GitHubActionsDestination
     from drt.destinations.hubspot import HubSpotDestination
@@ -18,6 +23,7 @@ if TYPE_CHECKING:
     from drt.sources.bigquery import BigQuerySource
     from drt.sources.duckdb import DuckDBSource
     from drt.sources.postgres import PostgresSource
+    from drt.sources.redshift import RedshiftSource
 
 from drt import __version__
 from drt.cli.output import (
@@ -240,12 +246,18 @@ def mcp_run() -> None:
 # ---------------------------------------------------------------------------
 
 def _get_source(
-    profile: BigQueryProfile | DuckDBProfile | PostgresProfile,
-) -> BigQuerySource | DuckDBSource | PostgresSource:
-    from drt.config.credentials import BigQueryProfile, DuckDBProfile, PostgresProfile
+    profile: BigQueryProfile | DuckDBProfile | PostgresProfile | RedshiftProfile,
+) -> BigQuerySource | DuckDBSource | PostgresSource | RedshiftSource:
+    from drt.config.credentials import (
+        BigQueryProfile,
+        DuckDBProfile,
+        PostgresProfile,
+        RedshiftProfile,
+    )
     from drt.sources.bigquery import BigQuerySource
     from drt.sources.duckdb import DuckDBSource
     from drt.sources.postgres import PostgresSource
+    from drt.sources.redshift import RedshiftSource
 
     if isinstance(profile, BigQueryProfile):
         return BigQuerySource()
@@ -253,6 +265,8 @@ def _get_source(
         return DuckDBSource()
     if isinstance(profile, PostgresProfile):
         return PostgresSource()
+    if isinstance(profile, RedshiftProfile):
+        return RedshiftSource()
     raise ValueError(f"Unsupported source type: {type(profile)}")
 
 

--- a/drt/config/credentials.py
+++ b/drt/config/credentials.py
@@ -64,8 +64,32 @@ class PostgresProfile:
     password: str | None = None       # explicit (non-recommended)
 
 
+@dataclass
+class RedshiftProfile:
+    """Amazon Redshift profile — PostgreSQL-compatible with schema support.
+
+    Example ~/.drt/profiles.yml:
+        redshift_prod:
+          type: redshift
+          host: my-cluster.xxx.us-east-1.redshift.amazonaws.com
+          port: 5439
+          dbname: analytics
+          user: analyst
+          password_env: REDSHIFT_PASSWORD
+          schema: public
+    """
+    type: Literal["redshift"]
+    host: str = ""
+    port: int = 5439  # Redshift default port
+    dbname: str = ""
+    user: str = ""
+    password_env: str | None = None   # env var name
+    password: str | None = None       # explicit (non-recommended)
+    schema: str = "public"            # Redshift schema
+
+
 # Union type — used throughout the codebase
-ProfileConfig = BigQueryProfile | DuckDBProfile | PostgresProfile
+ProfileConfig = BigQueryProfile | DuckDBProfile | PostgresProfile | RedshiftProfile
 
 
 # ---------------------------------------------------------------------------
@@ -146,9 +170,21 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             password=raw.get("password"),
         )
 
+    if source_type == "redshift":
+        return RedshiftProfile(
+            type="redshift",
+            host=raw.get("host", ""),
+            port=int(raw.get("port", 5439)),
+            dbname=raw.get("dbname", ""),
+            user=raw.get("user", ""),
+            password_env=raw.get("password_env"),
+            password=raw.get("password"),
+            schema=raw.get("schema", "public"),
+        )
+
     raise ValueError(
         f"Unsupported source type '{source_type}'. "
-        "Supported: bigquery, duckdb, postgres"
+        "Supported: bigquery, duckdb, postgres, redshift"
     )
 
 
@@ -185,6 +221,17 @@ def save_profile(
             "port": profile.port,
             "dbname": profile.dbname,
             "user": profile.user,
+        }
+        if profile.password_env:
+            entry["password_env"] = profile.password_env
+    elif isinstance(profile, RedshiftProfile):
+        entry = {
+            "type": "redshift",
+            "host": profile.host,
+            "port": profile.port,
+            "dbname": profile.dbname,
+            "user": profile.user,
+            "schema": profile.schema,
         }
         if profile.password_env:
             entry["password_env"] = profile.password_env

--- a/drt/sources/redshift.py
+++ b/drt/sources/redshift.py
@@ -1,0 +1,84 @@
+"""Amazon Redshift source implementation.
+
+Requires: pip install drt-core[redshift]
+
+Redshift is PostgreSQL-compatible (based on PartiQL/Postgres 8.x),
+so this connector reuses psycopg2 with Redshift-specific defaults.
+
+Example ~/.drt/profiles.yml:
+    redshift_prod:
+      type: redshift
+      host: my-cluster.xxx.us-east-1.redshift.amazonaws.com
+      port: 5439
+      dbname: analytics
+      user: analyst
+      password_env: REDSHIFT_PASSWORD
+      schema: public
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from typing import Any
+
+from psycopg2 import sql
+
+from drt.config.credentials import RedshiftProfile
+
+
+class RedshiftSource:
+    """Extract records from an Amazon Redshift cluster.
+
+    Redshift uses PostgreSQL wire protocol, so we connect via psycopg2.
+    The main differences from vanilla Postgres:
+      - Default port is 5439
+      - Schema support is important for Redshift's multi-schema warehouses
+      - Connection string uses same parameters
+    """
+
+    def extract(self, query: str, config: RedshiftProfile) -> Iterator[dict[str, Any]]:
+        """Execute query and yield records as dicts."""
+        conn = self._connect(config)
+        try:
+            cur = conn.cursor()
+            # Set search_path to the configured schema
+            if config.schema:
+                cur.execute(sql.SQL("SET search_path TO {}").format(sql.Identifier(config.schema)))
+            cur.execute(query)
+            columns = [desc[0] for desc in cur.description]
+            for row in cur.fetchall():
+                yield dict(zip(columns, row))
+        finally:
+            conn.close()
+
+    def test_connection(self, config: RedshiftProfile) -> bool:
+        """Test if the Redshift cluster is reachable."""
+        try:
+            conn = self._connect(config)
+            cur = conn.cursor()
+            cur.execute("SELECT 1")
+            conn.close()
+            return True
+        except Exception:
+            return False
+
+    def _connect(self, config: RedshiftProfile) -> Any:
+        """Create a connection to Redshift using psycopg2."""
+        try:
+            import psycopg2
+        except ImportError as e:
+            raise ImportError(
+                "Redshift support requires: pip install drt-core[redshift]"
+            ) from e
+
+        password = config.password or (
+            os.environ.get(config.password_env) if config.password_env else None
+        )
+        return psycopg2.connect(
+            host=config.host,
+            port=config.port,
+            dbname=config.dbname,
+            user=config.user,
+            password=password,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 bigquery = ["google-cloud-bigquery>=3.0"]
 duckdb = ["duckdb>=0.10"]
 postgres = ["psycopg2-binary>=2.9"]
+redshift = ["psycopg2-binary>=2.9"]  # Redshift uses PostgreSQL wire protocol
 mcp = ["fastmcp>=2.0"]
 dev = [
     "pytest>=8.0",

--- a/tests/unit/test_redshift.py
+++ b/tests/unit/test_redshift.py
@@ -1,0 +1,137 @@
+"""Tests for Redshift source connector."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from drt.config.credentials import RedshiftProfile  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# FakeRedshiftSource (test double)
+# ---------------------------------------------------------------------------
+
+class FakeRedshiftSource:
+    """Fake Redshift source for testing without a real cluster."""
+
+    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
+        self._rows = rows or []
+        self.queries_executed: list[str] = []
+        self.schema_set: str | None = None
+
+    def extract(self, query: str, config: RedshiftProfile) -> Iterator[dict[str, Any]]:
+        """Yield rows and track the query."""
+        self.queries_executed.append(query)
+        if config.schema:
+            self.schema_set = config.schema
+        yield from self._rows
+
+    def test_connection(self, config: RedshiftProfile) -> bool:
+        """Always succeeds for the fake."""
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Profile tests
+# ---------------------------------------------------------------------------
+
+def test_redshift_profile_defaults() -> None:
+    """RedshiftProfile has sensible defaults."""
+    profile = RedshiftProfile(type="redshift")
+    assert profile.port == 5439  # Redshift default, not Postgres 5432
+    assert profile.schema == "public"
+    assert profile.host == ""
+    assert profile.dbname == ""
+
+
+def test_redshift_profile_custom_schema() -> None:
+    """RedshiftProfile accepts custom schema."""
+    profile = RedshiftProfile(
+        type="redshift",
+        host="cluster.xxx.redshift.amazonaws.com",
+        port=5439,
+        dbname="warehouse",
+        user="analyst",
+        password_env="RS_PASS",
+        schema="analytics",
+    )
+    assert profile.schema == "analytics"
+    assert profile.host == "cluster.xxx.redshift.amazonaws.com"
+
+
+# ---------------------------------------------------------------------------
+# FakeRedshiftSource tests
+# ---------------------------------------------------------------------------
+
+def test_fake_redshift_source_extract() -> None:
+    """FakeRedshiftSource yields configured rows."""
+    rows = [
+        {"id": 1, "name": "Alice"},
+        {"id": 2, "name": "Bob"},
+    ]
+    source = FakeRedshiftSource(rows)
+    config = RedshiftProfile(
+        type="redshift",
+        host="test",
+        dbname="test",
+        user="test",
+        schema="public",
+    )
+
+    result = list(source.extract("SELECT * FROM users", config))
+
+    assert result == rows
+    assert source.queries_executed == ["SELECT * FROM users"]
+    assert source.schema_set == "public"
+
+
+def test_fake_redshift_source_tracks_schema() -> None:
+    """FakeRedshiftSource tracks which schema was used."""
+    source = FakeRedshiftSource([])
+    config = RedshiftProfile(
+        type="redshift",
+        host="test",
+        dbname="test",
+        user="test",
+        schema="analytics",
+    )
+
+    list(source.extract("SELECT 1", config))
+
+    assert source.schema_set == "analytics"
+
+
+def test_fake_redshift_source_test_connection() -> None:
+    """FakeRedshiftSource.test_connection always returns True."""
+    source = FakeRedshiftSource()
+    config = RedshiftProfile(type="redshift")
+    assert source.test_connection(config) is True
+
+
+def test_fake_redshift_source_empty() -> None:
+    """FakeRedshiftSource handles empty result set."""
+    source = FakeRedshiftSource([])
+    config = RedshiftProfile(type="redshift")
+
+    result = list(source.extract("SELECT * FROM empty", config))
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Integration with engine (using FakeRedshiftSource)
+# ---------------------------------------------------------------------------
+
+def test_redshift_source_with_engine_pattern(tmp_path: pytest.TempPathFactory) -> None:
+    """Verify FakeRedshiftSource follows the Source protocol."""
+    from drt.sources.base import Source
+
+    source = FakeRedshiftSource([{"id": 1}])
+
+    # Should match the Source protocol (duck typing)
+    assert hasattr(source, "extract")
+    assert hasattr(source, "test_connection")
+    # Protocol check via isinstance with runtime_checkable
+    assert isinstance(source, Source)


### PR DESCRIPTION
## Summary

- Add `RedshiftSource` connector using psycopg2 (PostgreSQL wire protocol)
- Add `RedshiftProfile` dataclass with Redshift-specific defaults (port 5439, schema support)
- `SET search_path` uses `psycopg2.sql.Identifier` to prevent SQL injection
- CLI `drt init` wizard updated to support `redshift` source type
- `_get_source` factory in CLI and MCP server updated
- `drt-core[redshift]` extra added to `pyproject.toml`

## Testing

- 7 new unit tests in `tests/unit/test_redshift.py` (91 total, all pass)
- `FakeRedshiftSource` test double included (no real cluster required)

## Notes

This is a clean rebase of #34 (contributed by @Jdubin1417) onto current `main`.
The original PR had merge conflicts due to changes merged since it was opened.
All review feedback from the original PR has been addressed (sql.Identifier for schema).

Closes #20
Supersedes #34

## Test plan

- [x] `make lint` — passes (ruff + mypy)
- [x] `make test` — 91 passed, 1 skipped
- [x] `RedshiftProfile` defaults: port=5439, schema="public"
- [x] `sql.Identifier` used for schema in `SET search_path`

🤖 Generated with [Claude Code](https://claude.com/claude-code)