### PR TITLE
feat: add SSL/TLS connection options for PostgreSQL and MySQL

### DIFF
--- a/docs/llm/API_REFERENCE.md
+++ b/docs/llm/API_REFERENCE.md
@@ -189,6 +189,11 @@ destination:
   password_env: TARGET_PG_PASSWORD   # env var for password
   table: public.analytics_scores     # required: target table
   upsert_key: [id]                   # required: columns for ON CONFLICT
+  ssl:                               # optional: SSL/TLS connection
+    enabled: true
+    ca_env: PG_SSL_CA                # env var for CA cert path
+    cert_env: PG_SSL_CERT            # env var for client cert path
+    key_env: PG_SSL_KEY              # env var for client key path
 ```
 
 > Uses `INSERT ... ON CONFLICT (upsert_key) DO UPDATE SET ...` for idempotent writes.
@@ -205,6 +210,11 @@ destination:
   password_env: TARGET_MYSQL_PASS    # env var for password
   table: analytics.scores            # required: target table
   upsert_key: [id]                   # required: columns for ON DUPLICATE KEY
+  ssl:                               # optional: SSL/TLS connection
+    enabled: true
+    ca_env: MYSQL_SSL_CA             # env var for CA cert path
+    cert_env: MYSQL_SSL_CERT         # env var for client cert path
+    key_env: MYSQL_SSL_KEY           # env var for client key path
 ```
 
 > Uses `INSERT ... ON DUPLICATE KEY UPDATE ...` for idempotent writes.

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -116,6 +116,15 @@ class HubSpotDestinationConfig(BaseModel):
     auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
 
 
+class SslConfig(BaseModel):
+    """SSL/TLS connection options for DB destinations."""
+
+    enabled: bool = False
+    ca_env: str | None = None  # env var for CA cert path
+    cert_env: str | None = None  # env var for client cert path
+    key_env: str | None = None  # env var for client key path
+
+
 class PostgresDestinationConfig(BaseModel):
     type: Literal["postgres"]
     host: str | None = None
@@ -129,6 +138,7 @@ class PostgresDestinationConfig(BaseModel):
     password_env: str | None = None
     table: str  # e.g. "public.analytics_scores"
     upsert_key: list[str]  # columns for ON CONFLICT
+    ssl: SslConfig | None = None
 
     @model_validator(mode="after")
     def _check_connection(self) -> "PostgresDestinationConfig":
@@ -152,6 +162,7 @@ class MySQLDestinationConfig(BaseModel):
     password_env: str | None = None
     table: str  # e.g. "interviewer_learning_profiles"
     upsert_key: list[str]  # columns for ON DUPLICATE KEY
+    ssl: SslConfig | None = None
 
     @model_validator(mode="after")
     def _check_connection(self) -> "MySQLDestinationConfig":

--- a/drt/destinations/mysql.py
+++ b/drt/destinations/mysql.py
@@ -125,4 +125,17 @@ class MySQLDestination:
         if password:
             kwargs["password"] = password
 
+        if config.ssl and config.ssl.enabled:
+            ssl_dict: dict[str, Any] = {}
+            ca = resolve_env(None, config.ssl.ca_env)
+            if ca:
+                ssl_dict["ca"] = ca
+            cert = resolve_env(None, config.ssl.cert_env)
+            if cert:
+                ssl_dict["cert"] = cert
+            key = resolve_env(None, config.ssl.key_env)
+            if key:
+                ssl_dict["key"] = key
+            kwargs["ssl"] = ssl_dict
+
         return pymysql.connect(**kwargs)

--- a/drt/destinations/postgres.py
+++ b/drt/destinations/postgres.py
@@ -122,10 +122,24 @@ class PostgresDestination:
         if not dbname:
             raise ValueError("PostgreSQL destination: dbname could not be resolved.")
 
