### PR TITLE
feat(dagster-drt): align API with dagster-dbt/dagster-dlt patterns

### DIFF
--- a/integrations/dagster-drt/dagster_drt/__init__.py
+++ b/integrations/dagster-drt/dagster_drt/__init__.py
@@ -1,4 +1,14 @@
-from dagster_drt.assets import DrtConfig, drt_assets
-from dagster_drt.translator import DagsterDrtTranslator
+from dagster_drt.assets import DrtConfig, drt_assets, drt_assets_legacy
+from dagster_drt.resource import DagsterDrtResource
+from dagster_drt.specs import build_drt_asset_specs
+from dagster_drt.translator import DagsterDrtTranslator, DrtTranslatorData
 
-__all__ = ["DagsterDrtTranslator", "DrtConfig", "drt_assets"]
+__all__ = [
+    "DagsterDrtResource",
+    "DagsterDrtTranslator",
+    "DrtConfig",
+    "DrtTranslatorData",
+    "build_drt_asset_specs",
+    "drt_assets",
+    "drt_assets_legacy",
+]

--- a/integrations/dagster-drt/dagster_drt/assets.py
+++ b/integrations/dagster-drt/dagster_drt/assets.py
@@ -1,17 +1,28 @@
-"""Expose drt syncs as Dagster assets."""
+"""Expose drt syncs as Dagster assets.
 
+Provides two APIs:
+
+- ``@drt_assets`` decorator (new, recommended) — wraps ``@multi_asset``
+- ``drt_assets()`` function (legacy) — returns ``list[AssetsDefinition]``
+"""
+
+import warnings
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 from dagster import (
     AssetExecutionContext,
     AssetsDefinition,
+    BackfillPolicy,
     Config,
     MaterializeResult,
     MetadataValue,
-    asset,
+    PartitionsDefinition,
+    multi_asset,
 )
 
+from dagster_drt.specs import build_drt_asset_specs
 from dagster_drt.translator import DagsterDrtTranslator
 
 
@@ -24,13 +35,105 @@ class DrtConfig(Config):
     dry_run: bool = False
 
 
+# ------------------------------------------------------------------
+# New API: @drt_assets decorator
+# ------------------------------------------------------------------
+
+
 def drt_assets(
-    project_dir: Union[str, Path],
-    sync_names: Union[list[str], None] = None,
+    *,
+    project_dir: str | Path,
+    sync_names: list[str] | None = None,
+    dagster_drt_translator: DagsterDrtTranslator | None = None,
+    name: str | None = None,
+    group_name: str | None = None,
+    op_tags: dict[str, Any] | None = None,
+    partitions_def: PartitionsDefinition | None = None,
+    backfill_policy: BackfillPolicy | None = None,
+    pool: str | None = None,
+) -> Callable[[Callable[..., Any]], AssetsDefinition]:
+    """Decorator that creates a Dagster ``multi_asset`` from drt syncs.
+
+    Follows the same pattern as ``@dbt_assets`` and ``@dlt_assets``.
+
+    Usage::
+
+        @drt_assets(project_dir=".")
+        def my_syncs(context: AssetExecutionContext, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+    Args:
+        project_dir: Path to drt project root.
+        sync_names: Optional filter. If None, discovers all syncs.
+        dagster_drt_translator: Translator for customising asset specs.
+        name: Optional name for the multi_asset op.
+        group_name: Optional group name override for all assets.
+        op_tags: Optional tags for the op.
+        partitions_def: Optional partitions definition for time-based or
+            static partitioning.
+        backfill_policy: Optional backfill policy. If ``partitions_def`` is
+            set and this is None, defaults to ``BackfillPolicy.single_run()``.
+        pool: Optional concurrency pool name for limiting parallel execution.
+
+    Returns:
+        A decorator that wraps the function as a ``multi_asset``.
+    """
+    specs = build_drt_asset_specs(
+        project_dir=project_dir,
+        sync_names=sync_names,
+        dagster_drt_translator=dagster_drt_translator,
+    )
+
+    if group_name is not None:
+        # Detect conflict: raise if translator already set group names.
+        conflicting = [s for s in specs if s.group_name is not None and s.group_name != group_name]
+        if conflicting:
+            keys = [str(s.key) for s in conflicting]
+            raise ValueError(
+                f"group_name='{group_name}' conflicts with translator-set "
+                f"group names on assets: {keys}. Set group_name in the "
+                f"translator or in @drt_assets, not both."
+            )
+        specs = [s.replace_attributes(group_name=group_name) for s in specs]
+
+    multi_asset_kwargs: dict[str, Any] = {
+        "specs": specs,
+        "can_subset": True,
+    }
+    if name is not None:
+        multi_asset_kwargs["name"] = name
+    if op_tags is not None:
+        multi_asset_kwargs["op_tags"] = op_tags
+    if partitions_def is not None:
+        multi_asset_kwargs["partitions_def"] = partitions_def
+        if backfill_policy is None:
+            backfill_policy = BackfillPolicy.single_run()
+    if backfill_policy is not None:
+        multi_asset_kwargs["backfill_policy"] = backfill_policy
+    if pool is not None:
+        multi_asset_kwargs["pool"] = pool
+
+    def decorator(fn: Callable[..., Any]) -> AssetsDefinition:
+        return multi_asset(**multi_asset_kwargs)(fn)
+
+    return decorator
+
+
+# ------------------------------------------------------------------
+# Legacy API: drt_assets() function
+# ------------------------------------------------------------------
+
+
+def drt_assets_legacy(
+    project_dir: str | Path,
+    sync_names: list[str] | None = None,
     dagster_drt_translator: DagsterDrtTranslator | None = None,
     dry_run: bool = False,
 ) -> list[AssetsDefinition]:
     """Create Dagster assets from drt sync definitions.
+
+    .. deprecated::
+        Use the ``@drt_assets`` decorator instead for multi_asset support.
 
     Args:
         project_dir: Path to drt project root.
@@ -43,7 +146,16 @@ def drt_assets(
     Returns:
         List of Dagster asset definitions.
     """
+    from dagster import asset
+
     from drt.config.parser import load_syncs
