### PR TITLE
chore: update CLAUDE.md and v0.4 plan to reference GitHub Milestones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,11 +66,14 @@ make fmt      # ruff format + fix
 
 ## Roadmap Reference
 
-See the roadmap table in README.md. The short version:
+**SSoT: [GitHub Milestones](https://github.com/drt-hub/drt/milestones)** — all issues are tracked there.
+
 - v0.1 ✅: BigQuery → REST API working end-to-end
 - v0.2 ✅: Incremental sync + retry from config
 - v0.3 ✅: MCP Server + AI Skills for Claude Code + LLM-readable docs + row-level errors + security hardening + Redshift source
-- v0.4: Dagster integration + Google Sheets destination + dbt post-hook + examples
-- v0.5: Snowflake source + CSV/JSON destination + test coverage
-- v0.6: Salesforce destination + Airflow integration
+- [v0.4](https://github.com/drt-hub/drt/milestone/1): Dagster integration + Google Sheets destination + dbt post-hook + examples
+- [v0.5](https://github.com/drt-hub/drt/milestone/2): Snowflake source + CSV/JSON destination + test coverage
+- [v0.6](https://github.com/drt-hub/drt/milestone/3): Salesforce destination + Airflow integration
 - v1.x: Rust engine via PyO3
+
+**Good First Issues:** https://github.com/drt-hub/drt/issues?q=is%3Aopen+label%3A%22good+first+issue%22

--- a/docs/plans/2026-03-31-v0.4-implementation.md
+++ b/docs/plans/2026-03-31-v0.4-implementation.md
@@ -1,5 +1,9 @@
 # v0.4 Implementation Plan
 
+> **⚠️ ARCHIVED (2026-03-31):** This plan was generated for a single Claude Code session.
+> Google Sheets (#64) is now merged. Remaining v0.4 tasks are tracked in
+> **[Milestone v0.4](https://github.com/drt-hub/drt/milestone/1)**.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Ship v0.4 with Google Sheets destination, dagster-drt integration, dbt post-hook, and polished examples.


### PR DESCRIPTION
## Summary
- Update CLAUDE.md roadmap section to link to GitHub Milestones (SSoT) and Good First Issues
- Archive `docs/plans/v0.4-implementation.md` with milestone reference (Google Sheets #64 already merged)

## Context
Follow-up to #109. Completes the SSoT migration from static docs to GitHub Milestones + Issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)