### PR TITLE
feat: add 'upsert' sync mode for explicit intent in YAML config

### DIFF
--- a/docs/llm/API_REFERENCE.md
+++ b/docs/llm/API_REFERENCE.md
@@ -62,7 +62,7 @@ destination:                # required: see Destination Configs below
   # ... destination-specific fields
 
 sync:                       # optional: all fields have defaults
-  mode: full                # "full" (default) | "incremental"
+  mode: full                # "full" (default) | "incremental" | "upsert"
   cursor_field: updated_at  # required when mode=incremental — column name for watermark
   batch_size: 100           # default: 100 — rows per destination call
   on_error: fail            # "fail" (default) | "skip"

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -193,7 +193,7 @@ class RetryConfig(BaseModel):
 
 
 class SyncOptions(BaseModel):
-    mode: Literal["full", "incremental"] = "full"
+    mode: Literal["full", "incremental", "upsert"] = "full"
     cursor_field: str | None = None  # required when mode=incremental
     batch_size: int = 100
     rate_limit: RateLimitConfig = Field(default_factory=RateLimitConfig)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -16,6 +16,7 @@ from drt.config.models import (
     ProjectConfig,
     RestApiDestinationConfig,
     SyncConfig,
+    SyncOptions,
 )
 from drt.config.parser import load_project, load_syncs
 
@@ -202,6 +203,38 @@ def test_google_sheets_destination_config_parses() -> None:
     assert cfg.destination.spreadsheet_id == "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms"
     assert cfg.destination.sheet == "Sheet1"
     assert cfg.destination.mode == "overwrite"
+
+
+# ---------------------------------------------------------------------------
+# SyncOptions — upsert mode
+# ---------------------------------------------------------------------------
+
+def test_sync_options_upsert_mode_accepted() -> None:
+    """mode='upsert' is valid and behaves like 'full' (no cursor_field required)."""
+    opts = SyncOptions(mode="upsert")
+    assert opts.mode == "upsert"
+    assert opts.cursor_field is None
+
+
+def test_sync_options_full_mode_still_works() -> None:
+    """Backward compat: mode='full' remains the default."""
+    opts = SyncOptions()
+    assert opts.mode == "full"
+
+
+def test_sync_options_upsert_in_sync_config() -> None:
+    """mode='upsert' works end-to-end inside a SyncConfig."""
+    raw = {
+        "name": "upsert_sync",
+        "model": "ref('scores')",
+        "destination": {
+            "type": "rest_api",
+            "url": "https://example.com/api",
+        },
+        "sync": {"mode": "upsert"},
+    }
+    cfg = SyncConfig(**raw)
+    assert cfg.sync.mode == "upsert"
 
 
 def test_google_sheets_destination_defaults() -> None:


### PR DESCRIPTION
## Summary
- Add `"upsert"` to `SyncOptions.mode` (`Literal["full", "incremental", "upsert"]`)
- `mode: upsert` behaves identically to `mode: full` — the value is semantic, making YAML reader intent clearer when `upsert_key` is set
- Backward compatible: `mode: full` + `upsert_key` still works unchanged
- Updated API_REFERENCE.md

Closes #130

## Test plan
- [ ] `test_sync_options_upsert_mode_accepted` — validates upsert mode is accepted
- [ ] `test_sync_options_full_mode_still_works` — backward compat
- [ ] `test_sync_options_upsert_in_sync_config` — end-to-end in SyncConfig
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)