-        return psycopg2.connect(
-            host=host,
-            port=config.port,
-            dbname=dbname,
-            user=user,
-            password=password,
-        )
+        kwargs: dict[str, Any] = {
+            "host": host,
+            "port": config.port,
+            "dbname": dbname,
+            "user": user,
+            "password": password,
+        }
+
+        if config.ssl and config.ssl.enabled:
+            kwargs["sslmode"] = "require"
+            ca = resolve_env(None, config.ssl.ca_env)
+            if ca:
+                kwargs["sslrootcert"] = ca
+            cert = resolve_env(None, config.ssl.cert_env)
+            if cert:
+                kwargs["sslcert"] = cert
+            key = resolve_env(None, config.ssl.key_env)
+            if key:
+                kwargs["sslkey"] = key
+
+        return psycopg2.connect(**kwargs)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -13,8 +13,11 @@ from drt.config.models import (
     BasicAuth,
     BearerAuth,
     GoogleSheetsDestinationConfig,
+    MySQLDestinationConfig,
+    PostgresDestinationConfig,
     ProjectConfig,
     RestApiDestinationConfig,
+    SslConfig,
     SyncConfig,
     SyncOptions,
 )
@@ -235,6 +238,59 @@ def test_sync_options_upsert_in_sync_config() -> None:
     }
     cfg = SyncConfig(**raw)
     assert cfg.sync.mode == "upsert"
+
+
+def test_ssl_config_defaults() -> None:
+    ssl = SslConfig()
+    assert ssl.enabled is False
+    assert ssl.ca_env is None
+    assert ssl.cert_env is None
+    assert ssl.key_env is None
+
+
+def test_ssl_config_full() -> None:
+    ssl = SslConfig(enabled=True, ca_env="SSL_CA", cert_env="SSL_CERT", key_env="SSL_KEY")
+    assert ssl.enabled is True
+    assert ssl.ca_env == "SSL_CA"
+
+
+def test_postgres_destination_with_ssl() -> None:
+    cfg = PostgresDestinationConfig(
+        type="postgres",
+        host="localhost",
+        dbname="testdb",
+        table="t",
+        upsert_key=["id"],
+        ssl=SslConfig(enabled=True, ca_env="PG_SSL_CA"),
+    )
+    assert cfg.ssl is not None
+    assert cfg.ssl.enabled is True
+    assert cfg.ssl.ca_env == "PG_SSL_CA"
+
+
+def test_postgres_destination_without_ssl() -> None:
+    cfg = PostgresDestinationConfig(
+        type="postgres",
+        host="localhost",
+        dbname="testdb",
+        table="t",
+        upsert_key=["id"],
+    )
+    assert cfg.ssl is None
+
+
+def test_mysql_destination_with_ssl() -> None:
+    cfg = MySQLDestinationConfig(
+        type="mysql",
+        host="localhost",
+        dbname="testdb",
+        table="t",
+        upsert_key=["id"],
+        ssl=SslConfig(enabled=True, ca_env="MYSQL_SSL_CA", cert_env="MYSQL_SSL_CERT"),
+    )
+    assert cfg.ssl is not None
+    assert cfg.ssl.enabled is True
+    assert cfg.ssl.ca_env == "MYSQL_SSL_CA"
 
 
 def test_google_sheets_destination_defaults() -> None:


### PR DESCRIPTION
## Summary
- Add `SslConfig` model with `enabled`, `ca_env`, `cert_env`, `key_env` fields
- Add optional `ssl` parameter to `PostgresDestinationConfig` and `MySQLDestinationConfig`
- PostgreSQL: passes `sslmode`, `sslrootcert`, `sslcert`, `sslkey` to psycopg2
- MySQL: passes `ssl` dict with `ca`, `cert`, `key` to pymysql

Closes #131

## Test plan
- [ ] `test_ssl_config_defaults` / `test_ssl_config_full`
- [ ] `test_postgres_destination_with_ssl` / `test_postgres_destination_without_ssl`
- [ ] `test_mysql_destination_with_ssl`
- [ ] All 23 config tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)