### PR TITLE
docs: add CONTRIBUTING.ja.md and i18n sync check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,8 @@ jobs:
       - name: Check skills sync
         run: make check-skills
 
+      - name: Check i18n sync
+        run: make check-i18n || echo "::warning::Some translations are stale. Run 'make check-i18n' for details."
+
       - name: Test (pytest)
         run: pytest

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -1,0 +1,131 @@
+<!-- i18n-sync: base=CONTRIBUTING.md, hash=8fe1f12513ca3c9e3e0ba5e366e73c1c9fc25cd4 -->
+
+[English](./CONTRIBUTING.md) | [日本語](./CONTRIBUTING.ja.md)
+
+> **Note:** この翻訳は最新でない可能性があります。正確な情報は [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。
+
+# drt への貢献
+
+ご協力いただきありがとうございます！
+
+## 開発環境のセットアップ
+
+### 前提条件
+
+- Python 3.10+
+- [uv](https://docs.astral.sh/uv/)（推奨）または pip
+
+### クローンとインストール
+
+```bash
+git clone https://github.com/drt-hub/drt.git
+cd drt
+```
+
+**uv を使う場合（推奨）：**
+
+```bash
+uv sync --extra dev --extra bigquery
+```
+
+**pip を使う場合：**
+
+```bash
+pip install -e ".[dev,bigquery]"
+```
+
+または Makefile のショートカット：
+
+```bash
+make dev
+```
+
+## テストの実行
+
+```bash
+make test       # すべてのテストを実行（pytest）
+make lint       # ruff + mypy
+make fmt        # 自動フォーマット（ruff format + fix）
+```
+
+コマンドを直接実行することもできます：
+
+```bash
+uv run pytest
+uv run ruff check drt tests
+uv run mypy drt
+```
+
+## ブランチ命名規則
+
+| プレフィックス | 用途 |
+|--------|-------------|
+| `feat/` | 新機能やコネクタの追加 |
+| `fix/` | バグ修正 |
+| `docs/` | ドキュメントの変更 |
+| `chore/` | メンテナンス、依存関係の更新、CI の変更 |
+
+例: `feat/snowflake-source`, `fix/empty-batch-rest-api`, `docs/quickstart-update`
+
+## ブランチ戦略
+
+drt は **GitHub Flow** を使用します — すべての開発はフィーチャーブランチで行い、`main` に直接マージします。
+
+- `main` は常にリリース可能な状態です
+- `develop` や `release` ブランチはありません
+- リリースはタグ（`v0.2.0`, `v0.3.0`, ...）でマークされます
+
+## 変更の提出
+
+1. リポジトリをフォークする
+2. 上記の命名規則に従ってブランチを作成する: `git checkout -b feat/your-feature`
+3. テストを含む変更を加える
+4. `make lint` と `make test` を実行してすべてがパスすることを確認する
+5. プルリクエストを開き、PR テンプレートに記入する
+
+> **マージ戦略:** すべての PR は **Squash & merge** でマージされます。ブランチのコミットは `main` 上の単一のコミットにスカッシュされるため、WIP コミットをクリーンアップする必要はありません。
+
+## プルリクエストチェックリスト
+
+- [ ] テストがパスする（`make test`）
+- [ ] リンターがパスする（`make lint`）
+- [ ] `CHANGELOG.md` が更新されている（ユーザー向けの変更の場合）
+- [ ] 新しいコネクタには `tests/` 配下のテストと `examples/` 配下の例が含まれている
+
+## コミットスタイル
+
+[Conventional Commits](https://www.conventionalcommits.org/) を使用してください：
+
+```
+feat: add Snowflake source
+fix: handle empty batch in REST API destination
+docs: update quickstart example
+chore: bump dependencies
+```
+
+## コネクタの追加
+
+プロトコルのインターフェースについては `drt/sources/base.py` と `drt/destinations/base.py` を参照してください。
+プロトコルを実装し、`tests/` 配下にテストを、`examples/` 配下に例を追加してください。
+
+事前の議論なしに `Source` や `Destination` プロトコルのシグネチャを変更**しないでください** — これらは将来の Rust 書き換えのために設計された安定したインターフェースです。
+
+## 行動規範
+
+親切で建設的であること。私たちは [Contributor Covenant](https://www.contributor-covenant.org/) に従います。
+
+## AI スキルの更新
+
+drt はプラグインマーケットプレイス（`skills/drt/`）を介して Claude Code スキルを提供しています。スキルの内容を更新しても、プラグインのバージョンを上げない限り、ユーザーは更新を受け取りません。
+
+**ルール: `SKILL.md` が変更された場合は、必ず以下の3箇所でバージョンを上げてください：**
+
+```bash
+# 1. skills/drt/.claude-plugin/plugin.json
+# 2. .claude-plugin/marketplace.json  (プラグインエントリのバージョン)
+# 3. .claude-plugin/plugin.json       (リポジトリレベルのバージョン)
+```
+
+バージョンは `pyproject.toml` と同期してください（例: `0.4.0` をリリースする場合、すべてのプラグインバージョンを `0.4.0` に設定）。
+
+**新しいスキル** を追加する場合は、必要に応じて `skills/drt/.claude-plugin/plugin.json` にエントリを追加し、`README.md` と `docs/llm/CONTEXT.md` にドキュメントを追加してください。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+[English](./CONTRIBUTING.md) | [日本語](./CONTRIBUTING.ja.md)
+
 # Contributing to drt
 
 Thank you for your interest in contributing!

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install dev lint fmt test clean sync-skills check-skills sync-version release-check topics sync-labels
+.PHONY: install dev lint fmt test clean sync-skills check-skills check-i18n sync-version release-check topics sync-labels
 
 # ── Development ────────────────────────────────────────────────────────────────
 
@@ -51,6 +51,9 @@ check-skills:  ## Verify .claude/commands/ matches skills (CI gate)
 		exit 1; \
 	fi; \
 	echo "✓ All skills in sync"
+
+check-i18n:  ## Check if translated *.{lang}.md files are in sync with English base
+	@bash scripts/check-i18n-sync.sh
 
 sync-version:  ## Propagate version from pyproject.toml to all plugin JSONs
 	@python3 scripts/sync-version.py

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,3 +1,5 @@
+<!-- i18n-sync: base=README.md, hash=da09e7fded81c276bc17449c8eae4feea3a4afe4 -->
+
 [English](./README.md) | [日本語](./README.ja.md)
 
 > **Note:** この翻訳は最新でない可能性があります。正確な情報は [README.md](README.md) を参照してください。

--- a/scripts/check-i18n-sync.sh
+++ b/scripts/check-i18n-sync.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# check-i18n-sync.sh — Detect stale i18n translations.
+#
+# Scans for translated files matching *.{lang}.md (e.g. README.ja.md)
+# and checks whether the English base file has been updated since the
+# translation was last synced.
+#
+# Each translation file must contain a marker in its first 5 lines:
+#   <!-- i18n-sync: base=README.md, hash=<commit-hash> -->
+#
+# The script compares the recorded hash against the latest commit that
+# touched the base file.  If they differ, a warning is printed.
+#
+# Exit codes:
+#   0 — all translations are up to date (or no translations found)
+#   1 — one or more translations are stale (warning only)
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+stale=0
+checked=0
+
+# Find all *.{lang}.md files (2-letter language codes).
+for translated in *.??.md; do
+    [ -f "$translated" ] || continue
+
+    # Extract the i18n-sync marker from the first 5 lines.
+    marker=$(head -5 "$translated" | grep -o '<!-- i18n-sync: base=\([^,]*\), hash=\([a-f0-9]*\) -->' || true)
+    if [ -z "$marker" ]; then
+        echo "SKIP  $translated  (no i18n-sync marker)"
+        continue
+    fi
+
+    # Parse base file and recorded hash.
+    base=$(echo "$marker" | sed 's/.*base=\([^,]*\),.*/\1/')
+    recorded_hash=$(echo "$marker" | sed 's/.*hash=\([a-f0-9]*\).*/\1/')
+
+    if [ ! -f "$base" ]; then
+        echo "WARN  $translated  base file '$base' not found"
+        stale=1
+        continue
+    fi
+
+    # Get the latest commit hash that touched the base file.
+    latest_hash=$(git log -1 --format="%H" -- "$base" 2>/dev/null || echo "")
+    if [ -z "$latest_hash" ]; then
+        echo "SKIP  $translated  (cannot determine git history for '$base')"
+        continue
+    fi
+
+    checked=$((checked + 1))
+
+    if [ "$recorded_hash" = "$latest_hash" ]; then
+        echo "OK    $translated  (synced with $base)"
+    else
+        echo "STALE $translated  (base=$base updated: ${latest_hash:0:7}, recorded: ${recorded_hash:0:7})"
+        stale=1
+    fi
+done
+
+echo ""
+echo "Checked $checked translation(s)."
+
+if [ "$stale" -ne 0 ]; then
+    echo ""
+    echo "Some translations are stale. To fix:"
+    echo "  1. Update the translation content to match the base file"
+    echo "  2. Update the hash in the i18n-sync marker:"
+    echo "     git log -1 --format='%H' -- <base-file>"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.ja.md` — Japanese translation of CONTRIBUTING.md (at project root)
- Add i18n sync mechanism to detect stale translations in CI
- Supersedes #122 (closed with credit to @gemini-25-pro-collab)

## i18n Sync Mechanism

Each translated `*.{lang}.md` file contains a marker:
```html
<!-- i18n-sync: base=CONTRIBUTING.md, hash=8fe1f12... -->
```

`scripts/check-i18n-sync.sh` compares this hash against the latest commit on the base file. If they differ, the translation is flagged as stale.

- **Auto-detects** any `*.{lang}.md` file (2-letter code) — no config changes needed for new languages
- **CI: warning only** — does not block merge
- **`make check-i18n`** for local use

## Fixes from #122

- File location: project root (not `docs/`)
- Branch naming table: matches English version (4 types only)
- Commit examples: kept in English
- Translation quality: natural Japanese (e.g. "シグネチャ" not "署名")

Closes #96

## Test plan

- [x] `make check-i18n` passes (2 translations OK)
- [x] Stale detection works (tested with dummy hash)
- [x] `make check-skills` passes
- [x] `make test` passes (170 tests)
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)