### PR TITLE
chore(dagster-drt): prepare v0.2.0 release

### DIFF
--- a/.claude/commands/dagster-drt-release-check.md
+++ b/.claude/commands/dagster-drt-release-check.md
@@ -11,15 +11,23 @@ Check that all documentation and version references are consistent before a dags
 
 3. **CHANGELOG** — verify there is an entry for the current dagster-drt version with today's date in `integrations/dagster-drt/CHANGELOG.md` (if exists) or in the main `CHANGELOG.md`
 
-4. **README** — verify `integrations/dagster-drt/README.md`:
+4. **README (integration)** — verify `integrations/dagster-drt/README.md`:
    - PyPI badge version matches pyproject.toml
-   - All public API is documented: `drt_assets()`, `DagsterDrtTranslator`, `DrtConfig`
-   - Usage examples are current and working
+   - All public API is documented:
+     - `@drt_assets` decorator (new, recommended)
+     - `build_drt_asset_specs()` (spec-only generation)
+     - `DagsterDrtResource` (execution resource)
+     - `DagsterDrtTranslator` / `DrtTranslatorData` (customization)
+     - `DrtConfig` (run configuration)
+     - `drt_assets_legacy()` (deprecated, if still exported)
+   - Pipes usage example is included (using `build_drt_asset_specs` + `@multi_asset`)
+   - Migration guide from v0.1 to v0.2 is present (if breaking changes)
    - Install instructions use correct package name
 
 5. **Exports** — verify `integrations/dagster-drt/dagster_drt/__init__.py`:
    - All public classes/functions are exported in `__all__`
    - Exports match what README documents
+   - Expected exports: `drt_assets`, `drt_assets_legacy`, `DrtConfig`, `DagsterDrtResource`, `DagsterDrtTranslator`, `DrtTranslatorData`, `build_drt_asset_specs`
 
 6. **Tests** — verify all dagster-drt tests pass:
    ```bash
@@ -31,9 +39,14 @@ Check that all documentation and version references are consistent before a dags
    - Build directory is correct (`integrations/dagster-drt`)
    - PyPI Trusted Publishing is configured (check GitHub repo Settings > Environments > pypi)
 
-8. **Main project references** — verify:
-   - Main `README.md` mentions dagster-drt with correct install instructions
-   - `CLAUDE.md` lists dagster-drt in integrations
-   - `docs/llm/CONTEXT.md` mentions dagster-drt
+8. **Main project references** — verify these files have up-to-date dagster-drt content:
+   - `README.md` — dagster-drt section uses new API (`@drt_assets` decorator pattern)
+   - `README.ja.md` — Japanese translation matches README.md dagster-drt section
+   - `CLAUDE.md` — lists dagster-drt in integrations
+   - `docs/llm/CONTEXT.md` — dagster-drt section uses new API
+   - `docs/guides/using-with-dbt.md` — dagster-drt link is valid
+   - `SECURITY.md` — supported versions table includes current dagster-drt version
+
+9. **i18n sync** — run `make check-i18n` and verify README.ja.md is in sync
 
 Report any inconsistencies found and suggest fixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > `dagster-drt` is published as a separate PyPI package with its own version.
 
+### [0.2.0] - 2026-04-04 (dagster-drt)
+
+- **API alignment with dagster-dbt / dagster-dlt patterns** (#176, #177, #178, #179)
+- **`@drt_assets` decorator** — wraps `@multi_asset(can_subset=True)`, replacing the old `drt_assets()` function
+- **`build_drt_asset_specs()`** — pure spec generation, decoupled from execution. Enables Dagster Pipes remote execution (#175)
+- **`DagsterDrtResource`** — `ConfigurableResource` with `.run()` yielding `MaterializeResult` per sync. Auto-resolves `project_dir` from `@drt_assets` metadata
+- **`DagsterDrtTranslator.get_asset_spec()`** — new primary override point (per-attribute methods deprecated)
+- **`partitions_def`, `backfill_policy`, `pool`** support on `@drt_assets`
+- **Asset `kinds`** metadata — `{"drt", "<destination_type>"}` visible in Dagster UI
+- **Group name conflict detection** — raises if translator and decorator both set group names
+- **Subset execution** — `DagsterDrtResource.run()` respects `context.selected_asset_keys`
+- Old `drt_assets()` function renamed to `drt_assets_legacy()` with deprecation warning
+- Requires `drt-core>=0.4.1`, `dagster>=1.6`
+
 ### [0.1.0] - 2026-04-01 (dagster-drt)
 
 - First PyPI release (`pip install dagster-drt`)

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-sync: base=CONTRIBUTING.md, hash=8fe1f12513ca3c9e3e0ba5e366e73c1c9fc25cd4 -->
+<!-- i18n-sync: base=CONTRIBUTING.md, hash=43c09a58b7d6f74aab228fccd85d8d37b15ded02 -->
 
 [English](./CONTRIBUTING.md) | [日本語](./CONTRIBUTING.ja.md)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -240,28 +240,27 @@ Claude Codeの公式スキルをインストールすると、チャットイン
 
 ## オーケストレーション: dagster-drt
 
-コミュニティによって維持管理されている [Dagster](https://dagster.io/) との統合。 drtの同期を、可観測性を備えた Dagster アセットとして公開します。
+コミュニティによって維持管理されている [Dagster](https://dagster.io/) との統合。drt の同期を、可観測性を備えた Dagster アセットとして公開します。
+
 ```bash
 pip install dagster-drt
 ```
 
 ```python
