### PR TITLE
chore: release prep — drt-core v0.4.1 + dagster-drt v0.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "drt",
       "source": "./skills/drt",
       "description": "Create syncs, debug failures, initialize projects, and migrate from Census/Hightouch to drt",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "homepage": "https://github.com/drt-hub/drt",
       "repository": "https://github.com/drt-hub/drt",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "drt-hub",
   "description": "Skills for drt \u2014 Reverse ETL for the code-first data stack",
-  "version": "0.4.0"
+  "version": "0.4.1"
 }

--- a/.claude/commands/dagster-drt-release-check.md
+++ b/.claude/commands/dagster-drt-release-check.md
@@ -1,0 +1,39 @@
+Check that all documentation and version references are consistent before a dagster-drt release.
+
+## Steps
+
+1. **Version consistency** — verify the version string in:
+   - `integrations/dagster-drt/pyproject.toml` (project.version)
+
+2. **Dependencies** — verify:
+   - `drt-core` minimum version in `integrations/dagster-drt/pyproject.toml` matches or exceeds the latest published drt-core version
+   - `dagster` minimum version is reasonable
+
+3. **CHANGELOG** — verify there is an entry for the current dagster-drt version with today's date in `integrations/dagster-drt/CHANGELOG.md` (if exists) or in the main `CHANGELOG.md`
+
+4. **README** — verify `integrations/dagster-drt/README.md`:
+   - PyPI badge version matches pyproject.toml
+   - All public API is documented: `drt_assets()`, `DagsterDrtTranslator`, `DrtConfig`
+   - Usage examples are current and working
+   - Install instructions use correct package name
+
+5. **Exports** — verify `integrations/dagster-drt/dagster_drt/__init__.py`:
+   - All public classes/functions are exported in `__all__`
+   - Exports match what README documents
+
+6. **Tests** — verify all dagster-drt tests pass:
+   ```bash
+   cd integrations/dagster-drt && pip install -e "../../[dev]" -e "." && pytest tests/ -v
+   ```
+
+7. **Publish workflow** — verify `.github/workflows/publish-dagster-drt.yml`:
+   - Tag pattern matches release convention (`dagster-drt-v*`)
+   - Build directory is correct (`integrations/dagster-drt`)
+   - PyPI Trusted Publishing is configured (check GitHub repo Settings > Environments > pypi)
+
+8. **Main project references** — verify:
+   - Main `README.md` mentions dagster-drt with correct install instructions
+   - `CLAUDE.md` lists dagster-drt in integrations
+   - `docs/llm/CONTEXT.md` mentions dagster-drt
+
+Report any inconsistencies found and suggest fixes.

--- a/.claude/commands/drt-release-check.md
+++ b/.claude/commands/drt-release-check.md
@@ -34,9 +34,13 @@ Check that all documentation and version references are consistent before a drt 
    - `.claude/commands/drt-create-sync.md` lists all destinations
    - `skills/drt/skills/drt-create-sync/SKILL.md` lists all destinations
 
-9. **CI** — verify all tests pass: `make test && make lint`
+9. **dagster-drt dependency** — verify:
+   - `integrations/dagster-drt/pyproject.toml` has `drt-core>=` matching or exceeding the version being released
+   - If drt-core has breaking changes, dagster-drt tests still pass
 
-10. **GitHub** — verify:
+10. **CI** — verify all tests pass: `make test && make lint`
+
+11. **GitHub** — verify:
     - All milestone issues are closed or moved
     - No open PRs blocking the release
 

--- a/.github/workflows/publish-dagster-drt.yml
+++ b/.github/workflows/publish-dagster-drt.yml
@@ -1,9 +1,9 @@
-name: Publish to PyPI
+name: Publish dagster-drt to PyPI
 
 on:
   push:
     tags:
-      - "v*"
+      - "dagster-drt-v*"
 
 jobs:
   publish:
@@ -23,8 +23,11 @@ jobs:
       - name: Install uv
         run: pip install uv
 
-      - name: Build
+      - name: Build dagster-drt
+        working-directory: integrations/dagster-drt
         run: uv build
 
-      - name: Publish to PyPI
+      - name: Publish dagster-drt to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: integrations/dagster-drt/dist/

