### PR TITLE
feat: add Discord webhook destination connector

### DIFF
--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -84,6 +84,18 @@ class SlackDestinationConfig(BaseModel):
     block_kit: bool = False
 
 
+class DiscordDestinationConfig(BaseModel):
+    type: Literal["discord"]
+    webhook_url: str | None = None
+    webhook_url_env: str | None = None
+    # Jinja2 template for Discord message. Supports plain text or embeds JSON.
+    # Plain text example: "New user: {{ row.name }} ({{ row.email }})"
+    # Embeds: full JSON payload with "embeds" array
+    message_template: str = "{{ row }}"
+    # If True, treat message_template as a JSON payload with embeds
+    embeds: bool = False
+
+
 class GitHubActionsDestinationConfig(BaseModel):
     type: Literal["github_actions"]
     owner: str
@@ -183,6 +195,7 @@ class MySQLDestinationConfig(BaseModel):
 DestinationConfig = Annotated[
     RestApiDestinationConfig
     | SlackDestinationConfig
+    | DiscordDestinationConfig
     | GitHubActionsDestinationConfig
     | HubSpotDestinationConfig
     | GoogleSheetsDestinationConfig

--- a/drt/destinations/discord.py
+++ b/drt/destinations/discord.py
@@ -1,0 +1,117 @@
+"""Discord destination — Webhook Integration.
+
+Sends messages to a Discord channel via Webhook URL.
+Supports plain text messages and Discord embeds via Jinja2 templates.
+
+No extra dependencies required (uses httpx from core).
+
+Example sync YAML:
+
+    destination:
+      type: discord
+      webhook_url_env: DISCORD_WEBHOOK_URL
+      message_template: "New signup: {{ row.name }} ({{ row.email }})"
+
+Embed example:
+
+    destination:
+      type: discord
+      webhook_url_env: DISCORD_WEBHOOK_URL
+      embeds: true
+      message_template: |
+        {
+          "embeds": [
+            {
+              "title": "{{ row.title }}",
+              "description": "{{ row.description }}",
+              "color": 3447003
+            }
+          ]
+        }
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import httpx
+
+from drt.config.models import DestinationConfig, RetryConfig, SyncOptions, DiscordDestinationConfig
+from drt.destinations.base import SyncResult
+from drt.destinations.rate_limiter import RateLimiter
+from drt.destinations.retry import with_retry
+from drt.destinations.row_errors import RowError
+from drt.templates.renderer import render_template
+
+_DEFAULT_RETRY = RetryConfig(
+    max_attempts=3,
+    initial_backoff=1.0,
+    retryable_status_codes=(429, 500, 502, 503, 504),
+)
+
+
+class DiscordDestination:
+    """Send records as Discord messages via Webhook."""
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, DiscordDestinationConfig)
+        webhook_url = config.webhook_url or (
+            os.environ.get(config.webhook_url_env) if config.webhook_url_env else None
+        )
+        if not webhook_url:
+            raise ValueError(
+                "Discord destination: provide 'webhook_url' or set 'webhook_url_env'."
+            )
+
+        result = SyncResult()
+        rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
+
+        with httpx.Client(timeout=30.0) as client:
+            for i, record in enumerate(records):
+                rate_limiter.acquire()
+                try:
+                    rendered = render_template(config.message_template, record)
+                    if config.embeds:
+                        payload = json.loads(rendered)
+                    else:
+                        payload = {"content": rendered}
+
+                    _url = webhook_url
+                    _payload = payload
+
+                    def do_post() -> httpx.Response:
+                        response = client.post(_url, json=_payload)
+                        response.raise_for_status()
+                        return response
+
+                    with_retry(do_post, _DEFAULT_RETRY)
+                    result.success += 1
+                except httpx.HTTPStatusError as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=e.response.status_code,
+                            error_message=e.response.text[:500],
+                        )
+                    )
+                except Exception as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=None,
+                            error_message=str(e),
+                        )
+                    )
+
+        return result

--- a/examples/duckdb_to_discord/drt_project.yml
+++ b/examples/duckdb_to_discord/drt_project.yml
@@ -1,0 +1,3 @@
+name: duckdb-to-discord
+version: "0.1"
+profile: local

--- a/examples/duckdb_to_discord/profiles.yml.example
+++ b/examples/duckdb_to_discord/profiles.yml.example
@@ -1,0 +1,9 @@
+# Copy this file to profiles.yml and fill in your values
+# For Discord, you need to create a webhook in your Discord server:
+# 1. Go to Server Settings > Integrations > Webhooks
+# 2. Click "Create Webhook"
+# 3. Copy the Webhook URL
+
+local:
+  type: duckdb
+  database: ":memory:"  # Or path to your DuckDB file

--- a/examples/duckdb_to_discord/syncs/notify_discord.yml
+++ b/examples/duckdb_to_discord/syncs/notify_discord.yml
@@ -1,0 +1,13 @@
+name: notify_discord
+description: "Notify new users to Discord channel (DuckDB → Discord)"
+model: ref('new_users')
+destination:
+  type: discord
+  webhook_url_env: DISCORD_WEBHOOK_URL
+  message_template: ":wave: New user: **{{ row.name }}** ({{ row.email }})"
+sync:
+  mode: full
+  batch_size: 1       # Discord: send one message at a time
+  rate_limit:
+    requests_per_second: 2
+  on_error: skip

--- a/tests/unit/test_destinations.py
+++ b/tests/unit/test_destinations.py
@@ -10,11 +10,13 @@ from pytest_httpserver import HTTPServer
 
 from drt.config.models import (
     BearerAuth,
+    DiscordDestinationConfig,
     GitHubActionsDestinationConfig,
     HubSpotDestinationConfig,
     SlackDestinationConfig,
     SyncOptions,
 )
+from drt.destinations.discord import DiscordDestination
 from drt.destinations.github_actions import GitHubActionsDestination
 from drt.destinations.hubspot import HubSpotDestination
 from drt.destinations.slack import SlackDestination
@@ -76,6 +78,60 @@ class TestSlackDestination:
             ),
         )
         result = SlackDestination().load([{"msg": "hello"}], config, _options())
+        assert result.success == 1
+
+
+# ---------------------------------------------------------------------------
+# DiscordDestination
+# ---------------------------------------------------------------------------
+
+
+class TestDiscordDestination:
+    def test_success(self, httpserver: HTTPServer) -> None:
+        httpserver.expect_request("/webhook").respond_with_data("ok", status=200)
+        config = DiscordDestinationConfig(
+            type="discord",
+            webhook_url=httpserver.url_for("/webhook"),
+            message_template="hello {{ row.name }}",
+        )
+        result = DiscordDestination().load([{"name": "Alice"}], config, _options())
+        assert result.success == 1
+        assert result.failed == 0
+
+    def test_on_error_skip(self, httpserver: HTTPServer) -> None:
+        httpserver.expect_ordered_request("/webhook").respond_with_data("", status=500)
+        httpserver.expect_ordered_request("/webhook").respond_with_data("ok", status=200)
+        config = DiscordDestinationConfig(
+            type="discord",
+            webhook_url=httpserver.url_for("/webhook"),
+            message_template="{{ row.msg }}",
+        )
+        opts = SyncOptions(on_error="skip")
+        result = DiscordDestination().load(
+            [{"msg": "a"}, {"msg": "b"}], config, opts
+        )
+        assert result.failed == 1
+        assert result.success == 1
+
+    def test_missing_webhook_raises(self) -> None:
+        config = DiscordDestinationConfig(type="discord", message_template="hi")
+        with pytest.raises(ValueError, match="webhook_url"):
+            DiscordDestination().load([{"x": 1}], config, _options())
+
+    def test_embeds_payload(self, httpserver: HTTPServer) -> None:
+        httpserver.expect_request("/webhook").respond_with_data("ok", status=200)
+        config = DiscordDestinationConfig(
+            type="discord",
+            webhook_url=httpserver.url_for("/webhook"),
+            embeds=True,
+            message_template=(
+                '{"embeds": [{"title": "{{ row.title }}",'
+                ' "description": "{{ row.desc }}", "color": 3447003}]}'
+            ),
+        )
+        result = DiscordDestination().load(
+            [{"title": "New Alert", "desc": "Something happened"}], config, _options()
+        )
         assert result.success == 1
 
 


### PR DESCRIPTION
## Summary

This PR adds a Discord webhook destination connector, addressing issue #84.

## Changes

- Create `drt/destinations/discord.py` with `DiscordDestination` class
- Add `DiscordDestinationConfig` to `drt/config/models.py`
- Support plain text messages and Discord embeds via Jinja2 templates
- Add unit tests in `tests/unit/test_destinations.py`
- Add example configuration in `examples/duckdb_to_discord/`

## Implementation Details

The Discord destination follows the same pattern as the existing Slack destination (`slack.py`). Discord webhooks are very similar to Slack incoming webhooks:

- Plain text messages use `content` field (similar to Slack's `text`)
- Rich content uses `embeds` array (similar to Slack's Block Kit)
- Both use the same retry and rate limiting logic

## Testing

All 4 unit tests pass:
- `test_success`: Basic webhook functionality
- `test_on_error_skip`: Error handling with skip mode
- `test_missing_webhook_raises`: Validation for missing webhook URL
- `test_embeds_payload`: Embed JSON payload support

## Usage Example

```yaml
destination:
  type: discord
  webhook_url_env: DISCORD_WEBHOOK_URL
  message_template: "New user: **{{ row.name }}** ({{ row.email }})"
```

For embeds:

```yaml
destination:
  type: discord
  webhook_url_env: DISCORD_WEBHOOK_URL
  embeds: true
  message_template: |
    {
      "embeds": [
        {
          "title": "{{ row.title }}",
          "description": "{{ row.description }}",
          "color": 3447003
        }
      ]
    }
```

Closes #84