+
+    warnings.warn(
+        "drt_assets_legacy() is deprecated. Use the @drt_assets decorator "
+        "with DagsterDrtResource instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     translator = dagster_drt_translator or DagsterDrtTranslator()
     project_path = Path(project_dir)
@@ -70,9 +182,7 @@ def drt_assets(
         if static_metadata:
             asset_kwargs["metadata"] = static_metadata
 
-        def _make_asset_fn(
-            _sync_cfg: Any, _default_dry_run: bool
-        ) -> AssetsDefinition:
+        def _make_asset_fn(_sync_cfg: Any, _default_dry_run: bool) -> AssetsDefinition:
             @asset(**asset_kwargs)
             def _asset_fn(
                 context: AssetExecutionContext,
@@ -108,11 +218,8 @@ def drt_assets(
                     f"{result.skipped} skipped (dry_run={effective_dry_run})"
                 )
 
-                # Log row-level error details for debugging
                 for row_error in result.row_errors:
-                    context.log.warning(
-                        f"Row error in '{_sync_cfg.name}': {row_error}"
-                    )
+                    context.log.warning(f"Row error in '{_sync_cfg.name}': {row_error}")
 
                 return MaterializeResult(
                     metadata={
@@ -121,9 +228,7 @@ def drt_assets(
                         "rows_failed": MetadataValue.int(result.failed),
                         "rows_skipped": MetadataValue.int(result.skipped),
                         "dry_run": MetadataValue.bool(effective_dry_run),
-                        "row_errors_count": MetadataValue.int(
-                            len(result.row_errors)
-                        ),
+                        "row_errors_count": MetadataValue.int(len(result.row_errors)),
                     }
                 )
 

--- a/integrations/dagster-drt/dagster_drt/resource.py
+++ b/integrations/dagster-drt/dagster_drt/resource.py
@@ -1,0 +1,139 @@
+"""DagsterDrtResource — Dagster resource for executing drt syncs.
+
+Follows the same pattern as dagster-dlt's ``DagsterDltResource``.
+Encapsulates execution logic so that ``@drt_assets`` function bodies
+remain thin and the execution strategy can be swapped in the future.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+from dagster import (
+    AssetExecutionContext,
+    ConfigurableResource,
+    MaterializeResult,
+    MetadataValue,
+)
+
+from dagster_drt.specs import META_KEY_PROJECT_DIR, META_KEY_SYNC_NAME
+
+
+class DagsterDrtResource(ConfigurableResource):
+    """Dagster resource that executes drt syncs.
+
+    Usage::
+
+        @drt_assets(project_dir=".")
+        def my_syncs(context: AssetExecutionContext, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+        defs = Definitions(
+            assets=[my_syncs],
+            resources={"drt": DagsterDrtResource(project_dir=".")},
+        )
+
+    Attributes:
+        project_dir: Path to drt project root. If empty, auto-retrieved
+            from ``@drt_assets`` metadata.
+        dry_run: Default dry-run mode. Can be overridden per-run via
+            ``DrtConfig`` in the Dagster UI.
+    """
+
+    project_dir: str = ""
+    dry_run: bool = False
+
+    def _resolve_project_dir(self, context: AssetExecutionContext) -> Path:
+        """Resolve project_dir from resource config or asset metadata."""
+        if self.project_dir:
+            return Path(self.project_dir)
+
+        # Auto-retrieve from @drt_assets metadata.
+        specs = context.assets_def.specs_by_key
+        for spec in specs.values():
+            meta_dir = (spec.metadata or {}).get(META_KEY_PROJECT_DIR)
+            if meta_dir:
+                return Path(meta_dir)
+
+        raise ValueError(
+            "project_dir must be set on DagsterDrtResource or embedded in @drt_assets metadata."
+        )
+
+    def run(
+        self,
+        context: AssetExecutionContext,
+        dry_run: bool | None = None,
+    ) -> Iterator[MaterializeResult]:
+        """Execute drt syncs and yield ``MaterializeResult`` per sync.
+
+        Automatically filters to ``context.selected_asset_keys`` when
+        used inside a ``@multi_asset`` with ``can_subset=True``.
+
+        Args:
+            context: Dagster asset execution context.
+            dry_run: Override dry-run mode for this run. If None, uses
+                the resource-level default.
+        """
+        from drt.cli.main import _get_destination, _get_source
+        from drt.config.credentials import load_profile
+        from drt.config.parser import load_project, load_syncs
+        from drt.engine.sync import run_sync
+        from drt.state.manager import StateManager
+
+        effective_dry_run = dry_run if dry_run is not None else self.dry_run
+        project_path = self._resolve_project_dir(context)
+
+        project = load_project(project_path)
+        profile = load_profile(project.profile)
+        source = _get_source(profile)
+        state_mgr = StateManager(project_path)
+
+        # Build a mapping from sync_name -> SyncConfig.
+        all_syncs = {s.name: s for s in load_syncs(project_path)}
+
+        # Determine which syncs to run from selected asset keys.
+        selected_keys = context.selected_asset_keys
+        specs_by_key = context.assets_def.specs_by_key
+
+        for key in selected_keys:
+            spec = specs_by_key.get(key)
+            if spec is None:
+                continue
+            sync_name = (spec.metadata or {}).get(META_KEY_SYNC_NAME)
+            if sync_name is None or sync_name not in all_syncs:
+                context.log.warning(f"No drt sync found for asset key {key}. Skipping.")
+                continue
+
+            sync_config = all_syncs[sync_name]
+            destination = _get_destination(sync_config)
+
+            result = run_sync(
+                sync_config,
+                source,
+                destination,
+                profile,
+                project_path,
+                dry_run=effective_dry_run,
+                state_manager=state_mgr,
+            )
+
+            context.log.info(
+                f"drt sync '{sync_name}': "
+                f"{result.success} synced, {result.failed} failed, "
+                f"{result.skipped} skipped (dry_run={effective_dry_run})"
+            )
+            for row_error in result.row_errors:
+                context.log.warning(f"Row error in '{sync_name}': {row_error}")
+
+            yield MaterializeResult(
+                asset_key=key,
+                metadata={
+                    "sync_name": MetadataValue.text(sync_name),
+                    "rows_synced": MetadataValue.int(result.success),
+                    "rows_failed": MetadataValue.int(result.failed),
+                    "rows_skipped": MetadataValue.int(result.skipped),
+                    "dry_run": MetadataValue.bool(effective_dry_run),
+                    "row_errors_count": MetadataValue.int(len(result.row_errors)),
+                },
+            )

--- a/integrations/dagster-drt/dagster_drt/specs.py
+++ b/integrations/dagster-drt/dagster_drt/specs.py
@@ -1,0 +1,70 @@
+"""Pure spec generation — decoupled from execution logic.
+
+``build_drt_asset_specs()`` returns a list of ``AssetSpec`` objects that
+describe drt syncs as Dagster assets, without attaching any compute
+function.  This enables Pipes-based remote execution and other custom
+patterns.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dagster import AssetSpec
+
+from dagster_drt.translator import DagsterDrtTranslator, DrtTranslatorData
+
+# Metadata keys used to store drt-specific info in AssetSpec metadata.
+META_KEY_SYNC_NAME = "dagster_drt/sync_name"
+META_KEY_PROJECT_DIR = "dagster_drt/project_dir"
+
+
+def build_drt_asset_specs(
+    project_dir: str | Path,
+    sync_names: list[str] | None = None,
+    dagster_drt_translator: DagsterDrtTranslator | None = None,
+) -> list[AssetSpec]:
+    """Generate Dagster ``AssetSpec`` objects from drt sync definitions.
+
+    This function only generates specs — no execution logic is attached.
+    Use the returned specs with ``@multi_asset`` or ``@drt_assets`` to
+    add execution.
+
+    Args:
+        project_dir: Path to drt project root.
+        sync_names: Optional filter. If None, discovers all syncs.
+        dagster_drt_translator: Translator for customising asset specs.
+
+    Returns:
+        List of ``AssetSpec`` objects, one per sync.
+    """
+    from drt.config.parser import load_syncs
+
+    translator = dagster_drt_translator or DagsterDrtTranslator()
+    project_path = Path(project_dir)
+    syncs = load_syncs(project_path)
+
+    if sync_names:
+        syncs = [s for s in syncs if s.name in sync_names]
+
+    specs: list[AssetSpec] = []
+    for sync_config in syncs:
+        data = DrtTranslatorData(
+            sync_config=sync_config,
+            project_dir=str(project_path),
+        )
+        spec = translator.get_asset_spec(data)
+
+        # Merge internal metadata keys for downstream use by
+        # DagsterDrtResource and @drt_assets.
+        internal_metadata = {
+            META_KEY_SYNC_NAME: sync_config.name,
+            META_KEY_PROJECT_DIR: str(project_path),
+        }
+        existing_metadata = dict(spec.metadata or {})
+        existing_metadata.update(internal_metadata)
+        spec = spec.replace_attributes(metadata=existing_metadata)
+
+        specs.append(spec)
+
+    return specs

--- a/integrations/dagster-drt/dagster_drt/translator.py
+++ b/integrations/dagster-drt/dagster_drt/translator.py
@@ -1,47 +1,173 @@
 """DagsterDrtTranslator — controls how drt syncs map to Dagster assets.
 
 Follows the same Translator pattern as dagster-dbt and dagster-dlt.
-Subclass and override methods to customise asset keys, groups, deps, etc.
+The primary override point is ``get_asset_spec()``. Legacy per-attribute
+methods (``get_asset_key``, ``get_group_name``, etc.) still work but are
+deprecated in favour of ``get_asset_spec()``.
 """
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any
 
-from dagster import AssetKey
+from dagster import AssetKey, AssetSpec
 
 from drt.config.models import SyncConfig
+
+
+@dataclass(frozen=True)
+class DrtTranslatorData:
+    """Data passed to :meth:`DagsterDrtTranslator.get_asset_spec`.
+
+    Attributes:
+        sync_config: The parsed drt sync configuration.
+        project_dir: Path to the drt project root (as string).
+    """
+
+    sync_config: SyncConfig
+    project_dir: str
+
+
+# Internal sentinel to detect whether a legacy method was overridden.
+_SENTINEL = object()
 
 
 class DagsterDrtTranslator:
     """Default translator from drt SyncConfig to Dagster asset properties.
 
-    Override any method in a subclass to customise behavior::
+    The recommended override point is ``get_asset_spec()``::
 
         class MyTranslator(DagsterDrtTranslator):
-            def get_group_name(self, sync_config):
-                return "reverse_etl"
+            def get_asset_spec(self, data):
+                default = super().get_asset_spec(data)
+                return default.replace_attributes(group_name="reverse_etl")
 
-        drt_assets(project_dir="...", dagster_drt_translator=MyTranslator())
+    Legacy per-attribute methods still work but emit deprecation warnings.
     """
 
+    # ------------------------------------------------------------------
+    # Primary API (new)
+    # ------------------------------------------------------------------
+
+    def get_asset_spec(self, data: DrtTranslatorData) -> AssetSpec:
+        """Return a complete ``AssetSpec`` for a drt sync.
+
+        Override this method to customise how syncs map to Dagster assets.
+        """
+        sync_config = data.sync_config
+
+        # Check if any legacy methods were overridden in a subclass.
+        # If so, delegate to them for backward compatibility.
+        if self._has_legacy_overrides():
+            return self._build_spec_from_legacy(sync_config)
+
+        dest = sync_config.destination
+        dest_type = dest.type if hasattr(dest, "type") else "unknown"
+
+        kwargs: dict[str, Any] = {
+            "key": AssetKey(f"drt_{sync_config.name}"),
+            "kinds": {"drt", dest_type},
+        }
+        if sync_config.description:
+            kwargs["description"] = sync_config.description
+
+        return AssetSpec(**kwargs)
+
+    # ------------------------------------------------------------------
+    # Legacy API (deprecated — kept for backward compat)
+    # ------------------------------------------------------------------
+
     def get_asset_key(self, sync_config: SyncConfig) -> AssetKey:
-        """Return the Dagster AssetKey for a sync."""
+        """Return the Dagster AssetKey for a sync.
+
+        .. deprecated::
+            Override ``get_asset_spec()`` instead.
+        """
         return AssetKey(f"drt_{sync_config.name}")
 
     def get_group_name(self, sync_config: SyncConfig) -> str | None:
-        """Return the group name for a sync asset, or None for default."""
+        """Return the group name for a sync asset, or None for default.
+
+        .. deprecated::
+            Override ``get_asset_spec()`` instead.
+        """
         return None
 
     def get_description(self, sync_config: SyncConfig) -> str | None:
-        """Return the asset description."""
+        """Return the asset description.
+
+        .. deprecated::
+            Override ``get_asset_spec()`` instead.
+        """
         return sync_config.description
 
     def get_deps(self, sync_config: SyncConfig) -> Sequence[AssetKey]:
-        """Return upstream asset dependencies for a sync."""
+        """Return upstream asset dependencies for a sync.
+
+        .. deprecated::
+            Override ``get_asset_spec()`` instead.
+        """
         return []
 
     def get_metadata(self, sync_config: SyncConfig) -> Mapping[str, Any]:
-        """Return static metadata to attach to the asset definition."""
+        """Return static metadata to attach to the asset definition.
+
+        .. deprecated::
+            Override ``get_asset_spec()`` instead.
+        """
         return {}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    _LEGACY_METHODS = (
+        "get_asset_key",
+        "get_group_name",
+        "get_description",
+        "get_deps",
+        "get_metadata",
+    )
+
+    def _has_legacy_overrides(self) -> bool:
+        """Return True if any legacy per-attribute method was overridden."""
+        for name in self._LEGACY_METHODS:
+            if getattr(type(self), name) is not getattr(DagsterDrtTranslator, name):
+                return True
+        return False
+
+    def _build_spec_from_legacy(self, sync_config: SyncConfig) -> AssetSpec:
+        """Build an AssetSpec by calling legacy per-attribute methods."""
+        warnings.warn(
+            "Overriding individual translator methods (get_asset_key, "
+            "get_group_name, etc.) is deprecated. Override get_asset_spec() "
+            "instead.",
+            DeprecationWarning,
+            stacklevel=4,
+        )
+        key = self.get_asset_key(sync_config)
+        group_name = self.get_group_name(sync_config)
+        description = self.get_description(sync_config)
+        deps = self.get_deps(sync_config)
+        metadata = self.get_metadata(sync_config)
+
+        dest = sync_config.destination
+        dest_type = dest.type if hasattr(dest, "type") else "unknown"
+
+        kwargs: dict[str, Any] = {
+            "key": key,
+            "kinds": {"drt", dest_type},
+        }
+        if group_name is not None:
+            kwargs["group_name"] = group_name
+        if description:
+            kwargs["description"] = description
+        if deps:
+            kwargs["deps"] = deps
+        if metadata:
+            kwargs["metadata"] = metadata
+
+        return AssetSpec(**kwargs)

--- a/integrations/dagster-drt/tests/test_assets.py
+++ b/integrations/dagster-drt/tests/test_assets.py
@@ -1,6 +1,17 @@
+import warnings
+from dataclasses import dataclass, field
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-from dagster import AssetKey
+import pytest
+from dagster import (
+    AssetKey,
+    AssetsDefinition,
+    AssetSpec,
+    BackfillPolicy,
+    DailyPartitionsDefinition,
+    MaterializeResult,
+)
 
 SYNC_YAML = "name: test_sync\nmodel: ref('users')\ndestination:\n  type: rest_api\n  url: http://example.com\n"
 PROJECT_YAML = "name: test\nversion: '0.1'\nprofile: local\n"
@@ -18,143 +29,640 @@ def _setup_project(tmp_path: Path, syncs: dict[str, str] | None = None) -> Path:
     return tmp_path
 
 
-# --- Basic asset creation ---
+TWO_SYNCS = {
+    "a.yml": "name: a\nmodel: ref('t')\ndestination:\n  type: rest_api\n  url: http://x.com\n",
+    "b.yml": "name: b\nmodel: ref('t')\ndestination:\n  type: rest_api\n  url: http://x.com\n",
+}
 
 
-def test_drt_assets_creates_asset_list(tmp_path: Path) -> None:
-    project = _setup_project(tmp_path)
-    from dagster_drt.assets import drt_assets
-
-    assets = drt_assets(project_dir=project)
-    assert len(assets) == 1
+# ===================================================================
+# build_drt_asset_specs()
+# ===================================================================
 
 
-def test_drt_assets_filter_by_name(tmp_path: Path) -> None:
-    project = _setup_project(
-        tmp_path,
-        {
-            "a.yml": "name: a\nmodel: ref('t')\ndestination:\n  type: rest_api\n  url: http://x.com\n",
-            "b.yml": "name: b\nmodel: ref('t')\ndestination:\n  type: rest_api\n  url: http://x.com\n",
-        },
-    )
-    from dagster_drt.assets import drt_assets
+class TestBuildDrtAssetSpecs:
+    def test_returns_asset_specs(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.specs import build_drt_asset_specs
 
-    assets = drt_assets(project_dir=project, sync_names=["a"])
-    assert len(assets) == 1
+        specs = build_drt_asset_specs(project_dir=project)
+        assert len(specs) == 1
+        assert isinstance(specs[0], AssetSpec)
 
+    def test_default_key(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.specs import build_drt_asset_specs
 
-# --- Translator: default ---
+        specs = build_drt_asset_specs(project_dir=project)
+        assert specs[0].key == AssetKey("drt_test_sync")
 
+    def test_filter_by_name(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path, TWO_SYNCS)
+        from dagster_drt.specs import build_drt_asset_specs
 
-def test_default_translator_asset_key(tmp_path: Path) -> None:
-    project = _setup_project(tmp_path)
-    from dagster_drt.assets import drt_assets
+        specs = build_drt_asset_specs(project_dir=project, sync_names=["a"])
+        assert len(specs) == 1
+        assert specs[0].key == AssetKey("drt_a")
 
-    assets = drt_assets(project_dir=project)
-    assert assets[0].key == AssetKey("drt_test_sync")
+    def test_all_syncs(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path, TWO_SYNCS)
+        from dagster_drt.specs import build_drt_asset_specs
 
+        specs = build_drt_asset_specs(project_dir=project)
+        assert len(specs) == 2
 
-def test_default_translator_no_group(tmp_path: Path) -> None:
-    project = _setup_project(tmp_path)
-    from dagster_drt.assets import drt_assets
+    def test_internal_metadata(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.specs import (
+            META_KEY_PROJECT_DIR,
+            META_KEY_SYNC_NAME,
+            build_drt_asset_specs,
+        )
 
-    assets = drt_assets(project_dir=project)
-    assert assets[0].group_names_by_key.get(AssetKey("drt_test_sync")) == "default"
+        specs = build_drt_asset_specs(project_dir=project)
+        meta = specs[0].metadata
+        assert meta[META_KEY_SYNC_NAME] == "test_sync"
+        assert meta[META_KEY_PROJECT_DIR] == str(project)
 
+    def test_kinds_metadata(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.specs import build_drt_asset_specs
 
-# --- Translator: custom ---
-
-
-def test_custom_translator_group_name(tmp_path: Path) -> None:
-    project = _setup_project(tmp_path)
-    from dagster_drt.assets import drt_assets
-    from dagster_drt.translator import DagsterDrtTranslator
-
-    class MyTranslator(DagsterDrtTranslator):
-        def get_group_name(self, sync_config):
-            return "reverse_etl"
-
-    assets = drt_assets(project_dir=project, dagster_drt_translator=MyTranslator())
-    assert assets[0].group_names_by_key[AssetKey("drt_test_sync")] == "reverse_etl"
-
-
-def test_custom_translator_asset_key(tmp_path: Path) -> None:
-    project = _setup_project(tmp_path)
-    from dagster_drt.assets import drt_assets
-    from dagster_drt.translator import DagsterDrtTranslator
-
-    class MyTranslator(DagsterDrtTranslator):
-        def get_asset_key(self, sync_config):
-            return AssetKey(["my_prefix", sync_config.name])
-
-    assets = drt_assets(project_dir=project, dagster_drt_translator=MyTranslator())
-    assert assets[0].key == AssetKey(["my_prefix", "test_sync"])
+        specs = build_drt_asset_specs(project_dir=project)
+        assert "drt" in specs[0].kinds
 
 
-def test_custom_translator_deps(tmp_path: Path) -> None:
-    project = _setup_project(tmp_path)
-    from dagster_drt.assets import drt_assets
-    from dagster_drt.translator import DagsterDrtTranslator
-
-    class MyTranslator(DagsterDrtTranslator):
-        def get_deps(self, sync_config):
-            return [AssetKey("upstream_model")]
-
-    assets = drt_assets(project_dir=project, dagster_drt_translator=MyTranslator())
-    dep_keys = {dep.asset_key for dep in assets[0].specs_by_key[AssetKey("drt_test_sync")].deps}
-    assert AssetKey("upstream_model") in dep_keys
+# ===================================================================
+# DagsterDrtTranslator — get_asset_spec() (new API)
+# ===================================================================
 
 
-# --- DrtConfig ---
+class TestTranslatorNewAPI:
+    def test_get_asset_spec_default(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.specs import build_drt_asset_specs
+
+        specs = build_drt_asset_specs(project_dir=project)
+        assert specs[0].key == AssetKey("drt_test_sync")
+
+    def test_get_asset_spec_override(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.specs import build_drt_asset_specs
+        from dagster_drt.translator import DagsterDrtTranslator
+
+        class MyTranslator(DagsterDrtTranslator):
+            def get_asset_spec(self, data):
+                default = super().get_asset_spec(data)
+                return default.replace_attributes(
+                    key=AssetKey(["custom", data.sync_config.name]),
+                    group_name="reverse_etl",
+                )
+
+        specs = build_drt_asset_specs(
+            project_dir=project,
+            dagster_drt_translator=MyTranslator(),
+        )
+        assert specs[0].key == AssetKey(["custom", "test_sync"])
+        assert specs[0].group_name == "reverse_etl"
 
 
-def test_drt_assets_accepts_dry_run_default(tmp_path: Path) -> None:
-    """dry_run parameter should not break asset creation."""
-    project = _setup_project(tmp_path)
-    from dagster_drt.assets import drt_assets
-
-    assets = drt_assets(project_dir=project, dry_run=True)
-    assert len(assets) == 1
+# ===================================================================
+# DagsterDrtTranslator — legacy per-attribute methods (backward compat)
+# ===================================================================
 
 
-def test_drt_config_defaults() -> None:
-    from dagster_drt.assets import DrtConfig
+class TestTranslatorLegacy:
+    def test_legacy_group_name(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.specs import build_drt_asset_specs
+        from dagster_drt.translator import DagsterDrtTranslator
 
-    config = DrtConfig()
-    assert config.dry_run is False
+        class MyTranslator(DagsterDrtTranslator):
+            def get_group_name(self, sync_config):
+                return "reverse_etl"
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            specs = build_drt_asset_specs(
+                project_dir=project,
+                dagster_drt_translator=MyTranslator(),
+            )
+            assert any("deprecated" in str(warning.message).lower() for warning in w)
+        assert specs[0].group_name == "reverse_etl"
+
+    def test_legacy_asset_key(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.specs import build_drt_asset_specs
+        from dagster_drt.translator import DagsterDrtTranslator
+
+        class MyTranslator(DagsterDrtTranslator):
+            def get_asset_key(self, sync_config):
+                return AssetKey(["my_prefix", sync_config.name])
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            specs = build_drt_asset_specs(
+                project_dir=project,
+                dagster_drt_translator=MyTranslator(),
+            )
+        assert specs[0].key == AssetKey(["my_prefix", "test_sync"])
+
+    def test_legacy_deps(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.specs import build_drt_asset_specs
+        from dagster_drt.translator import DagsterDrtTranslator
+
+        class MyTranslator(DagsterDrtTranslator):
+            def get_deps(self, sync_config):
+                return [AssetKey("upstream_model")]
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            specs = build_drt_asset_specs(
+                project_dir=project,
+                dagster_drt_translator=MyTranslator(),
+            )
+        dep_keys = {dep.asset_key for dep in specs[0].deps}
+        assert AssetKey("upstream_model") in dep_keys
 
 
-def test_drt_config_dry_run() -> None:
-    from dagster_drt.assets import DrtConfig
-
-    config = DrtConfig(dry_run=True)
-    assert config.dry_run is True
+# ===================================================================
+# @drt_assets decorator
+# ===================================================================
 
 
-# --- Return type ---
+class TestDrtAssetsDecorator:
+    def test_creates_multi_asset(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.assets import drt_assets
+        from dagster_drt.resource import DagsterDrtResource
+
+        @drt_assets(project_dir=project)
+        def my_syncs(context, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+        assert isinstance(my_syncs, AssetsDefinition)
+        assert AssetKey("drt_test_sync") in my_syncs.keys
+
+    def test_multi_asset_can_subset(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path, TWO_SYNCS)
+        from dagster_drt.assets import drt_assets
+        from dagster_drt.resource import DagsterDrtResource
+
+        @drt_assets(project_dir=project)
+        def my_syncs(context, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+        assert my_syncs.can_subset
+
+    def test_filter_by_name(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path, TWO_SYNCS)
+        from dagster_drt.assets import drt_assets
+        from dagster_drt.resource import DagsterDrtResource
+
+        @drt_assets(project_dir=project, sync_names=["a"])
+        def my_syncs(context, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+        assert len(my_syncs.keys) == 1
+        assert AssetKey("drt_a") in my_syncs.keys
+
+    def test_group_name_override(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.assets import drt_assets
+        from dagster_drt.resource import DagsterDrtResource
+
+        @drt_assets(project_dir=project, group_name="reverse_etl")
+        def my_syncs(context, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+        assert my_syncs.group_names_by_key[AssetKey("drt_test_sync")] == "reverse_etl"
+
+    def test_custom_translator(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.assets import drt_assets
+        from dagster_drt.resource import DagsterDrtResource
+        from dagster_drt.translator import DagsterDrtTranslator
+
+        class MyTranslator(DagsterDrtTranslator):
+            def get_asset_spec(self, data):
+                default = super().get_asset_spec(data)
+                return default.replace_attributes(key=AssetKey(["custom", data.sync_config.name]))
+
+        @drt_assets(project_dir=project, dagster_drt_translator=MyTranslator())
+        def my_syncs(context, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+        assert AssetKey(["custom", "test_sync"]) in my_syncs.keys
 
 
-def test_asset_returns_materialize_result(tmp_path: Path) -> None:
-    """Verify asset function return annotation is MaterializeResult."""
-    project = _setup_project(tmp_path)
-    from dagster import MaterializeResult
-
-    from dagster_drt.assets import drt_assets
-
-    assets = drt_assets(project_dir=project)
-    # Check the output type from the asset spec
-    spec = assets[0].specs_by_key[AssetKey("drt_test_sync")]
-    # MaterializeResult assets have no output type annotation on the spec
-    # but we can verify the asset was created successfully with the new signature
-    assert spec is not None
+# ===================================================================
+# Legacy drt_assets_legacy() function
+# ===================================================================
 
 
-# --- Exports ---
+class TestLegacyDrtAssets:
+    def test_creates_asset_list(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.assets import drt_assets_legacy
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            assets = drt_assets_legacy(project_dir=project)
+        assert len(assets) == 1
+
+    def test_emits_deprecation_warning(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.assets import drt_assets_legacy
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            drt_assets_legacy(project_dir=project)
+            assert any("deprecated" in str(warning.message).lower() for warning in w)
+
+    def test_filter_by_name(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path, TWO_SYNCS)
+        from dagster_drt.assets import drt_assets_legacy
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            assets = drt_assets_legacy(project_dir=project, sync_names=["a"])
+        assert len(assets) == 1
+
+
+# ===================================================================
+# DrtConfig
+# ===================================================================
+
+
+class TestDrtConfig:
+    def test_defaults(self) -> None:
+        from dagster_drt.assets import DrtConfig
+
+        config = DrtConfig()
+        assert config.dry_run is False
+
+    def test_dry_run(self) -> None:
+        from dagster_drt.assets import DrtConfig
+
+        config = DrtConfig(dry_run=True)
+        assert config.dry_run is True
+
+
+# ===================================================================
+# Public exports
+# ===================================================================
+
+
+# ===================================================================
+# @drt_assets — partitions_def, backfill_policy, pool
+# ===================================================================
+
+
+class TestDrtAssetsAdvanced:
+    def test_partitions_def(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.assets import drt_assets
+        from dagster_drt.resource import DagsterDrtResource
+
+        partitions = DailyPartitionsDefinition(start_date="2024-01-01")
+
+        @drt_assets(project_dir=project, partitions_def=partitions)
+        def my_syncs(context, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+        assert my_syncs.partitions_def == partitions
+
+    def test_partitions_def_auto_backfill_policy(self, tmp_path: Path) -> None:
+        """When partitions_def is set without backfill_policy, defaults to single_run."""
+        project = _setup_project(tmp_path)
+        from dagster_drt.assets import drt_assets
+        from dagster_drt.resource import DagsterDrtResource
+
+        partitions = DailyPartitionsDefinition(start_date="2024-01-01")
+
+        @drt_assets(project_dir=project, partitions_def=partitions)
+        def my_syncs(context, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+        assert my_syncs.backfill_policy == BackfillPolicy.single_run()
+
+    def test_explicit_backfill_policy(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.assets import drt_assets
+        from dagster_drt.resource import DagsterDrtResource
+
+        policy = BackfillPolicy.multi_run(max_partitions_per_run=5)
+
+        @drt_assets(
+            project_dir=project,
+            partitions_def=DailyPartitionsDefinition(start_date="2024-01-01"),
+            backfill_policy=policy,
+        )
+        def my_syncs(context, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+        assert my_syncs.backfill_policy == policy
+
+    def test_pool_parameter(self, tmp_path: Path) -> None:
+        project = _setup_project(tmp_path)
+        from dagster_drt.assets import drt_assets
+        from dagster_drt.resource import DagsterDrtResource
+
+        @drt_assets(project_dir=project, pool="drt_pool")
+        def my_syncs(context, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+        assert isinstance(my_syncs, AssetsDefinition)
+
+    def test_group_name_conflict_raises(self, tmp_path: Path) -> None:
+        """Raise ValueError when translator sets group and decorator also sets group."""
+        project = _setup_project(tmp_path)
+        from dagster_drt.assets import drt_assets
+        from dagster_drt.resource import DagsterDrtResource
+        from dagster_drt.translator import DagsterDrtTranslator
+
+        class MyTranslator(DagsterDrtTranslator):
+            def get_asset_spec(self, data):
+                default = super().get_asset_spec(data)
+                return default.replace_attributes(group_name="from_translator")
+
+        with pytest.raises(ValueError, match="conflicts with translator-set"):
+
+            @drt_assets(
+                project_dir=project,
+                group_name="from_decorator",
+                dagster_drt_translator=MyTranslator(),
+            )
+            def my_syncs(context, drt: DagsterDrtResource):
+                yield from drt.run(context=context)
+
+
+# ===================================================================
+# Legacy translator — kinds preserved
+# ===================================================================
+
+
+class TestTranslatorLegacyKinds:
+    def test_legacy_path_preserves_kinds(self, tmp_path: Path) -> None:
+        """Legacy translator overrides should still produce kinds metadata."""
+        project = _setup_project(tmp_path)
+        from dagster_drt.specs import build_drt_asset_specs
+        from dagster_drt.translator import DagsterDrtTranslator
+
+        class MyTranslator(DagsterDrtTranslator):
+            def get_group_name(self, sync_config):
+                return "custom_group"
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            specs = build_drt_asset_specs(
+                project_dir=project,
+                dagster_drt_translator=MyTranslator(),
+            )
+        assert "drt" in specs[0].kinds
+        assert "rest_api" in specs[0].kinds
+
+
+# ===================================================================
+# DagsterDrtResource — integration tests with mocked run_sync
+# ===================================================================
+
+
+@dataclass
+class _FakeSyncResult:
+    """Minimal SyncResult stand-in for testing."""
+
+    success: int = 10
+    failed: int = 0
+    skipped: int = 0
+    errors: list[str] = field(default_factory=list)
+    row_errors: list = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return self.success + self.failed + self.skipped
+
+
+def _make_mock_context(
+    assets_def: AssetsDefinition,
+    selected_keys: set[AssetKey] | None = None,
+) -> MagicMock:
+    """Create a mock AssetExecutionContext for resource tests."""
+    ctx = MagicMock(spec=["assets_def", "selected_asset_keys", "log"])
+    ctx.assets_def = assets_def
+    ctx.selected_asset_keys = selected_keys or assets_def.keys
+    ctx.log = MagicMock()
+    return ctx
+
+
+# Patch targets for lazy imports inside DagsterDrtResource.run().
+_P_LOAD_PROJECT = "drt.config.parser.load_project"
+_P_LOAD_PROFILE = "drt.config.credentials.load_profile"
+_P_GET_SOURCE = "drt.cli.main._get_source"
+_P_GET_DEST = "drt.cli.main._get_destination"
+_P_RUN_SYNC = "drt.engine.sync.run_sync"
+_P_STATE_MGR = "drt.state.manager.StateManager"
+_P_LOAD_SYNCS = "drt.config.parser.load_syncs"
+
+
+class TestDagsterDrtResourceRun:
+    def test_run_yields_materialize_result(self, tmp_path: Path) -> None:
+        """Resource.run() should yield MaterializeResult per sync."""
+        project = _setup_project(tmp_path)
+        from dagster_drt.assets import drt_assets
+        from dagster_drt.resource import DagsterDrtResource
+
+        @drt_assets(project_dir=project)
+        def my_syncs(context, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+        ctx = _make_mock_context(my_syncs)
+        resource = DagsterDrtResource(project_dir=str(project))
+
+        with (
+            patch(_P_LOAD_PROJECT) as mock_proj,
+            patch(_P_LOAD_PROFILE),
+            patch(_P_GET_SOURCE),
+            patch(_P_GET_DEST),
+            patch(_P_RUN_SYNC) as mock_run,
+            patch(_P_STATE_MGR),
+            patch(_P_LOAD_SYNCS) as mock_load_syncs,
+        ):
+            mock_proj.return_value = MagicMock(profile="local")
+            mock_sync = MagicMock()
+            mock_sync.name = "test_sync"
+            mock_load_syncs.return_value = [mock_sync]
+            mock_run.return_value = _FakeSyncResult(success=42, failed=1)
+
+            results = list(resource.run(context=ctx))
+
+        assert len(results) == 1
+        assert isinstance(results[0], MaterializeResult)
+        assert results[0].metadata["rows_synced"].value == 42
+        assert results[0].metadata["rows_failed"].value == 1
+
+    def test_run_subset_execution(self, tmp_path: Path) -> None:
+        """Resource.run() should only execute syncs for selected asset keys."""
+        project = _setup_project(tmp_path, TWO_SYNCS)
+        from dagster_drt.assets import drt_assets
+        from dagster_drt.resource import DagsterDrtResource
+
+        @drt_assets(project_dir=project)
+        def my_syncs(context, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+        # Only select asset "a", not "b".
+        ctx = _make_mock_context(my_syncs, selected_keys={AssetKey("drt_a")})
+        resource = DagsterDrtResource(project_dir=str(project))
+
+        with (
+            patch(_P_LOAD_PROJECT) as mock_proj,
+            patch(_P_LOAD_PROFILE),
+            patch(_P_GET_SOURCE),
+            patch(_P_GET_DEST),
+            patch(_P_RUN_SYNC) as mock_run,
+            patch(_P_STATE_MGR),
+            patch(_P_LOAD_SYNCS) as mock_load_syncs,
+        ):
+            mock_proj.return_value = MagicMock(profile="local")
+            mock_a = MagicMock()
+            mock_a.name = "a"
+            mock_b = MagicMock()
+            mock_b.name = "b"
+            mock_load_syncs.return_value = [mock_a, mock_b]
+            mock_run.return_value = _FakeSyncResult()
+
+            results = list(resource.run(context=ctx))
+
+        assert len(results) == 1
+        assert results[0].asset_key == AssetKey("drt_a")
+        # run_sync should only be called once (for "a", not "b")
+        mock_run.assert_called_once()
+
+    def test_run_dry_run_override(self, tmp_path: Path) -> None:
+        """dry_run parameter passed to run() should override resource default."""
+        project = _setup_project(tmp_path)
+        from dagster_drt.assets import drt_assets
+        from dagster_drt.resource import DagsterDrtResource
+
+        @drt_assets(project_dir=project)
+        def my_syncs(context, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+        ctx = _make_mock_context(my_syncs)
+        resource = DagsterDrtResource(project_dir=str(project), dry_run=False)
+
+        with (
+            patch(_P_LOAD_PROJECT) as mock_proj,
+            patch(_P_LOAD_PROFILE),
+            patch(_P_GET_SOURCE),
+            patch(_P_GET_DEST),
+            patch(_P_RUN_SYNC) as mock_run,
+            patch(_P_STATE_MGR),
+            patch(_P_LOAD_SYNCS) as mock_load_syncs,
+        ):
+            mock_proj.return_value = MagicMock(profile="local")
+            mock_sync = MagicMock()
+            mock_sync.name = "test_sync"
+            mock_load_syncs.return_value = [mock_sync]
+            mock_run.return_value = _FakeSyncResult()
+
+            list(resource.run(context=ctx, dry_run=True))
+
+        # Verify dry_run=True was passed to run_sync
+        call_kwargs = mock_run.call_args
+        assert call_kwargs.kwargs.get("dry_run") is True
+
+    def test_run_missing_sync_warns(self, tmp_path: Path) -> None:
+        """Resource.run() should warn when sync not found for an asset key."""
+        project = _setup_project(tmp_path)
+        from dagster_drt.assets import drt_assets
+        from dagster_drt.resource import DagsterDrtResource
+
+        @drt_assets(project_dir=project)
+        def my_syncs(context, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+        ctx = _make_mock_context(my_syncs)
+        resource = DagsterDrtResource(project_dir=str(project))
+
+        with (
+            patch(_P_LOAD_PROJECT) as mock_proj,
+            patch(_P_LOAD_PROFILE),
+            patch(_P_GET_SOURCE),
+            patch(_P_STATE_MGR),
+            patch(_P_LOAD_SYNCS) as mock_load_syncs,
+        ):
+            mock_proj.return_value = MagicMock(profile="local")
+            # Return empty sync list — sync won't be found.
+            mock_load_syncs.return_value = []
+
+            results = list(resource.run(context=ctx))
+
+        assert len(results) == 0
+        ctx.log.warning.assert_called()
+
+    def test_run_auto_resolve_project_dir(self, tmp_path: Path) -> None:
+        """Resource should auto-resolve project_dir from asset metadata."""
+        project = _setup_project(tmp_path)
+        from dagster_drt.assets import drt_assets
+        from dagster_drt.resource import DagsterDrtResource
+
+        @drt_assets(project_dir=project)
+        def my_syncs(context, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+        ctx = _make_mock_context(my_syncs)
+        # No project_dir set on resource — should auto-resolve from metadata.
+        resource = DagsterDrtResource()
+
+        with (
+            patch(_P_LOAD_PROJECT) as mock_proj,
+            patch(_P_LOAD_PROFILE),
+            patch(_P_GET_SOURCE),
+            patch(_P_GET_DEST),
+            patch(_P_RUN_SYNC) as mock_run,
+            patch(_P_STATE_MGR),
+            patch(_P_LOAD_SYNCS) as mock_load_syncs,
+        ):
+            mock_proj.return_value = MagicMock(profile="local")
+            mock_sync = MagicMock()
+            mock_sync.name = "test_sync"
+            mock_load_syncs.return_value = [mock_sync]
+            mock_run.return_value = _FakeSyncResult()
+
+            results = list(resource.run(context=ctx))
+
+        assert len(results) == 1
+
+    def test_run_no_project_dir_raises(self, tmp_path: Path) -> None:
+        """Resource should raise if project_dir can't be resolved."""
+        from dagster_drt.resource import DagsterDrtResource
+
+        resource = DagsterDrtResource()
+
+        # Mock a context with no metadata.
+        ctx = MagicMock()
+        ctx.assets_def.specs_by_key = {AssetKey("x"): AssetSpec(key=AssetKey("x"))}
+        ctx.selected_asset_keys = {AssetKey("x")}
+
+        with pytest.raises(ValueError, match="project_dir must be set"):
+            list(resource.run(context=ctx))
+
+
+# ===================================================================
+# Public exports
+# ===================================================================
 
 
 def test_public_exports() -> None:
     import dagster_drt
 
     assert hasattr(dagster_drt, "drt_assets")
+    assert hasattr(dagster_drt, "drt_assets_legacy")
     assert hasattr(dagster_drt, "DrtConfig")
     assert hasattr(dagster_drt, "DagsterDrtTranslator")
+    assert hasattr(dagster_drt, "DrtTranslatorData")
+    assert hasattr(dagster_drt, "DagsterDrtResource")
+    assert hasattr(dagster_drt, "build_drt_asset_specs")


### PR DESCRIPTION
## Summary

- Add `build_drt_asset_specs()` for spec-only generation, decoupled from execution (#176)
- Add `@drt_assets` decorator wrapping `@multi_asset(can_subset=True)` (#177)
- Add `DagsterDrtResource` (`ConfigurableResource`) with `.run()` yielding `MaterializeResult` (#178)
- Migrate `DagsterDrtTranslator` to `get_asset_spec()` as primary override point (#179)
- Add `partitions_def`, `backfill_policy`, `pool` support
- Add `group_name` conflict detection, `project_dir` auto-resolve from metadata
- Legacy API preserved with deprecation warnings
- 34 tests (was 15) covering specs, decorator, resource, subsetting, errors

## Context

Aligns dagster-drt with the established patterns in dagster-dbt/dagster-dlt, which is the prerequisite for Pipes support (#175).

| | dagster-dlt | dagster-drt (after) |
|---|---|---|
| Decorator | `@dlt_assets` | `@drt_assets` |
| Spec generation | `build_dlt_asset_specs()` | `build_drt_asset_specs()` |
| Resource | `DagsterDltResource` | `DagsterDrtResource` |
| Translator | `get_asset_spec()` | `get_asset_spec()` |
| Partitions | ✅ | ✅ |
| Subsetting | ✅ | ✅ |

Closes #176, closes #177, closes #178, closes #179

## Test plan

- [x] 34 unit/integration tests passing (`pytest integrations/dagster-drt/`)
- [x] `ruff check` + `ruff format` clean
- [x] Full test suite (170 tests) unaffected
- [ ] Review new API surface for usability

🤖 Generated with [Claude Code](https://claude.com/claude-code)