-from dagster import Definitions
-from dagster_drt import drt_assets, DagsterDrtTranslator
+from dagster import AssetExecutionContext, Definitions
+from dagster_drt import drt_assets, DagsterDrtResource
 
-class MyTranslator(DagsterDrtTranslator):
-    def get_group_name(self, sync_config):
-        return "reverse_etl"
+@drt_assets(project_dir="path/to/drt-project")
+def my_syncs(context: AssetExecutionContext, drt: DagsterDrtResource):
+    yield from drt.run(context=context)
 
 defs = Definitions(
-    assets=drt_assets(
-        project_dir="path/to/drt-project",
-        dagster_drt_translator=MyTranslator(),
-    )
+    assets=[my_syncs],
+    resources={"drt": DagsterDrtResource(project_dir="path/to/drt-project")},
 )
 ```
 
-詳細なAPIドキュメント（Translator、DrtConfigのドライラン、MaterializeResult）については、 [dagster-drt README](integrations/dagster-drt/README.md) を参照してください。
+詳細な API ドキュメント（Translator、Pipes サポート、DrtConfig のドライラン、MaterializeResult）については、[dagster-drt README](integrations/dagster-drt/README.md) を参照してください。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -243,22 +243,20 @@ pip install dagster-drt
 ```
 
 ```python
-from dagster import Definitions
-from dagster_drt import drt_assets, DagsterDrtTranslator
+from dagster import AssetExecutionContext, Definitions
+from dagster_drt import drt_assets, DagsterDrtResource
 
-class MyTranslator(DagsterDrtTranslator):
-    def get_group_name(self, sync_config):
-        return "reverse_etl"
+@drt_assets(project_dir="path/to/drt-project")
+def my_syncs(context: AssetExecutionContext, drt: DagsterDrtResource):
+    yield from drt.run(context=context)
 
 defs = Definitions(
-    assets=drt_assets(
-        project_dir="path/to/drt-project",
-        dagster_drt_translator=MyTranslator(),
-    )
+    assets=[my_syncs],
+    resources={"drt": DagsterDrtResource(project_dir="path/to/drt-project")},
 )
 ```
 
-See [dagster-drt README](integrations/dagster-drt/README.md) for full API docs (Translator, DrtConfig dry-run, MaterializeResult).
+See [dagster-drt README](integrations/dagster-drt/README.md) for full API docs (Translator, Pipes support, DrtConfig dry-run, MaterializeResult).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,7 @@
 
 | Version | Supported |
 |---------|-----------|
