### PR TITLE
feat: add PostgreSQL destination with upsert support

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from drt.config.models import SyncConfig
     from drt.destinations.github_actions import GitHubActionsDestination
     from drt.destinations.hubspot import HubSpotDestination
+    from drt.destinations.postgres import PostgresDestination
     from drt.destinations.rest_api import RestApiDestination
     from drt.destinations.slack import SlackDestination
     from drt.sources.bigquery import BigQuerySource
@@ -65,6 +66,7 @@ def main(
 # init
 # ---------------------------------------------------------------------------
 
+
 @app.command()
 def init() -> None:
     """Initialize a new drt project in the current directory."""
@@ -85,6 +87,7 @@ def init() -> None:
 # ---------------------------------------------------------------------------
 # run
 # ---------------------------------------------------------------------------
+
 
 @app.command()
 def run(
@@ -149,6 +152,7 @@ def run(
 # list
 # ---------------------------------------------------------------------------
 
+
 @app.command(name="list")
 def list_syncs() -> None:
     """List all sync definitions in the project."""
@@ -161,6 +165,7 @@ def list_syncs() -> None:
 # ---------------------------------------------------------------------------
 # validate
 # ---------------------------------------------------------------------------
+
 
 @app.command()
 def validate(
@@ -192,6 +197,7 @@ def validate(
 # ---------------------------------------------------------------------------
 # status
 # ---------------------------------------------------------------------------
+
 
 @app.command()
 def status(
@@ -245,6 +251,7 @@ def mcp_run() -> None:
 # Source / Destination factories
 # ---------------------------------------------------------------------------
 
+
 def _get_source(
     profile: BigQueryProfile | DuckDBProfile | PostgresProfile | RedshiftProfile,
 ) -> BigQuerySource | DuckDBSource | PostgresSource | RedshiftSource:
@@ -273,15 +280,23 @@ def _get_source(
 
 def _get_destination(
     sync: SyncConfig,
-) -> RestApiDestination | SlackDestination | GitHubActionsDestination | HubSpotDestination:
+) -> (
+    RestApiDestination
+    | SlackDestination
+    | GitHubActionsDestination
+    | HubSpotDestination
+    | PostgresDestination
+):
     from drt.config.models import (
         GitHubActionsDestinationConfig,
         HubSpotDestinationConfig,
+        PostgresDestinationConfig,
         RestApiDestinationConfig,
         SlackDestinationConfig,
     )
     from drt.destinations.github_actions import GitHubActionsDestination
     from drt.destinations.hubspot import HubSpotDestination
+    from drt.destinations.postgres import PostgresDestination
     from drt.destinations.rest_api import RestApiDestination
     from drt.destinations.slack import SlackDestination
 
@@ -294,4 +309,6 @@ def _get_destination(
         return GitHubActionsDestination()
     if isinstance(dest, HubSpotDestinationConfig):
         return HubSpotDestination()
+    if isinstance(dest, PostgresDestinationConfig):
+        return PostgresDestination()
     raise ValueError(f"Unsupported destination type: {dest.type}")

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, model_validator
 # Auth (shared across destination types)
 # ---------------------------------------------------------------------------
 
+
 class BearerAuth(BaseModel):
     type: Literal["bearer"]
     token: str | None = None
@@ -37,6 +38,7 @@ AuthConfig = Annotated[
 # Source config (inline — kept for backward compat; prefer profiles.yml)
 # ---------------------------------------------------------------------------
 
+
 class SourceConfig(BaseModel):
     type: Literal["bigquery", "snowflake", "postgres", "duckdb"]
     project: str | None = None
@@ -48,6 +50,7 @@ class SourceConfig(BaseModel):
 # Project
 # ---------------------------------------------------------------------------
 
+
 class ProjectConfig(BaseModel):
     name: str
     version: str = "0.1"
@@ -58,6 +61,7 @@ class ProjectConfig(BaseModel):
 # ---------------------------------------------------------------------------
 # Destination configs — discriminated union
 # ---------------------------------------------------------------------------
+
 
 class RestApiDestinationConfig(BaseModel):
     type: Literal["rest_api"]
@@ -84,8 +88,8 @@ class GitHubActionsDestinationConfig(BaseModel):
     type: Literal["github_actions"]
     owner: str
     repo: str
-    workflow_id: str          # filename (e.g. "deploy.yml") or workflow ID
-    ref: str = "main"         # branch/tag to run on
+    workflow_id: str  # filename (e.g. "deploy.yml") or workflow ID
+    ref: str = "main"  # branch/tag to run on
     # Jinja2 template → JSON object for workflow inputs
     # Example: '{"environment": "{{ row.env }}", "version": "{{ row.version }}"}'
     inputs_template: str | None = None
@@ -103,12 +107,36 @@ class HubSpotDestinationConfig(BaseModel):
     auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
 
 
+class PostgresDestinationConfig(BaseModel):
+    type: Literal["postgres"]
+    host: str | None = None
+    host_env: str | None = None
+    port: int = 5432
+    dbname: str | None = None
+    dbname_env: str | None = None
+    user: str | None = None
+    user_env: str | None = None
+    password: str | None = None
+    password_env: str | None = None
+    table: str  # e.g. "public.analytics_scores"
+    upsert_key: list[str]  # columns for ON CONFLICT
+
+    @model_validator(mode="after")
+    def _check_connection(self) -> "PostgresDestinationConfig":
+        if not self.host and not self.host_env:
+            raise ValueError("Either host or host_env is required.")
+        if not self.dbname and not self.dbname_env:
+            raise ValueError("Either dbname or dbname_env is required.")
+        return self
+
+
 # Discriminated union — add new destination types here
 DestinationConfig = Annotated[
     RestApiDestinationConfig
     | SlackDestinationConfig
     | GitHubActionsDestinationConfig
-    | HubSpotDestinationConfig,
+    | HubSpotDestinationConfig
+    | PostgresDestinationConfig,
     Field(discriminator="type"),
 ]
 
@@ -116,6 +144,7 @@ DestinationConfig = Annotated[
 # ---------------------------------------------------------------------------
 # Sync options
 # ---------------------------------------------------------------------------
+
 
 class RateLimitConfig(BaseModel):
     requests_per_second: int = 10
@@ -140,9 +169,7 @@ class SyncOptions(BaseModel):
     @model_validator(mode="after")
     def _check_incremental_cursor(self) -> "SyncOptions":
         if self.mode == "incremental" and not self.cursor_field:
-            raise ValueError(
-                "cursor_field is required when mode is 'incremental'."
-            )
+            raise ValueError("cursor_field is required when mode is 'incremental'.")
         return self
 
 

--- a/drt/destinations/postgres.py
+++ b/drt/destinations/postgres.py
@@ -1,0 +1,130 @@
+"""PostgreSQL destination — upsert rows into a PostgreSQL table.
+
+Uses INSERT ... ON CONFLICT (upsert_key) DO UPDATE SET ... for idempotent writes.
+Requires: pip install drt-core[postgres]
+
+Example sync YAML:
+
+    destination:
+      type: postgres
+      host_env: TARGET_PG_HOST
+      dbname_env: TARGET_PG_DBNAME
+      user_env: TARGET_PG_USER
+      password_env: TARGET_PG_PASSWORD
+      table: public.analytics_scores
+      upsert_key: [id]
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from drt.config.credentials import resolve_env
+from drt.config.models import PostgresDestinationConfig, SyncOptions
+from drt.destinations.base import SyncResult
+from drt.destinations.row_errors import DetailedSyncResult, RowError
+
+
+class PostgresDestination:
+    """Upsert records into a PostgreSQL table."""
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: PostgresDestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        if not records:
+            return SyncResult()
+
+        conn = self._connect(config)
+        result = DetailedSyncResult()
+
+        try:
+            cur = conn.cursor()
+            columns = list(records[0].keys())
+            update_cols = [c for c in columns if c not in config.upsert_key]
+
+            sql = self._build_upsert_sql(config.table, columns, config.upsert_key, update_cols)
+
+            for i, record in enumerate(records):
+                try:
+                    values = [record.get(c) for c in columns]
+                    cur.execute(sql, values)
+                    result.success += 1
+                except Exception as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record, default=str)[:200],
+                            http_status=None,
+                            error_message=str(e),
+                        )
+                    )
+                    if sync_options.on_error == "fail":
+                        conn.rollback()
+                        return result  # type: ignore[return-value]
+                    # on_error == "skip": rollback this row, continue
+                    conn.rollback()
+                    # Re-open transaction for next rows
+                    cur = conn.cursor()
+                    continue
+
+            conn.commit()
+        finally:
+            conn.close()
+
+        return result  # type: ignore[return-value]
+
+    @staticmethod
+    def _build_upsert_sql(
+        table: str,
+        columns: list[str],
+        upsert_key: list[str],
+        update_cols: list[str],
+    ) -> str:
+        """Build INSERT ... ON CONFLICT DO UPDATE SQL."""
+        cols_str = ", ".join(f'"{c}"' for c in columns)
+        placeholders = ", ".join(["%s"] * len(columns))
+        conflict_str = ", ".join(f'"{c}"' for c in upsert_key)
+
+        if update_cols:
+            set_clause = ", ".join(f'"{c}" = EXCLUDED."{c}"' for c in update_cols)
+            return (
+                f"INSERT INTO {table} ({cols_str}) VALUES ({placeholders}) "
+                f"ON CONFLICT ({conflict_str}) DO UPDATE SET {set_clause}"
+            )
+        # All columns are part of the key — just ignore duplicates
+        return (
+            f"INSERT INTO {table} ({cols_str}) VALUES ({placeholders}) "
+            f"ON CONFLICT ({conflict_str}) DO NOTHING"
+        )
+
+    @staticmethod
+    def _connect(config: PostgresDestinationConfig) -> Any:
+        try:
+            import psycopg2
+        except ImportError as e:
+            raise ImportError(
+                "PostgreSQL destination requires: pip install drt-core[postgres]"
+            ) from e
+
+        host = resolve_env(config.host, config.host_env)
+        dbname = resolve_env(config.dbname, config.dbname_env)
+        user = resolve_env(config.user, config.user_env)
+        password = resolve_env(config.password, config.password_env)
+
+        if not host:
+            raise ValueError("PostgreSQL destination: host could not be resolved.")
+        if not dbname:
+            raise ValueError("PostgreSQL destination: dbname could not be resolved.")
+
+        return psycopg2.connect(
+            host=host,
+            port=config.port,
+            dbname=dbname,
+            user=user,
+            password=password,
+        )

--- a/drt/mcp/server.py
+++ b/drt/mcp/server.py
@@ -23,9 +23,7 @@ def create_server(project_dir: Path | None = None) -> Any:
     try:
         from fastmcp import FastMCP
     except ImportError as e:
-        raise ImportError(
-            "MCP server requires: pip install drt-core[mcp]"
-        ) from e
+        raise ImportError("MCP server requires: pip install drt-core[mcp]") from e
 
     _project_dir = project_dir or Path(".")
 
@@ -98,7 +96,13 @@ def create_server(project_dir: Path | None = None) -> Any:
         state_mgr = StateManager(_project_dir)
 
         result = run_sync(
-            sync, source, dest, profile, _project_dir, dry_run, state_mgr  # type: ignore[arg-type]
+            sync,
+            source,  # type: ignore[arg-type]  # concrete types vs Protocol
+            dest,  # type: ignore[arg-type]
+            profile,
+            _project_dir,
+            dry_run,
+            state_mgr,
         )
 
         return {

--- a/tests/unit/test_postgres_destination.py
+++ b/tests/unit/test_postgres_destination.py
@@ -1,0 +1,190 @@
+"""Unit tests for PostgreSQL destination.
+
+Uses a fake psycopg2 connection — no real database required.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from drt.config.models import PostgresDestinationConfig, SyncOptions
+from drt.destinations.postgres import PostgresDestination
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _options(**kwargs: Any) -> SyncOptions:
+    return SyncOptions(**kwargs)
+
+
+def _config(**overrides: Any) -> PostgresDestinationConfig:
+    defaults: dict[str, Any] = {
+        "type": "postgres",
+        "host": "localhost",
+        "dbname": "testdb",
+        "user": "testuser",
+        "password": "testpass",
+        "table": "public.scores",
+        "upsert_key": ["id"],
+    }
+    defaults.update(overrides)
+    return PostgresDestinationConfig(**defaults)
+
+
+def _fake_connection() -> MagicMock:
+    conn = MagicMock()
+    conn.cursor.return_value = MagicMock()
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestPostgresDestinationConfig:
+    def test_valid_config(self) -> None:
+        config = _config()
+        assert config.table == "public.scores"
+        assert config.upsert_key == ["id"]
+
+    def test_host_env_instead_of_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PG_HOST", "db.example.com")
+        config = _config(host=None, host_env="PG_HOST")
+        assert config.host_env == "PG_HOST"
+
+    def test_missing_host_and_host_env_raises(self) -> None:
+        with pytest.raises(ValueError, match="host"):
+            _config(host=None, host_env=None)
+
+    def test_missing_dbname_and_dbname_env_raises(self) -> None:
+        with pytest.raises(ValueError, match="dbname"):
+            _config(dbname=None, dbname_env=None)
+
+
+# ---------------------------------------------------------------------------
+# SQL generation
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertSql:
+    def test_basic_upsert(self) -> None:
+        sql = PostgresDestination._build_upsert_sql(
+            table="public.scores",
+            columns=["id", "score", "updated_at"],
+            upsert_key=["id"],
+            update_cols=["score", "updated_at"],
+        )
+        assert 'INSERT INTO public.scores ("id", "score", "updated_at")' in sql
+        assert "ON CONFLICT" in sql
+        assert 'DO UPDATE SET "score" = EXCLUDED."score"' in sql
+
+    def test_composite_upsert_key(self) -> None:
+        sql = PostgresDestination._build_upsert_sql(
+            table="results",
+            columns=["user_id", "metric_id", "value"],
+            upsert_key=["user_id", "metric_id"],
+            update_cols=["value"],
+        )
+        assert '"user_id", "metric_id"' in sql
+        assert 'DO UPDATE SET "value" = EXCLUDED."value"' in sql
+
+    def test_all_columns_are_key_does_nothing(self) -> None:
+        sql = PostgresDestination._build_upsert_sql(
+            table="lookup",
+            columns=["id"],
+            upsert_key=["id"],
+            update_cols=[],
+        )
+        assert "DO NOTHING" in sql
+
+
+# ---------------------------------------------------------------------------
+# Load behavior
+# ---------------------------------------------------------------------------
+
+
+class TestPostgresDestinationLoad:
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_success_upsert(self, mock_connect: MagicMock) -> None:
+        conn = _fake_connection()
+        mock_connect.return_value = conn
+
+        records = [
+            {"id": 1, "score": 0.95, "updated_at": "2026-03-31"},
+            {"id": 2, "score": 0.80, "updated_at": "2026-03-31"},
+        ]
+        result = PostgresDestination().load(records, _config(), _options())
+
+        assert result.success == 2
+        assert result.failed == 0
+        assert conn.cursor().execute.call_count == 2
+        conn.commit.assert_called_once()
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_empty_records(self, mock_connect: MagicMock) -> None:
+        result = PostgresDestination().load([], _config(), _options())
+        assert result.success == 0
+        assert result.failed == 0
+        mock_connect.assert_not_called()
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_row_error_on_error_skip(self, mock_connect: MagicMock) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        # First row fails, second succeeds
+        cur.execute.side_effect = [Exception("duplicate key"), None]
+        # After rollback, return a fresh cursor for the second row
+        new_cur = MagicMock()
+        conn.cursor.side_effect = [cur, new_cur]
+        mock_connect.return_value = conn
+
+        records = [
+            {"id": 1, "score": 0.5},
+            {"id": 2, "score": 0.9},
+        ]
+        result = PostgresDestination().load(records, _config(), _options(on_error="skip"))
+
+        assert result.failed == 1
+        assert result.success == 1
+        assert len(result.row_errors) == 1
+        assert "duplicate key" in result.row_errors[0].error_message
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_row_error_on_error_fail(self, mock_connect: MagicMock) -> None:
+        conn = _fake_connection()
+        conn.cursor().execute.side_effect = Exception("constraint violation")
+        mock_connect.return_value = conn
+
+        records = [
+            {"id": 1, "score": 0.5},
+            {"id": 2, "score": 0.9},
+        ]
+        result = PostgresDestination().load(records, _config(), _options(on_error="fail"))
+
+        assert result.failed == 1
+        assert result.success == 0
+        # Should stop after first failure
+        conn.rollback.assert_called_once()
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_connection_closed_on_success(self, mock_connect: MagicMock) -> None:
+        conn = _fake_connection()
+        mock_connect.return_value = conn
+
+        PostgresDestination().load([{"id": 1, "score": 0.5}], _config(), _options())
+        conn.close.assert_called_once()
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_connection_closed_on_error(self, mock_connect: MagicMock) -> None:
+        conn = _fake_connection()
+        conn.cursor().execute.side_effect = Exception("fail")
+        mock_connect.return_value = conn
+
+        PostgresDestination().load([{"id": 1, "score": 0.5}], _config(), _options(on_error="fail"))
+        conn.close.assert_called_once()


### PR DESCRIPTION
## Summary

- Add PostgreSQL destination that enables reverse ETL from BigQuery to operational databases (e.g. CloudSQL)
- Uses `INSERT ... ON CONFLICT DO UPDATE` for idempotent upsert writes
- `PostgresDestinationConfig` with `host/dbname/user/password` env var support
- Proper error handling with `on_error: skip/fail` modes
- 13 unit tests with fake connection (no real DB required)

Closes #39

## Changes

| File | Change |
|------|--------|
| `drt/config/models.py` | `PostgresDestinationConfig` added to `DestinationConfig` union |
| `drt/destinations/postgres.py` | New destination implementation |
| `drt/cli/main.py` | Registered in `_get_destination()` factory |
| `drt/mcp/server.py` | Fixed `type: ignore` placement for arg-type |
| `tests/unit/test_postgres_destination.py` | 13 unit tests |

## sync YAML example

```yaml
destination:
  type: postgres
  host_env: TARGET_PG_HOST
  dbname_env: TARGET_PG_DBNAME
  user_env: TARGET_PG_USER
  password_env: TARGET_PG_PASSWORD
  table: public.analytics_scores
  upsert_key: [id]
```

## Test plan

- [x] `make test` — 104 passed (13 new)
- [x] `make lint` — ruff clean, mypy 1 pre-existing error only (`bigquery.py`)
- [ ] Manual test with real PostgreSQL (future integration test)

## Note on `type: ignore`

This PR adds 2 `type: ignore[return-value]` in `postgres.py` (same pattern as all other destinations). Root cause is tracked in #80 — Protocol design improvement planned for v0.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)