### PR TITLE
docs: add Milestones and Good First Issues links to README roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,14 +201,17 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 
 ## Roadmap
 
+> **Detailed plans & progress → [GitHub Milestones](https://github.com/drt-hub/drt/milestones)**
+> **Looking to contribute? → [Good First Issues](https://github.com/drt-hub/drt/issues?q=is%3Aopen+label%3A%22good+first+issue%22)**
+
 | Version | Focus |
 |---------|-------|
 | **v0.1** ✅ | BigQuery / DuckDB / Postgres sources · REST API / Slack / GitHub Actions / HubSpot destinations · CLI · dry-run |
 | **v0.2** ✅ | Incremental sync (`cursor_field` watermark) · retry config per-sync |
 | **v0.3** ✅ | MCP Server (`drt mcp run`) · AI Skills for Claude Code · LLM-readable docs · row-level errors · security hardening · Redshift source |
-| v0.4 | Dagster integration · Google Sheets destination · dbt post-hook · examples |
-| v0.5 | Snowflake source · CSV/JSON destination · test coverage |
-| v0.6 | Salesforce destination · Airflow integration |
+| [v0.4](https://github.com/drt-hub/drt/milestone/1) | Dagster integration · Google Sheets destination · dbt post-hook · examples |
+| [v0.5](https://github.com/drt-hub/drt/milestone/2) | Snowflake source · CSV/JSON destination · test coverage |
+| [v0.6](https://github.com/drt-hub/drt/milestone/3) | Salesforce destination · Airflow integration |
 | v1.x | Rust engine (PyO3) |
 
 ---


### PR DESCRIPTION
## Summary
- Add links to GitHub Milestones and Good First Issues above the roadmap table
- Link each future version (v0.4, v0.5, v0.6) directly to its milestone

Part of the SSoT migration: version labels → GitHub Milestones.

## Context
- Created milestones v0.4 (8 issues), v0.5 (11 issues), v0.6 (2 issues)
- Created 25 new issues (#84–#108) across destinations, sources, docs, tests, CI, research
- Deprecated and removed version labels (`v0.4`/`v0.5`/`v0.6`) from all issues
- Replied to community comment on #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)