+| 0.2.x   | ✅        |
 | 0.1.x   | ✅        |
 
 ## Reporting a Vulnerability

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -124,21 +124,23 @@ The MCP server reads from the current working directory (the drt project root).
 Community-maintained Dagster integration. Install: `pip install dagster-drt`
 
 ```python
-from dagster_drt import drt_assets, DagsterDrtTranslator, DrtConfig
+from dagster import AssetExecutionContext, Definitions
+from dagster_drt import drt_assets, DagsterDrtResource, DagsterDrtTranslator
 
-# Basic usage
-assets = drt_assets(project_dir="path/to/drt-project")
+# Basic usage — @drt_assets decorator + DagsterDrtResource
+@drt_assets(project_dir="path/to/drt-project")
+def my_syncs(context: AssetExecutionContext, drt: DagsterDrtResource):
+    yield from drt.run(context=context)
 
-# Custom translator for group names and deps
-class MyTranslator(DagsterDrtTranslator):
-    def get_group_name(self, sync_config):
-        return "reverse_etl"
-
-assets = drt_assets(
-    project_dir="path/to/drt-project",
-    dagster_drt_translator=MyTranslator(),
-    dry_run=True,  # build-time default
+defs = Definitions(
+    assets=[my_syncs],
+    resources={"drt": DagsterDrtResource(project_dir="path/to/drt-project")},
 )
+
+# Pipes-based remote execution (Cloud Run, K8s, etc.)
+from dagster_drt import build_drt_asset_specs
+specs = build_drt_asset_specs(project_dir=".")
+# Use specs with @multi_asset + PipesClient
 ```
 
 ## AI Skills for Claude Code

