### PR TITLE
docs: dagster-drt documentation parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## dagster-drt
+
+> `dagster-drt` is published as a separate PyPI package with its own version.
+
+### [0.1.0] - 2026-04-01 (dagster-drt)
+
+- First PyPI release (`pip install dagster-drt`)
+- **DagsterDrtTranslator** (#127): Customise asset keys, group names, deps, and metadata (follows dagster-dbt pattern)
+- **DrtConfig with dry_run** (#126): RunConfig controllable from Dagster UI, plus `drt_assets(dry_run=True)` for build-time defaults
+- **MaterializeResult** (#128): Assets return structured metadata (rows_synced, rows_failed, rows_skipped, dry_run, row_errors_count)
+- Requires `drt-core>=0.4.1`
+
+---
+
+## drt-core
+
 ## [0.4.1] - 2026-04-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 | **Destination** | Notion | 🗓 planned | (core) |
 | **Destination** | Linear | 🗓 planned | (core) |
 | **Destination** | SendGrid | 🗓 planned | (core) |
+| **Integration** | Dagster | ✅ v0.4 | `pip install dagster-drt` |
+| **Integration** | Airflow | 🗓 v0.6 | `pip install airflow-drt` |
+| **Integration** | dbt manifest reader | ✅ v0.4 | (core) |
 
 ---
 
@@ -221,6 +224,34 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 | [v0.5](https://github.com/drt-hub/drt/milestone/2) | Snowflake source · CSV/JSON destination · test coverage |
 | [v0.6](https://github.com/drt-hub/drt/milestone/3) | Salesforce destination · Airflow integration |
 | v1.x | Rust engine (PyO3) |
+
+---
+
+## Orchestration: dagster-drt
+
+Community-maintained [Dagster](https://dagster.io/) integration. Expose drt syncs as Dagster assets with full observability.
+
+```bash
+pip install dagster-drt
+```
+
+```python
+from dagster import Definitions
+from dagster_drt import drt_assets, DagsterDrtTranslator
+
+class MyTranslator(DagsterDrtTranslator):
+    def get_group_name(self, sync_config):
+        return "reverse_etl"
+
+defs = Definitions(
+    assets=drt_assets(
+        project_dir="path/to/drt-project",
+        dagster_drt_translator=MyTranslator(),
+    )
+)
+```
+
+See [dagster-drt README](integrations/dagster-drt/README.md) for full API docs (Translator, DrtConfig dry-run, MaterializeResult).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,19 @@
 
 ## Supported Versions
 
+### drt-core
+
 | Version | Supported |
 |---------|-----------|
 | 0.4.x   | ✅        |
 | 0.3.x   | ✅        |
 | < 0.3   | ❌        |
+
+### dagster-drt
+
+| Version | Supported |
+|---------|-----------|
+| 0.1.x   | ✅        |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary
- **README**: Add "Orchestration: dagster-drt" section with install + usage example. Add Integration rows to Connectors table (Dagster, Airflow, dbt manifest)
- **CHANGELOG**: Add dagster-drt section with `[0.1.0]` entry (separate from drt-core versioning)
- **SECURITY**: Add dagster-drt supported versions table

## Why
dagster-drt is a separately published PyPI package managed in this repo. It should have the same documentation coverage as drt-core.

## Test plan
- [ ] CI green
- [ ] README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)