### PR TITLE
test(redshift): improve RedshiftSource unit tests

### DIFF
--- a/tests/unit/test_redshift.py
+++ b/tests/unit/test_redshift.py
@@ -1,137 +1,161 @@
-"""Tests for Redshift source connector."""
+"""Unit tests for Redshift source connector.
+
+These tests mock psycopg2 and validate real RedshiftSource behavior without
+connecting to a live Redshift cluster.
+"""
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from typing import Any
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from drt.config.credentials import RedshiftProfile  # noqa: E402
-
-# ---------------------------------------------------------------------------
-# FakeRedshiftSource (test double)
-# ---------------------------------------------------------------------------
-
-class FakeRedshiftSource:
-    """Fake Redshift source for testing without a real cluster."""
-
-    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
-        self._rows = rows or []
-        self.queries_executed: list[str] = []
-        self.schema_set: str | None = None
-
-    def extract(self, query: str, config: RedshiftProfile) -> Iterator[dict[str, Any]]:
-        """Yield rows and track the query."""
-        self.queries_executed.append(query)
-        if config.schema:
-            self.schema_set = config.schema
-        yield from self._rows
-
-    def test_connection(self, config: RedshiftProfile) -> bool:
-        """Always succeeds for the fake."""
-        return True
+from drt.config.credentials import RedshiftProfile
+from drt.sources.base import Source
+from drt.sources.redshift import RedshiftSource
 
 
-# ---------------------------------------------------------------------------
-# Profile tests
-# ---------------------------------------------------------------------------
-
-def test_redshift_profile_defaults() -> None:
-    """RedshiftProfile has sensible defaults."""
-    profile = RedshiftProfile(type="redshift")
-    assert profile.port == 5439  # Redshift default, not Postgres 5432
-    assert profile.schema == "public"
-    assert profile.host == ""
-    assert profile.dbname == ""
-
-
-def test_redshift_profile_custom_schema() -> None:
-    """RedshiftProfile accepts custom schema."""
-    profile = RedshiftProfile(
-        type="redshift",
-        host="cluster.xxx.redshift.amazonaws.com",
-        port=5439,
-        dbname="warehouse",
-        user="analyst",
-        password_env="RS_PASS",
-        schema="analytics",
-    )
-    assert profile.schema == "analytics"
-    assert profile.host == "cluster.xxx.redshift.amazonaws.com"
+def _config(**overrides: object) -> RedshiftProfile:
+    defaults: dict[str, object] = {
+        "type": "redshift",
+        "host": "cluster.example.redshift.amazonaws.com",
+        "port": 5439,
+        "dbname": "analytics",
+        "user": "analyst",
+        "schema": "public",
+    }
+    defaults.update(overrides)
+    return RedshiftProfile(**defaults)
 
 
-# ---------------------------------------------------------------------------
-# FakeRedshiftSource tests
-# ---------------------------------------------------------------------------
-
-def test_fake_redshift_source_extract() -> None:
-    """FakeRedshiftSource yields configured rows."""
-    rows = [
-        {"id": 1, "name": "Alice"},
-        {"id": 2, "name": "Bob"},
-    ]
-    source = FakeRedshiftSource(rows)
-    config = RedshiftProfile(
-        type="redshift",
-        host="test",
-        dbname="test",
-        user="test",
-        schema="public",
-    )
-
-    result = list(source.extract("SELECT * FROM users", config))
-
-    assert result == rows
-    assert source.queries_executed == ["SELECT * FROM users"]
-    assert source.schema_set == "public"
+def _fake_connection() -> MagicMock:
+    conn = MagicMock()
+    conn.cursor.return_value = MagicMock()
+    return conn
 
 
-def test_fake_redshift_source_tracks_schema() -> None:
-    """FakeRedshiftSource tracks which schema was used."""
-    source = FakeRedshiftSource([])
-    config = RedshiftProfile(
-        type="redshift",
-        host="test",
-        dbname="test",
-        user="test",
-        schema="analytics",
-    )
-
-    list(source.extract("SELECT 1", config))
-
-    assert source.schema_set == "analytics"
-
-
-def test_fake_redshift_source_test_connection() -> None:
-    """FakeRedshiftSource.test_connection always returns True."""
-    source = FakeRedshiftSource()
-    config = RedshiftProfile(type="redshift")
-    assert source.test_connection(config) is True
-
-
-def test_fake_redshift_source_empty() -> None:
-    """FakeRedshiftSource handles empty result set."""
-    source = FakeRedshiftSource([])
-    config = RedshiftProfile(type="redshift")
-
-    result = list(source.extract("SELECT * FROM empty", config))
-
-    assert result == []
-
-
-# ---------------------------------------------------------------------------
-# Integration with engine (using FakeRedshiftSource)
-# ---------------------------------------------------------------------------
-
-def test_redshift_source_with_engine_pattern(tmp_path: pytest.TempPathFactory) -> None:
-    """Verify FakeRedshiftSource follows the Source protocol."""
-    from drt.sources.base import Source
-
-    source = FakeRedshiftSource([{"id": 1}])
-
-    # Should match the Source protocol (duck typing)
-    assert hasattr(source, "extract")
-    assert hasattr(source, "test_connection")
-    # Protocol check via isinstance with runtime_checkable
+def test_redshift_source_implements_source_protocol() -> None:
+    source = RedshiftSource()
     assert isinstance(source, Source)
