### PR TITLE
feat: add DuckDB → Google Sheets example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ Ready-to-run drt configurations. Each directory is a self-contained project.
 | [notify_slack](./notify_slack/) | DuckDB | Slack | Alert-style notification pattern |
 | [bigquery_to_hubspot](./bigquery_to_hubspot/) | BigQuery | HubSpot | Requires GCP + HubSpot credentials |
 | [bigquery_to_github_actions](./bigquery_to_github_actions/) | BigQuery | GitHub Actions | Trigger workflows from query results |
+| [duckdb_to_google_sheets](./duckdb_to_google_sheets/) | DuckDB | Google Sheets | Requires GCP service account |
 
 Start with `quickstart/` if you are new to drt — it requires no cloud accounts and
 runs end-to-end in about 5 minutes.

--- a/examples/duckdb_to_google_sheets/README.md
+++ b/examples/duckdb_to_google_sheets/README.md
@@ -1,0 +1,63 @@
+# DuckDB → Google Sheets
+
+Export query results from a local DuckDB database to a Google Sheets spreadsheet.
+
+## Prerequisites
+
+- Python 3.10+
+- A Google Cloud service account with Sheets API access
+- A Google Sheets spreadsheet shared with the service account email
+
+## Setup
+
+1. Install drt with Sheets support:
+
+```bash
+pip install drt-core[sheets]
+```
+
+2. Create sample data:
+
+```bash
+python -c "
+import duckdb
+c = duckdb.connect('warehouse.duckdb')
+c.execute('''CREATE TABLE IF NOT EXISTS users AS SELECT * FROM (VALUES
+  (1, 'Alice', 'alice@example.com', 'Engineering'),
+  (2, 'Bob',   'bob@example.com',   'Sales'),
+  (3, 'Carol', 'carol@example.com', 'Marketing')
+) t(id, name, email, department)''')
+c.close()
+"
+```
+
+3. Set up your profile:
+
+```bash
+mkdir -p ~/.drt
+cat > ~/.drt/profiles.yml << 'EOF'
+local:
+  type: duckdb
+  database: ./warehouse.duckdb
+  dataset: main
+EOF
+```
+
+4. Update `syncs/export_to_sheets.yml`:
+   - Replace `spreadsheet_id` with your Google Sheets ID
+   - Replace `credentials_path` with your service account key path
+   - Update `sheet` name if not "Sheet1"
+
+## Run
+
+```bash
+drt run --dry-run   # preview
+drt run             # write to Google Sheets
+drt status          # check result
+```
+
+## Notes
+
+- `mode: overwrite` clears the sheet before writing (header + data)
+- `mode: append` adds rows without clearing
+- The service account email must have Editor access to the spreadsheet

--- a/examples/duckdb_to_google_sheets/drt_project.yml
+++ b/examples/duckdb_to_google_sheets/drt_project.yml
@@ -1,0 +1,3 @@
+name: duckdb-to-sheets
+version: "0.1"
+profile: local

--- a/examples/duckdb_to_google_sheets/syncs/export_to_sheets.yml
+++ b/examples/duckdb_to_google_sheets/syncs/export_to_sheets.yml
@@ -1,0 +1,12 @@
+name: export_to_sheets
+description: "Export user data to Google Sheets"
+model: ref('users')
+destination:
+  type: google_sheets
+  spreadsheet_id: "YOUR_SPREADSHEET_ID"
+  sheet: "Sheet1"
+  mode: overwrite
+  credentials_path: /path/to/service-account-key.json
+sync:
+  mode: full
+  batch_size: 100


### PR DESCRIPTION
## Summary

- Add `examples/duckdb_to_google_sheets/` — complete working example for Google Sheets destination
- Step-by-step README with setup instructions
- Updated examples/README.md table

Closes #94, contributes to #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)