### PR TITLE
chore: bump version to 0.3.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "drt",
       "source": "./skills/drt",
       "description": "Create syncs, debug failures, initialize projects, and migrate from Census/Hightouch to drt",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "homepage": "https://github.com/drt-hub/drt",
       "repository": "https://github.com/drt-hub/drt",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "drt-hub",
   "description": "Skills for drt — Reverse ETL for the code-first data stack",
-  "version": "0.3.3"
+  "version": "0.3.4"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2026-03-30
+
+### Added
+
+- **Redshift source** (#76, closes #20): Amazon Redshift connector via psycopg2. New `RedshiftProfile` with host/port/dbname/user/password_env/schema fields (port defaults to 5439). `drt init` wizard updated to support `redshift` source type. Install: `pip install drt-core[redshift]`.
+
 ## [0.3.3] - 2026-03-30
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,9 @@ make fmt      # ruff format + fix
 
 ## Current Status
 
-- **v0.3.3 released** — MCP Server, AI Skills (plugin marketplace), LLM docs, row-level errors, BigQuery location support, security hardening (SQL injection fix, HTTP timeout, auth validation, state corruption recovery)
+- **v0.3.4 released** — Redshift source connector (`drt-core[redshift]`)
 - CLI fully wired: `init`, `run`, `list`, `validate`, `status`, `mcp run`
-- Sources: BigQuery, DuckDB, PostgreSQL
+- Sources: BigQuery, DuckDB, PostgreSQL, Redshift
 - Destinations: REST API, Slack, GitHub Actions, HubSpot
 - MCP Server: `drt mcp run` via `drt-core[mcp]` (FastMCP)
 - 84 tests, integration tests use `pytest-httpserver` (no real HTTP mocking)
@@ -69,7 +69,7 @@ make fmt      # ruff format + fix
 See the roadmap table in README.md. The short version:
 - v0.1 ✅: BigQuery → REST API working end-to-end
 - v0.2 ✅: Incremental sync + retry from config
-- v0.3 ✅: MCP Server + AI Skills for Claude Code + LLM-readable docs + row-level errors + security hardening
+- v0.3 ✅: MCP Server + AI Skills for Claude Code + LLM-readable docs + row-level errors + security hardening + Redshift source
 - v0.4: Dagster integration + Google Sheets destination + dbt post-hook + examples
 - v0.5: Snowflake source + CSV/JSON destination + test coverage
 - v0.6: Salesforce destination + Airflow integration

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 | **Source** | DuckDB | ✅ v0.1 | (core) |
 | **Source** | PostgreSQL | ✅ v0.1 | `pip install drt-core[postgres]` |
 | **Source** | Snowflake | 🗓 planned | `pip install drt-core[snowflake]` |
-| **Source** | Redshift | 🗓 planned | `pip install drt-core[redshift]` |
+| **Source** | Redshift | ✅ v0.3.4 | `pip install drt-core[redshift]` |
 | **Source** | MySQL | 🗓 planned | `pip install drt-core[mysql]` |
 | **Destination** | REST API | ✅ v0.1 | (core) |
 | **Destination** | Slack Incoming Webhook | ✅ v0.1 | (core) |
@@ -210,7 +210,7 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 |---------|-------|
 | **v0.1** ✅ | BigQuery / DuckDB / Postgres sources · REST API / Slack / GitHub Actions / HubSpot destinations · CLI · dry-run |
 | **v0.2** ✅ | Incremental sync (`cursor_field` watermark) · retry config per-sync |
-| **v0.3** ✅ | MCP Server (`drt mcp run`) · AI Skills for Claude Code · LLM-readable docs · row-level errors · security hardening |
+| **v0.3** ✅ | MCP Server (`drt mcp run`) · AI Skills for Claude Code · LLM-readable docs · row-level errors · security hardening · Redshift source |
 | v0.4 | Dagster integration · Google Sheets destination · dbt post-hook · examples |
 | v0.5 | Snowflake source · CSV/JSON destination · test coverage |
 | v0.6 | Salesforce destination · Airflow integration |

--- a/docs/llm/API_REFERENCE.md
+++ b/docs/llm/API_REFERENCE.md
@@ -36,6 +36,16 @@ prod_pg:
   type: postgres
   connection_string_env: DATABASE_URL   # env var with postgres:// URL
   dataset: public
+
+# Redshift example:
+redshift_prod:
+  type: redshift
+  host: my-cluster.xxx.us-east-1.redshift.amazonaws.com
+  port: 5439              # default: 5439
+  dbname: analytics
+  user: analyst
+  password_env: REDSHIFT_PASSWORD
+  schema: public          # default: "public"
 ```
 
 ---

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -14,7 +14,7 @@ dlt (load into DWH) → dbt (transform) → drt (activate out of DWH)
 - **Tagline:** "Reverse ETL for the code-first data stack"
 - **Install:** `pip install drt-core` or `uv add drt-core`
 - **Package name:** `drt-core` (PyPI) — CLI command is `drt`
-- **Current version:** v0.3.3
+- **Current version:** v0.3.4
 
 ## What drt is NOT
 
@@ -56,6 +56,7 @@ my-project/
 | BigQuery | `drt-core[bigquery]` | Uses ADC or keyfile. Supports `location` (e.g. `"EU"`, `"asia-northeast1"`) |
 | DuckDB | (core) | Local `.duckdb` file |
 | PostgreSQL | `drt-core[postgres]` | Connection string via env |
+| Redshift | `drt-core[redshift]` | PostgreSQL wire protocol via psycopg2. Supports `schema` (search_path). Port defaults to 5439. |
 
 Source is configured in `~/.drt/profiles.yml` (dbt-style):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "drt-core"
-version = "0.3.3"
+version = "0.3.4"
 description = "Reverse ETL for the code-first data stack"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/skills/drt/.claude-plugin/plugin.json
+++ b/skills/drt/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drt",
   "description": "Skills for drt — create syncs, debug failures, initialize projects, and migrate from Census/Hightouch",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "author": {
     "name": "drt-hub"
   },


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` version to `0.3.4`
- Update CHANGELOG with v0.3.4 entry (Redshift source)
- Update README, CONTEXT.md, API_REFERENCE.md, CLAUDE.md to include Redshift
- Bump all `plugin.json` files to `0.3.4`

## Test plan

- [x] `make lint` passes
- [x] `make test` — 91 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)