+
+
+def test_connect_uses_explicit_password_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REDSHIFT_PASSWORD", "env-secret")
+    conn = _fake_connection()
+    connect = MagicMock(return_value=conn)
+    fake_psycopg2 = SimpleNamespace(connect=connect)
+    monkeypatch.setitem(sys.modules, "psycopg2", fake_psycopg2)
+
+    profile = _config(password="explicit-secret", password_env="REDSHIFT_PASSWORD")
+    RedshiftSource()._connect(profile)
+
+    connect.assert_called_once_with(
+        host="cluster.example.redshift.amazonaws.com",
+        port=5439,
+        dbname="analytics",
+        user="analyst",
+        password="explicit-secret",
+    )
+
+
+def test_connect_reads_password_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REDSHIFT_PASSWORD", "env-secret")
+    conn = _fake_connection()
+    connect = MagicMock(return_value=conn)
+    fake_psycopg2 = SimpleNamespace(connect=connect)
+    monkeypatch.setitem(sys.modules, "psycopg2", fake_psycopg2)
+
+    profile = _config(password=None, password_env="REDSHIFT_PASSWORD")
+    RedshiftSource()._connect(profile)
+
+    connect.assert_called_once_with(
+        host="cluster.example.redshift.amazonaws.com",
+        port=5439,
+        dbname="analytics",
+        user="analyst",
+        password="env-secret",
+    )
+
+
+def test_extract_maps_rows_to_dicts_and_sets_schema() -> None:
+    source = RedshiftSource()
+    conn = _fake_connection()
+    cur = conn.cursor.return_value
+    cur.description = [("id",), ("email",)]
+    cur.fetchall.return_value = [(1, "a@example.com"), (2, "b@example.com")]
+
+    with patch.object(source, "_connect", return_value=conn):
+        result = list(source.extract("SELECT id, email FROM users", _config(schema="analytics")))
+
+    assert result == [
+        {"id": 1, "email": "a@example.com"},
+        {"id": 2, "email": "b@example.com"},
+    ]
+    assert cur.execute.call_count == 2
+    assert cur.execute.call_args_list[1].args[0] == "SELECT id, email FROM users"
+    conn.close.assert_called_once()
+
+
+def test_extract_incremental_query_passthrough() -> None:
+    source = RedshiftSource()
+    conn = _fake_connection()
+    cur = conn.cursor.return_value
+    cur.description = [("id",), ("updated_at",)]
+    cur.fetchall.return_value = [(42, "2026-03-31T00:00:00")]
+
+    query = (
+        "SELECT id, updated_at FROM events "
+        "WHERE updated_at > '2026-03-01T00:00:00' ORDER BY updated_at"
+    )
+    with patch.object(source, "_connect", return_value=conn):
+        result = list(source.extract(query, _config(schema="public")))
+
+    assert result == [{"id": 42, "updated_at": "2026-03-31T00:00:00"}]
+    assert cur.execute.call_args_list[1].args[0] == query
+
+
+def test_extract_raises_on_query_error_and_closes_connection() -> None:
+    source = RedshiftSource()
+    conn = _fake_connection()
+    cur = conn.cursor.return_value
+    cur.execute.side_effect = [None, RuntimeError("query failed")]
+
+    with patch.object(source, "_connect", return_value=conn):
+        with pytest.raises(RuntimeError, match="query failed"):
+            list(source.extract("SELECT * FROM broken", _config(schema="analytics")))
+
+    conn.close.assert_called_once()
+
+
+def test_test_connection_success() -> None:
+    source = RedshiftSource()
+    conn = _fake_connection()
+
+    with patch.object(source, "_connect", return_value=conn):
+        ok = source.test_connection(_config())
+
+    assert ok is True
+    conn.cursor.return_value.execute.assert_called_once_with("SELECT 1")
+    conn.close.assert_called_once()
+
+
+def test_test_connection_returns_false_on_connection_error() -> None:
+    source = RedshiftSource()
+
+    with patch.object(source, "_connect", side_effect=RuntimeError("cannot connect")):
+        ok = source.test_connection(_config())
+
+    assert ok is False
+
+
+def test_test_connection_returns_false_on_query_error() -> None:
+    source = RedshiftSource()
+    conn = _fake_connection()
+    conn.cursor.return_value.execute.side_effect = RuntimeError("bad query")
+
+    with patch.object(source, "_connect", return_value=conn):
+        ok = source.test_connection(_config())
+
+    assert ok is False


### PR DESCRIPTION
## Summary
This PR improves unit test coverage for `RedshiftSource` using mock-based tests.  
Closes #99

## What changed
- Reworked tests in `tests/unit/test_redshift.py` to target the real `RedshiftSource` implementation
- Added connection initialization tests with mocked `psycopg2`
- Added query execution and row mapping tests
- Added incremental cursor query passthrough test
- Added error handling tests for connection and query failures
- Added protocol compatibility check with `Source`

## Validation
- Ran: `python3 -m pytest -q tests/unit/test_redshift.py`
- Result: **9 passed**

## Notes
- Existing pytest warning about `asyncio_mode` is unrelated to this change.