### PR TITLE
feat: add MySQL source connector

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from drt.config.credentials import (
         BigQueryProfile,
         DuckDBProfile,
+        MySQLProfile,
         PostgresProfile,
         RedshiftProfile,
     )
@@ -25,6 +26,7 @@ if TYPE_CHECKING:
     from drt.destinations.slack import SlackDestination
     from drt.sources.bigquery import BigQuerySource
     from drt.sources.duckdb import DuckDBSource
+    from drt.sources.mysql import MySQLSource
     from drt.sources.postgres import PostgresSource
     from drt.sources.redshift import RedshiftSource
 
@@ -255,16 +257,18 @@ def mcp_run() -> None:
 
 
 def _get_source(
-    profile: BigQueryProfile | DuckDBProfile | PostgresProfile | RedshiftProfile,
-) -> BigQuerySource | DuckDBSource | PostgresSource | RedshiftSource:
+    profile: BigQueryProfile | DuckDBProfile | MySQLProfile | PostgresProfile | RedshiftProfile,
+) -> BigQuerySource | DuckDBSource | MySQLSource | PostgresSource | RedshiftSource:
     from drt.config.credentials import (
         BigQueryProfile,
         DuckDBProfile,
+        MySQLProfile,
         PostgresProfile,
         RedshiftProfile,
     )
     from drt.sources.bigquery import BigQuerySource
     from drt.sources.duckdb import DuckDBSource
+    from drt.sources.mysql import MySQLSource
     from drt.sources.postgres import PostgresSource
 
     if isinstance(profile, BigQueryProfile):
@@ -273,6 +277,8 @@ def _get_source(
         return DuckDBSource()
     if isinstance(profile, PostgresProfile):
         return PostgresSource()
+    if isinstance(profile, MySQLProfile):
+        return MySQLSource()
     if isinstance(profile, RedshiftProfile):
         from drt.sources.redshift import RedshiftSource
 

--- a/drt/config/credentials.py
+++ b/drt/config/credentials.py
@@ -88,8 +88,30 @@ class RedshiftProfile:
     schema: str = "public"            # Redshift schema
 
 
+@dataclass
+class MySQLProfile:
+    """MySQL profile for extracting data from MySQL databases.
+
+    Example ~/.drt/profiles.yml:
+        mysql:
+          type: mysql
+          host: localhost
+          port: 3306
+          dbname: analytics
+          user: analyst
+          password_env: MYSQL_PASSWORD
+    """
+    type: Literal["mysql"]
+    host: str = "localhost"
+    port: int = 3306  # MySQL default port
+    dbname: str = ""
+    user: str = ""
+    password_env: str | None = None   # env var name
+    password: str | None = None       # explicit (non-recommended)
+
+
 # Union type — used throughout the codebase
-ProfileConfig = BigQueryProfile | DuckDBProfile | PostgresProfile | RedshiftProfile
+ProfileConfig = BigQueryProfile | DuckDBProfile | PostgresProfile | RedshiftProfile | MySQLProfile
 
 
 # ---------------------------------------------------------------------------
@@ -182,9 +204,20 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             schema=raw.get("schema", "public"),
         )
 
+    if source_type == "mysql":
+        return MySQLProfile(
+            type="mysql",
+            host=raw.get("host", "localhost"),
+            port=int(raw.get("port", 3306)),
+            dbname=raw.get("dbname", ""),
+            user=raw.get("user", ""),
+            password_env=raw.get("password_env"),
+            password=raw.get("password"),
+        )
+
     raise ValueError(
         f"Unsupported source type '{source_type}'. "
-        "Supported: bigquery, duckdb, postgres, redshift"
+        "Supported: bigquery, duckdb, postgres, redshift, mysql"
     )
 
 
@@ -232,6 +265,16 @@ def save_profile(
             "dbname": profile.dbname,
             "user": profile.user,
             "schema": profile.schema,
+        }
+        if profile.password_env:
+            entry["password_env"] = profile.password_env
+    elif isinstance(profile, MySQLProfile):
+        entry = {
+            "type": "mysql",
+            "host": profile.host,
+            "port": profile.port,
+            "dbname": profile.dbname,
+            "user": profile.user,
         }
         if profile.password_env:
             entry["password_env"] = profile.password_env