--- a/.github/workflows/publish-drt-core.yml
+++ b/.github/workflows/publish-drt-core.yml
@@ -1,0 +1,30 @@
+name: Publish drt-core to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # for Trusted Publishing (no API token needed)
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Build
+        run: uv build
+
+      - name: Publish drt-core to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-04-01
+
+### Added
+
+- **Upsert sync mode** (#130): `mode: upsert` for explicit intent in YAML — behaves like `mode: full` with `upsert_key`
+- **SSL/TLS for DB destinations** (#131): Optional `ssl` config for PostgreSQL and MySQL with `ca_env`, `cert_env`, `key_env`
+- **Connection string support** (#132): `connection_string_env` for PostgreSQL and MySQL — alternative to individual host/port/dbname params
+- **dagster-drt: DagsterDrtTranslator** (#127): Customise asset keys, group names, deps, and metadata (follows dagster-dbt pattern)
+- **dagster-drt: DrtConfig with dry_run** (#126): RunConfig controllable from Dagster UI, plus `drt_assets(dry_run=True)` for build-time defaults
+- **dagster-drt: MaterializeResult** (#128): Assets return structured metadata (rows_synced, rows_failed, rows_skipped, dry_run, row_errors_count)
+
+### Fixed
+
+- **MySQL type: ignore** (#133): Replaced `# type: ignore[import-untyped]` with `types-PyMySQL` dev dependency
+
 ## [0.4.0] - 2026-03-31
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,12 +50,12 @@ make fmt      # ruff format + fix
 
 ## Current Status
 
-- **v0.4.0 released** — Google Sheets, PostgreSQL dest, MySQL dest, dagster-drt, dbt manifest reader
+- **v0.4.1 released** — SSL/TLS + connection_string_env for DB destinations, upsert sync mode, dagster-drt enhancements (Translator, DrtConfig, MaterializeResult)
 - CLI fully wired: `init`, `run`, `list`, `validate`, `status`, `mcp run`
 - Sources: BigQuery, DuckDB, PostgreSQL, Redshift
 - Destinations: REST API, Slack, GitHub Actions, HubSpot, Google Sheets, PostgreSQL, MySQL
 - Integrations: MCP Server (`drt-core[mcp]`), dagster-drt, dbt manifest reader
-- 136 tests, integration tests use `pytest-httpserver`
+- 152+ tests, integration tests use `pytest-httpserver`
 
 ## What NOT to do
 

--- a/docs/llm/API_REFERENCE.md
+++ b/docs/llm/API_REFERENCE.md
@@ -18,7 +18,7 @@ profile: default          # optional, default: "default" — maps to ~/.drt/prof
 
 ```yaml
 default:
-  type: bigquery            # "bigquery" | "duckdb" | "postgres"
+  type: bigquery            # "bigquery" | "duckdb" | "postgres" | "redshift"
   project: my-gcp-project   # BigQuery: GCP project ID
   dataset: analytics        # BigQuery: dataset name
   location: US              # optional: "US" (default), "EU", "asia-northeast1", etc.
@@ -62,7 +62,7 @@ destination:                # required: see Destination Configs below
   # ... destination-specific fields
 
 sync:                       # optional: all fields have defaults
-  mode: full                # "full" (default) | "incremental" | "upsert"
+  mode: full                # "full" (default) | "incremental" | "upsert"  # "upsert" is a semantic alias for "full" when upsert_key is set
   cursor_field: updated_at  # required when mode=incremental — column name for watermark
   batch_size: 100           # default: 100 — rows per destination call
   on_error: fail            # "fail" (default) | "skip"
@@ -400,6 +400,31 @@ destination:
 sync:
   mode: incremental
   cursor_field: updated_at
+  on_error: skip
+```
+
+### MySQL upsert
+
+```yaml
+name: sync_leads_mysql
+description: "Upsert lead scores to target MySQL"
+model: ref('lead_scores')
+
+destination:
+  type: mysql
+  host_env: TARGET_MYSQL_HOST
+  database_env: TARGET_MYSQL_DB
+  user_env: TARGET_MYSQL_USER
+  password_env: TARGET_MYSQL_PASS
+  table: marketing.lead_scores
+  upsert_key: [lead_id]
+  ssl:
+    enabled: true
+    ca_env: MYSQL_SSL_CA
+
+sync:
+  mode: upsert
+  batch_size: 200
   on_error: skip
 ```
 

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -14,7 +14,7 @@ dlt (load into DWH) → dbt (transform) → drt (activate out of DWH)
 - **Tagline:** "Reverse ETL for the code-first data stack"
 - **Install:** `pip install drt-core` or `uv add drt-core`
 - **Package name:** `drt-core` (PyPI) — CLI command is `drt`
-- **Current version:** v0.4.0
+- **Current version:** v0.4.1
 
 ## What drt is NOT
 
@@ -116,6 +116,28 @@ drt mcp run   # starts stdio MCP server
 
 The MCP server reads from the current working directory (the drt project root).
 
+## Orchestration: dagster-drt
+
+Community-maintained Dagster integration. Install: `pip install dagster-drt`
+
+```python
+from dagster_drt import drt_assets, DagsterDrtTranslator, DrtConfig
+
+# Basic usage
+assets = drt_assets(project_dir="path/to/drt-project")
+
+# Custom translator for group names and deps
+class MyTranslator(DagsterDrtTranslator):
+    def get_group_name(self, sync_config):
+        return "reverse_etl"
+
+assets = drt_assets(
+    project_dir="path/to/drt-project",
+    dagster_drt_translator=MyTranslator(),
+    dry_run=True,  # build-time default
+)
+```
+
 ## AI Skills for Claude Code
 
 Four skills available via the Claude Code plugin marketplace:
@@ -147,6 +169,9 @@ Slash command versions also available in `.claude/commands/` for manual installa
 - drt saves `last_cursor_value` in `.drt/state.json` after each run
 - Next run automatically injects `WHERE <cursor_field> > '<last_value>'`
 - Cursor comparison uses numeric ordering when possible (handles integer/float cursors correctly)
+
+**Upsert mode**: Semantic alias for `mode: full` when `upsert_key` is set. Makes YAML intent explicit.
+- Set `sync.mode: upsert` — behaves identically to `mode: full`
 
 ### Model Reference
 

--- a/integrations/dagster-drt/README.md
+++ b/integrations/dagster-drt/README.md
@@ -1,14 +1,18 @@
 # dagster-drt
 
-Dagster integration for [drt](https://github.com/drt-hub/drt) — expose drt syncs as Dagster assets.
+[![PyPI](https://img.shields.io/pypi/v/dagster-drt)](https://pypi.org/project/dagster-drt/)
 
-## Install
+Community-maintained [Dagster](https://dagster.io/) integration for [drt](https://github.com/drt-hub/drt) (data reverse tool).
+
+Expose drt syncs as Dagster assets with full observability — metrics, dependencies, and dry-run support.
+
+## Installation
 
 ```bash
 pip install dagster-drt
 ```
 
-## Usage
+## Quick Start
 
 ```python
 from dagster import Definitions
@@ -17,7 +21,103 @@ from dagster_drt import drt_assets
 defs = Definitions(assets=drt_assets(project_dir="path/to/drt-project"))
 ```
 
-Then run:
-```bash
-dagster dev
+## Features
+
+### DagsterDrtTranslator
+
+Customise how drt syncs map to Dagster assets. Subclass and override methods:
+
+```python
+from dagster import AssetKey
+from dagster_drt import DagsterDrtTranslator, drt_assets
+
+class MyTranslator(DagsterDrtTranslator):
+    def get_group_name(self, sync_config):
+        return "reverse_etl"
+
+    def get_deps(self, sync_config):
+        deps_map = {
+            "trigger_bq_meeting_gha": [AssetKey("bq_meeting_cloudsql")],
+        }
+        return deps_map.get(sync_config.name, [])
+
+assets = drt_assets(
+    project_dir="pipeline/data-reverse",
+    dagster_drt_translator=MyTranslator(),
+)
 ```
+
+**Available methods:**
+
+| Method | Default | Purpose |
+|--------|---------|---------|
+| `get_asset_key(sync_config)` | `AssetKey(f"drt_{name}")` | Asset key |
+| `get_group_name(sync_config)` | `None` | Group name |
+| `get_description(sync_config)` | `sync_config.description` | Asset description |
+| `get_deps(sync_config)` | `[]` | Upstream dependencies |
+| `get_metadata(sync_config)` | `{}` | Static metadata |
+
+### Dry-Run Support (DrtConfig)
+
+Control dry-run mode per-run from the Dagster UI, or set a build-time default:
+
+```python
+# Build-time default: all syncs in dry-run mode
+assets = drt_assets(project_dir="...", dry_run=True)
+
+# Override per-run via Dagster UI → Run Config:
+# ops:
+#   drt_my_sync:
+#     config:
+#       dry_run: false
+```
+
+### MaterializeResult
+
+Assets return `MaterializeResult` with structured metadata visible in the Dagster UI:
+
+- `sync_name` — sync identifier
+- `rows_synced` — successful row count
+- `rows_failed` — failed row count
+- `rows_skipped` — skipped row count
+- `dry_run` — whether dry-run was active
+- `row_errors_count` — number of row-level errors (details in logs)
+
+### Filtering Syncs
+
+```python
+# Only expose specific syncs as assets
+assets = drt_assets(
+    project_dir="...",
+    sync_names=["sync_a", "sync_b"],
+)
+```
+
+## Usage with dagster-dbt
+
+```python
+from dagster import Definitions
+from dagster_dbt import dbt_assets
+from dagster_drt import drt_assets, DagsterDrtTranslator
+
+defs = Definitions(
+    assets=[*my_dbt_assets, *drt_assets("path/to/drt-project")],
+)
+```
+
+## API Reference
+
+### `drt_assets()`
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `project_dir` | `str \| Path` | required | Path to drt project root |
+| `sync_names` | `list[str] \| None` | `None` | Filter to specific syncs |
+| `dagster_drt_translator` | `DagsterDrtTranslator \| None` | `None` | Custom translator |
+| `dry_run` | `bool` | `False` | Default dry-run mode |
+
+Returns: `list[AssetsDefinition]`
+
+## License
+
+Apache-2.0

--- a/integrations/dagster-drt/pyproject.toml
+++ b/integrations/dagster-drt/pyproject.toml
@@ -4,12 +4,20 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dagster-drt"
-version = "0.4.0"
-description = "Dagster integration for drt (data reverse tool)"
+version = "0.1.0"
+description = "Community-maintained Dagster integration for drt (data reverse tool)"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
 dependencies = [
     "dagster>=1.6",
-    "drt-core>=0.3",
+    "drt-core>=0.4.1",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "drt-core"
-version = "0.4.0"
+version = "0.4.1"
 description = "Reverse ETL for the code-first data stack"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/skills/drt/.claude-plugin/plugin.json
+++ b/skills/drt/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drt",
   "description": "Skills for drt \u2014 create syncs, debug failures, initialize projects, and migrate from Census/Hightouch",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "drt-hub"
   },


### PR DESCRIPTION
## Summary
- **drt-core v0.4.1**: Version bump (4 files), CHANGELOG, CLAUDE.md, CONTEXT.md, API_REFERENCE.md updates for #126-133
- **dagster-drt v0.1.0**: First PyPI release prep — version, "Community-maintained" description, `drt-core>=0.4.1`, full README rewrite
- **Workflows**: Rename `publish.yml` → `publish-drt-core.yml`, add `publish-dagster-drt.yml`
- **Skills**: New `dagster-drt-release-check.md`, updated `drt-release-check.md` with dagster-drt dependency step

Closes #129

## Post-merge steps (manual)
1. Configure PyPI Trusted Publishing for `dagster-drt` package
2. Tag `v0.4.1` → drt-core publishes to PyPI
3. Tag `dagster-drt-v0.1.0` → dagster-drt publishes to PyPI

## Test plan
- [ ] 32 config tests pass
- [ ] ruff lint passes
- [ ] CI green
- [ ] Version consistency: all 4 files show 0.4.1
- [ ] CHANGELOG has v0.4.1 entry
- [ ] dagster-drt pyproject.toml: version=0.1.0, drt-core>=0.4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)