--- a/integrations/dagster-drt/README.md
+++ b/integrations/dagster-drt/README.md
@@ -4,7 +4,7 @@
 
 Community-maintained [Dagster](https://dagster.io/) integration for [drt](https://github.com/drt-hub/drt) (data reverse tool).
 
-Expose drt syncs as Dagster assets with full observability — metrics, dependencies, and dry-run support.
+Expose drt syncs as Dagster assets with full observability — metrics, dependencies, subsetting, and dry-run support.
 
 ## Installation
 
@@ -15,64 +15,119 @@ pip install dagster-drt
 ## Quick Start
 
 ```python
-from dagster import Definitions
-from dagster_drt import drt_assets
+from dagster import AssetExecutionContext, Definitions
+from dagster_drt import drt_assets, DagsterDrtResource
 
-defs = Definitions(assets=drt_assets(project_dir="path/to/drt-project"))
-```
+@drt_assets(project_dir="path/to/drt-project")
+def my_syncs(context: AssetExecutionContext, drt: DagsterDrtResource):
+    yield from drt.run(context=context)
 
-## Features
-
-### DagsterDrtTranslator
-
-Customise how drt syncs map to Dagster assets. Subclass and override methods:
-
-```python
-from dagster import AssetKey
-from dagster_drt import DagsterDrtTranslator, drt_assets
-
-class MyTranslator(DagsterDrtTranslator):
-    def get_group_name(self, sync_config):
-        return "reverse_etl"
-
-    def get_deps(self, sync_config):
-        deps_map = {
-            "trigger_bq_meeting_gha": [AssetKey("bq_meeting_cloudsql")],
-        }
-        return deps_map.get(sync_config.name, [])
-
-assets = drt_assets(
-    project_dir="pipeline/data-reverse",
-    dagster_drt_translator=MyTranslator(),
+defs = Definitions(
+    assets=[my_syncs],
+    resources={"drt": DagsterDrtResource(project_dir="path/to/drt-project")},
 )
 ```
 
-**Available methods:**
+## API Overview
 
-| Method | Default | Purpose |
-|--------|---------|---------|
-| `get_asset_key(sync_config)` | `AssetKey(f"drt_{name}")` | Asset key |
-| `get_group_name(sync_config)` | `None` | Group name |
-| `get_description(sync_config)` | `sync_config.description` | Asset description |
-| `get_deps(sync_config)` | `[]` | Upstream dependencies |
-| `get_metadata(sync_config)` | `{}` | Static metadata |
+| Component | Purpose |
+|---|---|
+| `@drt_assets` | Decorator — creates `@multi_asset` from drt syncs |
+| `build_drt_asset_specs()` | Spec-only generation (for Pipes / custom execution) |
+| `DagsterDrtResource` | Execution resource with `.run()` |
+| `DagsterDrtTranslator` | Customise how syncs map to assets |
+| `DrtConfig` | Per-run config (dry-run) from Dagster UI |
 
-### Dry-Run Support (DrtConfig)
+## Features
 
-Control dry-run mode per-run from the Dagster UI, or set a build-time default:
+### @drt_assets Decorator
+
+Creates a Dagster `multi_asset` with `can_subset=True` from drt sync definitions:
 
 ```python
-# Build-time default: all syncs in dry-run mode
-assets = drt_assets(project_dir="...", dry_run=True)
-
-# Override per-run via Dagster UI → Run Config:
-# ops:
-#   drt_my_sync:
-#     config:
-#       dry_run: false
+@drt_assets(
+    project_dir=".",
+    sync_names=["sync_a", "sync_b"],  # optional filter
+    group_name="reverse_etl",         # optional group override
+    partitions_def=DailyPartitionsDefinition(start_date="2024-01-01"),
+    pool="drt_pool",                  # optional concurrency control
+)
+def my_syncs(context: AssetExecutionContext, drt: DagsterDrtResource):
+    yield from drt.run(context=context)
 ```
 
-### MaterializeResult
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `project_dir` | `str \| Path` | required | Path to drt project root |
+| `sync_names` | `list[str] \| None` | `None` | Filter to specific syncs |
+| `dagster_drt_translator` | `DagsterDrtTranslator \| None` | `None` | Custom translator |
+| `name` | `str \| None` | `None` | Op name |
+| `group_name` | `str \| None` | `None` | Group name override |
+| `partitions_def` | `PartitionsDefinition \| None` | `None` | Partitions |
+| `backfill_policy` | `BackfillPolicy \| None` | auto `single_run` | Backfill policy |
+| `pool` | `str \| None` | `None` | Concurrency pool |
+
+### DagsterDrtResource
+
+Execution resource that yields `MaterializeResult` per sync:
+
+```python
+DagsterDrtResource(
+    project_dir=".",  # optional if @drt_assets has it
+    dry_run=False,    # default dry-run mode
+)
+```
+
+- Auto-resolves `project_dir` from `@drt_assets` metadata
+- Filters to `context.selected_asset_keys` for subset execution
+- Supports `dry_run` override per-run: `drt.run(context=ctx, dry_run=True)`
+
+### DagsterDrtTranslator
+
+Customise how drt syncs map to Dagster assets. Override `get_asset_spec()`:
+
+```python
+from dagster_drt import DagsterDrtTranslator, drt_assets
+
+class MyTranslator(DagsterDrtTranslator):
+    def get_asset_spec(self, data):
+        default = super().get_asset_spec(data)
+        return default.replace_attributes(
+            group_name="reverse_etl",
+            owners=["team:data"],
+        )
+
+@drt_assets(project_dir=".", dagster_drt_translator=MyTranslator())
+def my_syncs(context, drt):
+    yield from drt.run(context=context)
+```
+
+Legacy per-attribute methods (`get_asset_key`, `get_group_name`, etc.) still work but emit deprecation warnings. Migrate to `get_asset_spec()`.
+
+### build_drt_asset_specs (Pipes / Custom Execution)
+
+Generate specs without execution logic — use with Dagster Pipes for remote execution:
+
+```python
+from dagster import multi_asset
+from dagster_drt import build_drt_asset_specs
+
+specs = build_drt_asset_specs(project_dir=".", sync_names=["my_sync"])
+
+@multi_asset(specs=specs, can_subset=True)
+def my_drt_assets(context, pipes: PipesCloudRunJobClient):
+    return pipes.run(
+        context=context,
+        job_name="drt-runner",
+        command=["drt", "run", "--sync", "my_sync"],
+    ).get_results()
+```
+
+This is the same pattern as dagster-dlt's `build_dlt_asset_specs()`.
+
+### MaterializeResult Metadata
 
 Assets return `MaterializeResult` with structured metadata visible in the Dagster UI:
 
@@ -83,40 +138,59 @@ Assets return `MaterializeResult` with structured metadata visible in the Dagste
 - `dry_run` — whether dry-run was active
 - `row_errors_count` — number of row-level errors (details in logs)
 
-### Filtering Syncs
+### Asset Kinds
 
-```python
-# Only expose specific syncs as assets
-assets = drt_assets(
-    project_dir="...",
-    sync_names=["sync_a", "sync_b"],
-)
-```
+Assets are tagged with `kinds={"drt", "<destination_type>"}` (e.g. `{"drt", "rest_api"}`), visible in the Dagster UI asset graph.
 
 ## Usage with dagster-dbt
 
 ```python
 from dagster import Definitions
-from dagster_dbt import dbt_assets
-from dagster_drt import drt_assets, DagsterDrtTranslator
+from dagster_dbt import dbt_assets, DbtCliResource
+from dagster_drt import drt_assets, DagsterDrtResource
+
+@dbt_assets(manifest=dbt_project.manifest_path)
+def my_dbt_assets(context, dbt: DbtCliResource):
+    yield from dbt.cli(["build"], context=context).stream()
+
+@drt_assets(project_dir="path/to/drt-project")
+def my_drt_syncs(context, drt: DagsterDrtResource):
+    yield from drt.run(context=context)
 
 defs = Definitions(
-    assets=[*my_dbt_assets, *drt_assets("path/to/drt-project")],
+    assets=[my_dbt_assets, my_drt_syncs],
+    resources={
+        "dbt": DbtCliResource(project_dir=dbt_project),
+        "drt": DagsterDrtResource(project_dir="path/to/drt-project"),
+    },
 )
 ```
 
-## API Reference
+## Migration from v0.1
 
-### `drt_assets()`
+v0.2 introduces the `@drt_assets` decorator, `DagsterDrtResource`, and `build_drt_asset_specs()`. The old `drt_assets()` function is renamed to `drt_assets_legacy()` and emits a deprecation warning.
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `project_dir` | `str \| Path` | required | Path to drt project root |
-| `sync_names` | `list[str] \| None` | `None` | Filter to specific syncs |
-| `dagster_drt_translator` | `DagsterDrtTranslator \| None` | `None` | Custom translator |
-| `dry_run` | `bool` | `False` | Default dry-run mode |
+**Before (v0.1):**
 
-Returns: `list[AssetsDefinition]`
+```python
+from dagster_drt import drt_assets
+defs = Definitions(assets=drt_assets(project_dir="."))
+```
+
+**After (v0.2):**
+
+```python
+from dagster_drt import drt_assets, DagsterDrtResource
+
+@drt_assets(project_dir=".")
+def my_syncs(context, drt: DagsterDrtResource):
+    yield from drt.run(context=context)
+
+defs = Definitions(
+    assets=[my_syncs],
+    resources={"drt": DagsterDrtResource(project_dir=".")},
+)
+```
 
 ## License
 

--- a/integrations/dagster-drt/pyproject.toml
+++ b/integrations/dagster-drt/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dagster-drt"
-version = "0.1.0"
+version = "0.2.0"
 description = "Community-maintained Dagster integration for drt (data reverse tool)"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

- Rewrite dagster-drt README for new API (`@drt_assets`, `DagsterDrtResource`, `build_drt_asset_specs`)
- Add Pipes usage example and v0.1 → v0.2 migration guide
- Update all project-wide references (README, README.ja, CONTEXT.md, CHANGELOG, SECURITY)
- Update release-check skill for new API surface
- Bump version to 0.2.0

Closes #175

## Files changed (9)

| File | Change |
|---|---|
| `integrations/dagster-drt/README.md` | Full rewrite for new API |
| `integrations/dagster-drt/pyproject.toml` | 0.1.0 → 0.2.0 |
| `CHANGELOG.md` | v0.2.0 entry |
| `README.md` | dagster-drt section updated |
| `README.ja.md` | dagster-drt section updated (Japanese) |
| `docs/llm/CONTEXT.md` | dagster-drt section updated |
| `SECURITY.md` | 0.2.x added to supported |
| `.claude/commands/dagster-drt-release-check.md` | New API surface |
| `CONTRIBUTING.ja.md` | i18n sync hash fix |

## Test plan

- [x] 34 dagster-drt tests passing
- [x] 170 drt-core tests passing
- [x] `make check-i18n` passing
- [x] `make check-skills` passing
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)