--- a/drt/engine/resolver.py
+++ b/drt/engine/resolver.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from drt.config.credentials import BigQueryProfile, DuckDBProfile, PostgresProfile, ProfileConfig
+from drt.config.credentials import BigQueryProfile, DuckDBProfile, MySQLProfile, PostgresProfile, ProfileConfig
 
 # Matches: ref('table') or ref("table")
 _REF_PATTERN = re.compile(r"""^ref\(\s*['"]([^'"]+)['"]\s*\)$""", re.IGNORECASE)
@@ -71,6 +71,8 @@ def resolve_model_ref(
             base_sql = f"SELECT * FROM {table_name}"
         elif isinstance(profile, PostgresProfile):
             base_sql = f'SELECT * FROM "{table_name}"'
+        elif isinstance(profile, MySQLProfile):
+            base_sql = f"SELECT * FROM `{table_name}`"
         else:
             base_sql = f"SELECT * FROM {table_name}"
     else:

--- a/drt/sources/mysql.py
+++ b/drt/sources/mysql.py
@@ -1,0 +1,66 @@
+"""MySQL source implementation.
+
+Requires: pip install drt-core[mysql]
+
+Example ~/.drt/profiles.yml:
+    mysql:
+      type: mysql
+      host: localhost
+      port: 3306
+      dbname: analytics
+      user: analyst
+      password_env: MYSQL_PASSWORD   # export MYSQL_PASSWORD=secret
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from typing import Any
+
+from drt.config.credentials import MySQLProfile, ProfileConfig
+
+
+class MySQLSource:
+    """Extract records from a MySQL database."""
+
+    def extract(self, query: str, config: ProfileConfig) -> Iterator[dict[str, Any]]:
+        assert isinstance(config, MySQLProfile)
+        conn = self._connect(config)
+        try:
+            cur = conn.cursor()
+            cur.execute(query)
+            columns = [desc[0] for desc in cur.description]
+            for row in cur.fetchall():
+                yield dict(zip(columns, row))
+        finally:
+            conn.close()
+
+    def test_connection(self, config: ProfileConfig) -> bool:
+        assert isinstance(config, MySQLProfile)
+        try:
+            conn = self._connect(config)
+            cur = conn.cursor()
+            cur.execute("SELECT 1")
+            conn.close()
+            return True
+        except Exception:
+            return False
+
+    def _connect(self, config: MySQLProfile) -> Any:
+        try:
+            import pymysql
+        except ImportError as e:
+            raise ImportError("MySQL support requires: pip install drt-core[mysql]") from e
+
+        password = config.password or (
+            os.environ.get(config.password_env) if config.password_env else None
+        )
+        return pymysql.connect(
+            host=config.host,
+            port=config.port,
+            database=config.dbname,
+            user=config.user,
+            password=password,
+            charset="utf8mb4",
+        )


### PR DESCRIPTION
## Summary

This PR adds a MySQL source connector to drt, addressing issue #19 (good first issue).

## Changes

- **drt/sources/mysql.py**: New MySQL source implementation using pymysql
- **drt/config/credentials.py**: Added MySQLProfile dataclass and updated ProfileConfig union type
- **drt/config/credentials.py**: Updated load_profile and save_profile functions to handle MySQL profiles
- **drt/engine/resolver.py**: Updated ref() resolution to use backtick quoting for MySQL tables
- **drt/cli/main.py**: Updated _get_source function to support MySQLProfile

## Example Configuration

```yaml
# ~/.drt/profiles.yml
mysql:
  type: mysql
  host: localhost
  port: 3306
  dbname: analytics
  user: analyst
  password_env: MYSQL_PASSWORD
```

## Testing

- Syntax check passed for all modified files
- Implementation follows existing patterns (PostgresSource, RedshiftSource)

## Installation

Users can install MySQL support with:
```bash
pip install drt-core[mysql]
```

Closes #19