### PR TITLE
feat: add LINE Notify destination connector

### DIFF
--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -191,6 +191,15 @@ class MySQLDestinationConfig(BaseModel):
         return self
 
 
+class LineNotifyDestinationConfig(BaseModel):
+    type: Literal["line_notify"]
+    token: str | None = None
+    token_env: str | None = None
+    # Jinja2 template for LINE Notify message.
+    # Example: "New user: {{ row.name }} ({{ row.email }})"
+    message_template: str = "{{ row }}"
+
+
 # Discriminated union — add new destination types here
 DestinationConfig = Annotated[
     RestApiDestinationConfig
@@ -200,7 +209,8 @@ DestinationConfig = Annotated[
     | HubSpotDestinationConfig
     | GoogleSheetsDestinationConfig
     | PostgresDestinationConfig
-    | MySQLDestinationConfig,
+    | MySQLDestinationConfig
+    | LineNotifyDestinationConfig,
     Field(discriminator="type"),
 ]
 

--- a/drt/destinations/line_notify.py
+++ b/drt/destinations/line_notify.py
@@ -1,0 +1,98 @@
+"""LINE Notify destination — https://notify-bot.line.me/
+
+Sends messages to LINE Notify via personal access token.
+Supports plain text messages via Jinja2 templates.
+
+No extra dependencies required (uses httpx from core).
+
+Example sync YAML:
+
+    destination:
+      type: line_notify
+      token_env: LINE_NOTIFY_TOKEN
+      message_template: "New signup: {{ row.name }} ({{ row.email }})"
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from drt.config.models import DestinationConfig, LineNotifyDestinationConfig, RetryConfig, SyncOptions
+from drt.destinations.base import SyncResult
+from drt.destinations.rate_limiter import RateLimiter
+from drt.destinations.retry import with_retry
+from drt.destinations.row_errors import RowError
+from drt.templates.renderer import render_template
+
+_DEFAULT_RETRY = RetryConfig(
+    max_attempts=3,
+    initial_backoff=1.0,
+    retryable_status_codes=(429, 500, 502, 503, 504),
+)
+
+_LINE_NOTIFY_API = "https://notify-api.line.me/api/notify"
+
+
+class LineNotifyDestination:
+    """Send records as LINE Notify messages via personal access token."""
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, LineNotifyDestinationConfig)
+        token = config.token or (
+            os.environ.get(config.token_env) if config.token_env else None
+        )
+        if not token:
+            raise ValueError(
+                "LINE Notify destination: provide 'token' or set 'token_env'."
+            )
+
+        result = SyncResult()
+        rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
+
+        with httpx.Client(timeout=30.0) as client:
+            for i, record in enumerate(records):
+                rate_limiter.acquire()
+                try:
+                    rendered = render_template(config.message_template, record)
+
+                    def do_post() -> httpx.Response:
+                        response = client.post(
+                            _LINE_NOTIFY_API,
+                            data={"message": rendered},
+                            headers={"Authorization": f"Bearer {token}"},
+                        )
+                        response.raise_for_status()
+                        return response
+
+                    with_retry(do_post, _DEFAULT_RETRY)
+                    result.success += 1
+                except httpx.HTTPStatusError as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=str(record)[:200],
+                            http_status=e.response.status_code,
+                            error_message=e.response.text[:500],
+                        )
+                    )
+                except Exception as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=str(record)[:200],
+                            http_status=None,
+                            error_message=str(e),
+                        )
+                    )
+
+        return result

--- a/tests/unit/test_line_notify.py
+++ b/tests/unit/test_line_notify.py
@@ -1,0 +1,161 @@
+"""Unit tests for LineNotifyDestination — httpx mocked via unittest.mock."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from drt.config.models import (
+    LineNotifyDestinationConfig,
+    RateLimitConfig,
+    RetryConfig,
+    SyncOptions,
+)
+from drt.destinations.base import SyncResult
+from drt.destinations.line_notify import LineNotifyDestination, _LINE_NOTIFY_API
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sync_options(max_attempts: int = 1) -> SyncOptions:
+    return SyncOptions(
+        batch_size=10,
+        rate_limit=RateLimitConfig(requests_per_second=1000),
+        retry=RetryConfig(
+            max_attempts=max_attempts, initial_backoff=0.0, backoff_multiplier=1.0
+        ),
+        on_error="skip",
+    )
+
+
+def _dest_config(
+    token: str = "test_token", token_env: str | None = None
+) -> LineNotifyDestinationConfig:
+    return LineNotifyDestinationConfig(
+        type="line_notify",
+        token=token,
+        token_env=token_env,
+        message_template="{{ row.name }}: {{ row.email }}",
+    )
+
+
+def _make_response(status_code: int, json: dict | None = None) -> httpx.Response:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.text = ""
+    if json:
+        import json as _json
+
+        response._content = _json.dumps(json).encode()
+    if status_code >= 400:
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            message=f"HTTP {status_code}",
+            request=MagicMock(),
+            response=response,
+        )
+    else:
+        response.raise_for_status.return_value = None
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Success cases
+# ---------------------------------------------------------------------------
+
+
+class TestLineNotifyDestinationSuccess:
+    def test_all_records_succeed(self) -> None:
+        records = [{"name": "Alice", "email": "alice@example.com"}]
+        config = _dest_config(token="my_token")
+        options = _sync_options()
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = _make_response(200, {"status": 200})
+
+            dest = LineNotifyDestination()
+            result = dest.load(records, config, options)
+
+        assert result.success == 1
+        assert result.failed == 0
+        assert result.row_errors == []
+        mock_client.post.assert_called_once()
+        call_kwargs = mock_client.post.call_args
+        assert call_kwargs.kwargs["headers"]["Authorization"] == "Bearer my_token"
+        assert call_kwargs.kwargs["data"]["message"] == "Alice: alice@example.com"
+
+    def test_token_from_env(self) -> None:
+        records = [{"name": "Bob", "email": "bob@example.com"}]
+        config = LineNotifyDestinationConfig(
+            type="line_notify",
+            token_env="LINE_NOTIFY_TOKEN",
+            message_template="{{ row.name }}: {{ row.email }}",
+        )
+        options = _sync_options()
+
+        with patch.dict("os.environ", {"LINE_NOTIFY_TOKEN": "env_token"}):
+            with patch("httpx.Client") as mock_client_cls:
+                mock_client = MagicMock()
+                mock_client_cls.return_value.__enter__.return_value = mock_client
+                mock_client.post.return_value = _make_response(200, {"status": 200})
+
+                dest = LineNotifyDestination()
+                result = dest.load(records, config, options)
+
+        assert result.success == 1
+        assert (
+            mock_client.post.call_args.kwargs["headers"]["Authorization"]
+            == "Bearer env_token"
+        )
+
+
+class TestLineNotifyDestinationFailure:
+    def test_http_error_marks_record_failed(self) -> None:
+        records = [{"name": "Carol", "email": "carol@example.com"}]
+        config = _dest_config(token="bad_token")
+        options = _sync_options()
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = _make_response(401, {"status": 401, "message": "Invalid token"})
+
+            dest = LineNotifyDestination()
+            result = dest.load(records, config, options)
+
+        assert result.success == 0
+        assert result.failed == 1
+        assert len(result.row_errors) == 1
+        assert result.row_errors[0].http_status == 401
+
+    def test_missing_token_raises_value_error(self) -> None:
+        records = [{"name": "Dave", "email": "dave@example.com"}]
+        config = LineNotifyDestinationConfig(type="line_notify", token=None, token_env=None)
+        options = _sync_options()
+
+        dest = LineNotifyDestination()
+        try:
+            dest.load(records, config, options)
+            assert False, "Expected ValueError"
+        except ValueError as e:
+            assert "token" in str(e).lower()
+
+    def test_default_message_template(self) -> None:
+        records = [{"id": 1, "value": "test"}]
+        config = LineNotifyDestinationConfig(type="line_notify", token="tok")
+        options = _sync_options()
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = _make_response(200, {"status": 200})
+
+            dest = LineNotifyDestination()
+            result = dest.load(records, config, options)
+
+        assert result.success == 1
+        assert mock_client.post.call_args.kwargs["data"]["message"] == "{'id': 1, 'value': 'test'}"


### PR DESCRIPTION
## Summary
Add a LINE Notify destination connector following the existing Slack webhook pattern.

LINE Notify accepts simple POST requests with a Bearer token, making it structurally identical to the Slack destination. Great for Japanese users and AI agent notification workflows.

## Changes

### New file: `drt/destinations/line_notify.py`
- `LineNotifyDestination` class — sends Jinja2-templated messages to LINE Notify API
- POST to `https://notify-api.line.me/api/notify` with Bearer auth header
- Supports `token` config or `token_env` (LINE_NOTIFY_TOKEN)
- Full retry logic and rate limiting via existing infrastructure

### Modified: `drt/config/models.py`
- Added `LineNotifyDestinationConfig` Pydantic model
- Registered in the `DestinationConfig` discriminated union

### New file: `tests/unit/test_line_notify.py`
- 5 unit tests: success, token from env, HTTP error, missing token validation, default template

## Example usage

```yaml
destination:
  type: line_notify
  token_env: LINE_NOTIFY_TOKEN
  message_template: "New signup: {{ row.name }} ({{ row.email }})"
```

## Motivation
Fixes #87 (good first issue). LINE Notify is widely used in Japan for simple notifications and the API surface is minimal — a great first contribution.

Closes #87
