### PR TITLE
fix: remove type: ignore from mysql.py by adding types-PyMySQL

### DIFF
--- a/drt/destinations/mysql.py
+++ b/drt/destinations/mysql.py
@@ -99,7 +99,7 @@ class MySQLDestination:
     @staticmethod
     def _connect(config: MySQLDestinationConfig) -> Any:
         try:
-            import pymysql  # type: ignore[import-untyped]
+            import pymysql
         except ImportError as e:
             raise ImportError("MySQL destination requires: pip install drt-core[mysql]") from e
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "mypy>=1.10",
     "ruff>=0.4",
     "types-pyyaml",
+    "types-PyMySQL",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Add `types-PyMySQL` to dev dependencies to provide type stubs
- Remove `# type: ignore[import-untyped]` from `drt/destinations/mysql.py`

Closes #133

## Test plan
- [ ] `make lint` passes (mypy resolves pymysql types via stubs)
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)