### PR TITLE
chore: release v0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "drt",
       "source": "./skills/drt",
       "description": "Create syncs, debug failures, initialize projects, and migrate from Census/Hightouch to drt",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "homepage": "https://github.com/drt-hub/drt",
       "repository": "https://github.com/drt-hub/drt",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "drt-hub",
   "description": "Skills for drt — Reverse ETL for the code-first data stack",
-  "version": "0.3.4"
+  "version": "0.4.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-03-31
+
+### Added
+
+- **Google Sheets destination** (#64): Overwrite or append mode. Service account or ADC auth. Install: `pip install drt-core[sheets]`
+- **PostgreSQL destination** (#81): Upsert via `INSERT ... ON CONFLICT DO UPDATE`. Row-level error handling
+- **MySQL destination** (#83): Upsert via `INSERT ... ON DUPLICATE KEY UPDATE`. Row-level error handling
+- **dagster-drt integration** (#63): `integrations/dagster-drt/` package. Expose drt syncs as Dagster assets with `drt_assets()`
+- **dbt manifest reader** (#65): `drt.integrations.dbt.resolve_ref_from_manifest()` resolves `ref()` from `target/manifest.json`
+- **Google Sheets example** (#94): `examples/duckdb_to_google_sheets/`
+- **dbt usage guide**: `docs/guides/using-with-dbt.md`
+
+### Refactored
+
+- **Type safety overhaul** (#80, #110): Eliminated 13 `type: ignore` annotations. `Destination.load()` config type `object` → `DestinationConfig`. `Source.extract()` config type narrowed to `ProfileConfig`. `DetailedSyncResult` removed in favor of `SyncResult`. All sources/destinations use `assert isinstance()` for type narrowing
+- **Redshift lazy import** (#78): `RedshiftSource` no longer crashes when `psycopg2` is not installed
+
+### Tests
+
+- 136 tests total (up from 101 in v0.3.4)
+
 ## [0.3.4] - 2026-03-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "drt-core"
-version = "0.3.4"
+version = "0.4.0"
 description = "Reverse ETL for the code-first data stack"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/skills/drt/.claude-plugin/plugin.json
+++ b/skills/drt/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drt",
   "description": "Skills for drt — create syncs, debug failures, initialize projects, and migrate from Census/Hightouch",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "author": {
     "name": "drt-hub"
   },


### PR DESCRIPTION
## v0.4.0 Release

### Added
- Google Sheets destination (`drt-core[sheets]`)
- PostgreSQL destination (upsert)
- MySQL destination (upsert)
- dagster-drt integration package
- dbt manifest reader
- Google Sheets example
- dbt usage guide

### Refactored
- Type safety overhaul: 16 → 3 type:ignore
- DetailedSyncResult removed, unified to SyncResult

### Stats
- 136 tests (up from 101)
- 7 destinations, 5 sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)