### PR TITLE
feat: add SendGrid  destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Parquet file destination** (#171): Write sync results to local Parquet files using pandas + pyarrow. Supports snappy/gzip/zstd compression and partition columns. 11 unit tests. Install: `pip install drt-core[parquet]`.
 - **CSV/JSON/JSONL file destination** (#67): Write sync results to local CSV, JSON, or JSONL files. No extra dependencies — uses stdlib csv and json. 12 unit tests.
 - **Snowflake source connector** (#162): Extract data from Snowflake using `snowflake-connector-python`. Supports account, user, password/password_env, database, schema, warehouse, and optional role. Install: `pip install drt-core[snowflake]`.
+- **SendGrid email destination** (#194): Send transactional emails via SendGrid's v3 Mail Send API. Supports Jinja2 templates for subject and body, configurable recipient field, and bearer auth via env var.
 - **Dry-run summary** (#219): Enhanced `--dry-run` to show a summary including Source, Destination, Rows to sync, and Sync mode.
 - **Dockerfile and docker-compose example** (#161): Lightweight `python:3.12-slim` image with configurable `DRT_EXTRAS` build arg, non-root user, and pinned version. Includes `docker-compose.yml` and `.dockerignore`.
 

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -26,11 +26,11 @@ if TYPE_CHECKING:
     from drt.destinations.google_sheets import GoogleSheetsDestination
     from drt.destinations.hubspot import HubSpotDestination
     from drt.destinations.jira import JiraDestination
-    from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.mysql import MySQLDestination
     from drt.destinations.parquet import ParquetDestination
     from drt.destinations.postgres import PostgresDestination
     from drt.destinations.rest_api import RestApiDestination
+    from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.slack import SlackDestination
     from drt.destinations.teams import TeamsDestination
     from drt.sources.bigquery import BigQuerySource
@@ -521,11 +521,11 @@ def _get_destination(
         GoogleSheetsDestinationConfig,
         HubSpotDestinationConfig,
         JiraDestinationConfig,
-        SendGridDestinationConfig,
         MySQLDestinationConfig,
         ParquetDestinationConfig,
         PostgresDestinationConfig,
         RestApiDestinationConfig,
+        SendGridDestinationConfig,
         SlackDestinationConfig,
         TeamsDestinationConfig,
     )
@@ -534,10 +534,10 @@ def _get_destination(
     from drt.destinations.github_actions import GitHubActionsDestination
     from drt.destinations.hubspot import HubSpotDestination
     from drt.destinations.jira import JiraDestination
-    from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.mysql import MySQLDestination
     from drt.destinations.postgres import PostgresDestination
     from drt.destinations.rest_api import RestApiDestination
+    from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.slack import SlackDestination
 
     dest = sync.destination

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from drt.destinations.google_sheets import GoogleSheetsDestination
     from drt.destinations.hubspot import HubSpotDestination
     from drt.destinations.jira import JiraDestination
+    from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.mysql import MySQLDestination
     from drt.destinations.parquet import ParquetDestination
     from drt.destinations.postgres import PostgresDestination
@@ -503,6 +504,7 @@ def _get_destination(
     | GitHubActionsDestination
     | HubSpotDestination
     | JiraDestination
+    | SendGridDestination
     | GoogleSheetsDestination
     | PostgresDestination
     | MySQLDestination
@@ -519,6 +521,7 @@ def _get_destination(
         GoogleSheetsDestinationConfig,
         HubSpotDestinationConfig,
         JiraDestinationConfig,
+        SendGridDestinationConfig,
         MySQLDestinationConfig,
         ParquetDestinationConfig,
         PostgresDestinationConfig,
@@ -531,6 +534,7 @@ def _get_destination(
     from drt.destinations.github_actions import GitHubActionsDestination
     from drt.destinations.hubspot import HubSpotDestination
     from drt.destinations.jira import JiraDestination
+    from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.mysql import MySQLDestination
     from drt.destinations.postgres import PostgresDestination
     from drt.destinations.rest_api import RestApiDestination
@@ -549,6 +553,8 @@ def _get_destination(
         return HubSpotDestination()
     if isinstance(dest, JiraDestinationConfig):
         return JiraDestination()
+    if isinstance(dest, SendGridDestinationConfig):
+        return SendGridDestination()
     if isinstance(dest, GoogleSheetsDestinationConfig):
         from drt.destinations.google_sheets import GoogleSheetsDestination
 

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -148,10 +148,18 @@ class HubSpotDestinationConfig(BaseModel):
 
 class SendGridDestinationConfig(BaseModel):
     type: Literal["sendgrid"]
-    object_type: Literal["contacts", "deals", "companies"] = "contacts"
-    id_property: str = "email"
-    properties_template: str | None = None
-    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
+    # Sender info
+    from_email: str
+    from_name: str | None = None
+    # Templates
+    subject_template: str
+    body_template: str
+    # Optional: allow custom recipient field (default = "email")
+    to_email_field: str = "email" 
+    # Optional: SendGrid list IDs for recipient management
+    list_ids: list[str] | None = None 
+    # Auth (reuses shared AuthConfig)
+    auth: AuthConfig  
     
     
 class SslConfig(BaseModel):

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -148,20 +148,18 @@ class HubSpotDestinationConfig(BaseModel):
 
 class SendGridDestinationConfig(BaseModel):
     type: Literal["sendgrid"]
-    # Sender info
     from_email: str
     from_name: str | None = None
-    # Templates
     subject_template: str
     body_template: str
-    # Optional: allow custom recipient field (default = "email")
-    to_email_field: str = "email" 
-    # Optional: SendGrid list IDs for recipient management
-    list_ids: list[str] | None = None 
-    # Auth (reuses shared AuthConfig)
-    auth: AuthConfig  
-    
-    
+    to_email_field: str = "email"
+    list_ids: list[str] | None = None
+    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
+
+    def describe(self) -> str:
+        return f"sendgrid ({self.from_email})"
+
+
 class SslConfig(BaseModel):
     """SSL/TLS connection options for DB destinations."""
 

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -146,6 +146,14 @@ class HubSpotDestinationConfig(BaseModel):
         return f"{self.type} ({self.object_type})"
 
 
+class SendGridDestinationConfig(BaseModel):
+    type: Literal["sendgrid"]
+    object_type: Literal["contacts", "deals", "companies"] = "contacts"
+    id_property: str = "email"
+    properties_template: str | None = None
+    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
+    
+    
 class SslConfig(BaseModel):
     """SSL/TLS connection options for DB destinations."""
 
@@ -302,6 +310,7 @@ DestinationConfig = Annotated[
     | DiscordDestinationConfig
     | GitHubActionsDestinationConfig
     | HubSpotDestinationConfig
+    | SendGridDestinationConfig
     | GoogleSheetsDestinationConfig
     | PostgresDestinationConfig
     | MySQLDestinationConfig

--- a/drt/destinations/sendgrid.py
+++ b/drt/destinations/sendgrid.py
@@ -1,0 +1,261 @@
+"""SendGrid destination — Marketing Contacts upsert + transactional emails.
+
+Supports:
+1. Upserting contacts into SendGrid Marketing Contacts.
+2. Sending transactional emails per row (e.g. onboarding emails, alerts, billing reminders).
+
+Contacts:
+- Upserts contacts using the SendGrid v3 Marketing Contacts API.
+- Deduplicates automatically by email.
+
+Transactional Emails:
+- Sends one email per row using dynamic templates.
+- Useful for onboarding emails, alert notifications, billing reminders, etc.
+
+Requires: SENDGRID_API_KEY (API key with Marketing and/or Mail Send permissions).
+
+Example sync YAML — transactional emails:
+
+    destination:
+      type: sendgrid
+      from_email: "noreply@example.com"
+      from_name: "My App"
+      subject_template: "Welcome, {{ row.first_name }}!"
+      body_template: |
+        Hi {{ row.first_name }},
+
+        Thanks for signing up. Your account is ready.
+      auth:
+        type: bearer
+        token_env: SENDGRID_API_KEY
+
+Example sync YAML — contacts:
+
+    destination:
+      type: sendgrid
+      list_ids: ["your-list-id"]
+      properties_template: |
+        {
+          "email": "{{ row.email }}",
+          "first_name": "{{ row.first_name }}",
+          "last_name": "{{ row.last_name }}"
+        }
+      auth:
+        type: bearer
+        token_env: SENDGRID_API_KEY
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+from drt.config.credentials import resolve_env
+from drt.config.models import SendGridDestinationConfig, RetryConfig, SyncOptions
+from drt.destinations.base import SyncResult
+from drt.destinations.rate_limiter import RateLimiter
+from drt.destinations.retry import with_retry
+from drt.destinations.row_errors import RowError
+from drt.templates.renderer import render_template
+
+
+_SENDGRID_CONTACTS_API = "https://api.sendgrid.com/v3/marketing/contacts"
+_SENDGRID_MAIL_API = "https://api.sendgrid.com/v3/mail/send"
+
+_DEFAULT_RETRY = RetryConfig(
+    max_attempts=3,
+    initial_backoff=1.0,
+    retryable_status_codes=(429, 500, 502, 503, 504),
+)
+
+
+class SendGridDestination:
+    """SendGrid destination supporting contacts + transactional email."""
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: SendGridDestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        token = resolve_env(config.auth.token, config.auth.token_env)
+        if not token:
+            raise ValueError(
+                "SendGrid destination: set SENDGRID_API_KEY env var "
+                "or provide auth.token_env in the sync config."
+            )
+
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+        result = SyncResult()
+        rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
+
+        # Detect mode
+        is_email_mode = hasattr(config, "subject_template") and hasattr(config, "body_template")
+
+        with httpx.Client(timeout=30.0) as client:
+
+            # =========================
+            # 📧 TRANSACTIONAL EMAIL MODE
+            # =========================
+            if is_email_mode:
+                for i, record in enumerate(records):
+                    rate_limiter.acquire()
+
+                    try:
+                        to_email = record.get("email")
+                        if not to_email:
+                            raise ValueError("Missing required field: email")
+
+                        subject = render_template(config.subject_template, record)
+                        body = render_template(config.body_template, record)
+
+                        payload = {
+                            "personalizations": [
+                                {
+                                    "to": [{"email": to_email}]
+                                }
+                            ],
+                            "from": {
+                                "email": config.from_email,
+                                **({"name": config.from_name} if getattr(config, "from_name", None) else {}),
+                            },
+                            "subject": subject,
+                            "content": [
+                                {
+                                    "type": "text/plain",
+                                    "value": body,
+                                }
+                            ],
+                        }
+
+                        def send_email() -> httpx.Response:
+                            response = client.post(
+                                _SENDGRID_MAIL_API,
+                                json=payload,
+                                headers=headers,
+                            )
+                            response.raise_for_status()
+                            return response
+
+                        with_retry(send_email, _DEFAULT_RETRY)
+                        result.success += 1
+
+                    except httpx.HTTPStatusError as e:
+                        result.failed += 1
+                        result.row_errors.append(
+                            RowError(
+                                batch_index=i,
+                                record_preview=json.dumps(record)[:200],
+                                http_status=e.response.status_code,
+                                error_message=e.response.text[:500],
+                            )
+                        )
+
+                    except Exception as e:
+                        result.failed += 1
+                        result.row_errors.append(
+                            RowError(
+                                batch_index=i,
+                                record_preview=json.dumps(record)[:200],
+                                http_status=None,
+                                error_message=str(e),
+                            )
+                        )
+
+            # =========================
+            # 👥 CONTACTS MODE (BATCH)
+            # =========================
+            else:
+                batch_size = min(1000, getattr(sync_options, "batch_size", 1000))
+
+                def chunked(data: list[dict[str, Any]], size: int):
+                    for i in range(0, len(data), size):
+                        yield i, data[i : i + size]
+
+                for batch_index, batch in chunked(records, batch_size):
+                    rate_limiter.acquire()
+
+                    contacts = []
+                    row_map = []
+
+                    for i, record in enumerate(batch):
+                        global_index = batch_index + i
+
+                        try:
+                            if config.properties_template:
+                                rendered = render_template(
+                                    config.properties_template, record
+                                )
+                                contact = json.loads(rendered)
+                            else:
+                                contact = record
+
+                            if "email" not in contact:
+                                raise ValueError("Missing required field: email")
+
+                            contacts.append(contact)
+                            row_map.append(global_index)
+
+                        except Exception as e:
+                            result.failed += 1
+                            result.row_errors.append(
+                                RowError(
+                                    batch_index=global_index,
+                                    record_preview=json.dumps(record)[:200],
+                                    http_status=None,
+                                    error_message=str(e),
+                                )
+                            )
+
+                    if not contacts:
+                        continue
+
+                    payload: dict[str, Any] = {"contacts": contacts}
+
+                    if getattr(config, "list_ids", None):
+                        payload["list_ids"] = config.list_ids
+
+                    def upsert_contacts() -> httpx.Response:
+                        response = client.put(
+                            _SENDGRID_CONTACTS_API,
+                            json=payload,
+                            headers=headers,
+                        )
+                        response.raise_for_status()
+                        return response
+
+                    try:
+                        with_retry(upsert_contacts, _DEFAULT_RETRY)
+                        result.success += len(contacts)
+
+                    except httpx.HTTPStatusError as e:
+                        for idx in row_map:
+                            result.failed += 1
+                            result.row_errors.append(
+                                RowError(
+                                    batch_index=idx,
+                                    record_preview="batch item",
+                                    http_status=e.response.status_code,
+                                    error_message=e.response.text[:500],
+                                )
+                            )
+
+                    except Exception as e:
+                        for idx in row_map:
+                            result.failed += 1
+                            result.row_errors.append(
+                                RowError(
+                                    batch_index=idx,
+                                    record_preview="batch item",
+                                    http_status=None,
+                                    error_message=str(e),
+                                )
+                            )
+
+        return result

--- a/drt/destinations/sendgrid.py
+++ b/drt/destinations/sendgrid.py
@@ -16,7 +16,6 @@ Example sync YAML:
         Hi {{ row.first_name }},
 
         Thanks for signing up. Your account is ready.
-      list_ids: ["abc123"]
       auth:
         type: bearer
         token_env: SENDGRID_API_KEY
@@ -25,34 +24,25 @@ SendGrid API reference:
     Endpoint: POST https://api.sendgrid.com/v3/mail/send
     Docs: https://docs.sendgrid.com/api-reference/mail-send/mail-send
     Auth: Authorization: Bearer <SENDGRID_API_KEY>
-
-Example payload:
-    {
-      "personalizations": [{"to": [{"email": "user@example.com"}]}],
-      "from": {"email": "noreply@example.com"},
-      "subject": "Welcome!",
-      "content": [{"type": "text/plain", "value": "Hi there"}]
-    }
 """
 
 from __future__ import annotations
 
 import json
-import os
+import logging
 from typing import Any
 
 import httpx
 
-from drt.config.models import (
-    SendGridDestinationConfig,
-    RetryConfig,
-    SyncOptions,
-)
+from drt.config.credentials import resolve_env
+from drt.config.models import DestinationConfig, RetryConfig, SendGridDestinationConfig, SyncOptions
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter
 from drt.destinations.retry import with_retry
 from drt.destinations.row_errors import RowError
 from drt.templates.renderer import render_template
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_RETRY = RetryConfig(
     max_attempts=3,
@@ -60,39 +50,31 @@ _DEFAULT_RETRY = RetryConfig(
     retryable_status_codes=(429, 500, 502, 503, 504),
 )
 
+_SENDGRID_API_URL = "https://api.sendgrid.com/v3/mail/send"
+
+
+def _record_preview(row: dict[str, Any]) -> str:
+    return json.dumps(row, default=str)[:200]
+
 
 class SendGridDestination:
     """Send records as transactional emails via SendGrid."""
 
-    SENDGRID_API_URL = "https://api.sendgrid.com/v3/mail/send"
-
     def load(
         self,
         records: list[dict[str, Any]],
-        config: SendGridDestinationConfig,
+        config: DestinationConfig,
         sync_options: SyncOptions,
     ) -> SyncResult:
         assert isinstance(config, SendGridDestinationConfig)
 
-        # --- Auth (explicit, no getattr) ---
-        if config.auth.type != "bearer":
-            raise ValueError("SendGrid destination requires bearer auth.")
-
-        api_key = config.auth.token or (
-            os.environ.get(config.auth.token_env)
-            if config.auth.token_env
-            else None
-        )
-
+        api_key = resolve_env(config.auth.token, config.auth.token_env)
         if not api_key:
             raise ValueError(
                 "SendGrid destination: missing API key via auth.token or auth.token_env."
             )
 
-        # --- Required fields (already enforced by Pydantic, but kept for clarity) ---
-        if not config.from_email:
-            raise ValueError("SendGrid destination: 'from_email' is required.")
-
+        retry_config = sync_options.retry or _DEFAULT_RETRY
         result = SyncResult()
         rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
 
@@ -105,18 +87,15 @@ class SendGridDestination:
             for i, record in enumerate(records):
                 rate_limiter.acquire()
                 try:
-                    # --- Render templates ---
                     subject = render_template(config.subject_template, record)
                     body = render_template(config.body_template, record)
 
-                    # --- Resolve recipient ---
                     to_email = record.get(config.to_email_field)
                     if not to_email:
                         raise ValueError(
                             f"Record missing '{config.to_email_field}' field for recipient."
                         )
 
-                    # --- Build payload (SendGrid spec) ---
                     payload: dict[str, Any] = {
                         "personalizations": [
                             {
@@ -136,21 +115,16 @@ class SendGridDestination:
                         ],
                     }
 
-                    # --- Optional list_ids (explicit field) ---
-                    if config.list_ids:
-                        payload["list_ids"] = config.list_ids
-
-                    # --- HTTP send with retry ---
-                    def do_post() -> httpx.Response:
+                    def do_post(_payload: dict[str, Any] = payload) -> httpx.Response:
                         response = client.post(
-                            self.SENDGRID_API_URL,
+                            _SENDGRID_API_URL,
                             headers=headers,
-                            json=payload,
+                            json=_payload,
                         )
                         response.raise_for_status()
                         return response
 
-                    with_retry(do_post, _DEFAULT_RETRY)
+                    with_retry(do_post, retry_config)
                     result.success += 1
 
                 except httpx.HTTPStatusError as e:
@@ -158,31 +132,36 @@ class SendGridDestination:
                     result.row_errors.append(
                         RowError(
                             batch_index=i,
-                            record_preview=json.dumps(record)[:200],
+                            record_preview=_record_preview(record),
                             http_status=e.response.status_code,
                             error_message=e.response.text[:500],
                         )
                     )
+                    if sync_options.on_error == "fail":
+                        break
                 except httpx.RequestError as e:
                     result.failed += 1
                     result.row_errors.append(
                         RowError(
                             batch_index=i,
-                            record_preview=json.dumps(record)[:200],
+                            record_preview=_record_preview(record),
                             http_status=None,
-                            error_message=f"Request error: {str(e)}",
+                            error_message=f"Request error: {e}",
                         )
                     )
+                    if sync_options.on_error == "fail":
+                        break
                 except Exception as e:
                     result.failed += 1
                     result.row_errors.append(
                         RowError(
                             batch_index=i,
-                            record_preview=json.dumps(record)[:200],
+                            record_preview=_record_preview(record),
                             http_status=None,
                             error_message=str(e),
                         )
                     )
+                    if sync_options.on_error == "fail":
+                        break
 
         return result
-    

--- a/drt/destinations/sendgrid.py
+++ b/drt/destinations/sendgrid.py
@@ -1,20 +1,11 @@
-"""SendGrid destination — Marketing Contacts upsert + transactional emails.
+"""SendGrid destination — Transactional Email Integration.
 
-Supports:
-1. Upserting contacts into SendGrid Marketing Contacts.
-2. Sending transactional emails per row (e.g. onboarding emails, alerts, billing reminders).
+Sends one email per record using SendGrid's v3 Mail Send API.
+Supports subject + body templating via Jinja2.
 
-Contacts:
-- Upserts contacts using the SendGrid v3 Marketing Contacts API.
-- Deduplicates automatically by email.
+No extra dependencies required (uses httpx from core).
 
-Transactional Emails:
-- Sends one email per row using dynamic templates.
-- Useful for onboarding emails, alert notifications, billing reminders, etc.
-
-Requires: SENDGRID_API_KEY (API key with Marketing and/or Mail Send permissions).
-
-Example sync YAML — transactional emails:
+Example sync YAML:
 
     destination:
       type: sendgrid
@@ -25,44 +16,43 @@ Example sync YAML — transactional emails:
         Hi {{ row.first_name }},
 
         Thanks for signing up. Your account is ready.
+      list_ids: ["abc123"]
       auth:
         type: bearer
         token_env: SENDGRID_API_KEY
 
-Example sync YAML — contacts:
+SendGrid API reference:
+    Endpoint: POST https://api.sendgrid.com/v3/mail/send
+    Docs: https://docs.sendgrid.com/api-reference/mail-send/mail-send
+    Auth: Authorization: Bearer <SENDGRID_API_KEY>
 
-    destination:
-      type: sendgrid
-      list_ids: ["your-list-id"]
-      properties_template: |
-        {
-          "email": "{{ row.email }}",
-          "first_name": "{{ row.first_name }}",
-          "last_name": "{{ row.last_name }}"
-        }
-      auth:
-        type: bearer
-        token_env: SENDGRID_API_KEY
+Example payload:
+    {
+      "personalizations": [{"to": [{"email": "user@example.com"}]}],
+      "from": {"email": "noreply@example.com"},
+      "subject": "Welcome!",
+      "content": [{"type": "text/plain", "value": "Hi there"}]
+    }
 """
 
 from __future__ import annotations
 
 import json
+import os
 from typing import Any
 
 import httpx
 
-from drt.config.credentials import resolve_env
-from drt.config.models import SendGridDestinationConfig, RetryConfig, SyncOptions
+from drt.config.models import (
+    SendGridDestinationConfig,
+    RetryConfig,
+    SyncOptions,
+)
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter
 from drt.destinations.retry import with_retry
 from drt.destinations.row_errors import RowError
 from drt.templates.renderer import render_template
-
-
-_SENDGRID_CONTACTS_API = "https://api.sendgrid.com/v3/marketing/contacts"
-_SENDGRID_MAIL_API = "https://api.sendgrid.com/v3/mail/send"
 
 _DEFAULT_RETRY = RetryConfig(
     max_attempts=3,
@@ -72,7 +62,9 @@ _DEFAULT_RETRY = RetryConfig(
 
 
 class SendGridDestination:
-    """SendGrid destination supporting contacts + transactional email."""
+    """Send records as transactional emails via SendGrid."""
+
+    SENDGRID_API_URL = "https://api.sendgrid.com/v3/mail/send"
 
     def load(
         self,
@@ -80,182 +72,117 @@ class SendGridDestination:
         config: SendGridDestinationConfig,
         sync_options: SyncOptions,
     ) -> SyncResult:
-        token = resolve_env(config.auth.token, config.auth.token_env)
-        if not token:
+        assert isinstance(config, SendGridDestinationConfig)
+
+        # --- Auth (explicit, no getattr) ---
+        if config.auth.type != "bearer":
+            raise ValueError("SendGrid destination requires bearer auth.")
+
+        api_key = config.auth.token or (
+            os.environ.get(config.auth.token_env)
+            if config.auth.token_env
+            else None
+        )
+
+        if not api_key:
             raise ValueError(
-                "SendGrid destination: set SENDGRID_API_KEY env var "
-                "or provide auth.token_env in the sync config."
+                "SendGrid destination: missing API key via auth.token or auth.token_env."
             )
 
-        headers = {
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        }
+        # --- Required fields (already enforced by Pydantic, but kept for clarity) ---
+        if not config.from_email:
+            raise ValueError("SendGrid destination: 'from_email' is required.")
 
         result = SyncResult()
         rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
 
-        # Detect mode
-        is_email_mode = hasattr(config, "subject_template") and hasattr(config, "body_template")
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
 
         with httpx.Client(timeout=30.0) as client:
+            for i, record in enumerate(records):
+                rate_limiter.acquire()
+                try:
+                    # --- Render templates ---
+                    subject = render_template(config.subject_template, record)
+                    body = render_template(config.body_template, record)
 
-            # =========================
-            # 📧 TRANSACTIONAL EMAIL MODE
-            # =========================
-            if is_email_mode:
-                for i, record in enumerate(records):
-                    rate_limiter.acquire()
-
-                    try:
-                        to_email = record.get("email")
-                        if not to_email:
-                            raise ValueError("Missing required field: email")
-
-                        subject = render_template(config.subject_template, record)
-                        body = render_template(config.body_template, record)
-
-                        payload = {
-                            "personalizations": [
-                                {
-                                    "to": [{"email": to_email}]
-                                }
-                            ],
-                            "from": {
-                                "email": config.from_email,
-                                **({"name": config.from_name} if getattr(config, "from_name", None) else {}),
-                            },
-                            "subject": subject,
-                            "content": [
-                                {
-                                    "type": "text/plain",
-                                    "value": body,
-                                }
-                            ],
-                        }
-
-                        def send_email() -> httpx.Response:
-                            response = client.post(
-                                _SENDGRID_MAIL_API,
-                                json=payload,
-                                headers=headers,
-                            )
-                            response.raise_for_status()
-                            return response
-
-                        with_retry(send_email, _DEFAULT_RETRY)
-                        result.success += 1
-
-                    except httpx.HTTPStatusError as e:
-                        result.failed += 1
-                        result.row_errors.append(
-                            RowError(
-                                batch_index=i,
-                                record_preview=json.dumps(record)[:200],
-                                http_status=e.response.status_code,
-                                error_message=e.response.text[:500],
-                            )
+                    # --- Resolve recipient ---
+                    to_email = record.get(config.to_email_field)
+                    if not to_email:
+                        raise ValueError(
+                            f"Record missing '{config.to_email_field}' field for recipient."
                         )
 
-                    except Exception as e:
-                        result.failed += 1
-                        result.row_errors.append(
-                            RowError(
-                                batch_index=i,
-                                record_preview=json.dumps(record)[:200],
-                                http_status=None,
-                                error_message=str(e),
-                            )
-                        )
+                    # --- Build payload (SendGrid spec) ---
+                    payload: dict[str, Any] = {
+                        "personalizations": [
+                            {
+                                "to": [{"email": to_email}],
+                                "subject": subject,
+                            }
+                        ],
+                        "from": {
+                            "email": config.from_email,
+                            **({"name": config.from_name} if config.from_name else {}),
+                        },
+                        "content": [
+                            {
+                                "type": "text/plain",
+                                "value": body,
+                            }
+                        ],
+                    }
 
-            # =========================
-            # 👥 CONTACTS MODE (BATCH)
-            # =========================
-            else:
-                batch_size = min(1000, getattr(sync_options, "batch_size", 1000))
-
-                def chunked(data: list[dict[str, Any]], size: int):
-                    for i in range(0, len(data), size):
-                        yield i, data[i : i + size]
-
-                for batch_index, batch in chunked(records, batch_size):
-                    rate_limiter.acquire()
-
-                    contacts = []
-                    row_map = []
-
-                    for i, record in enumerate(batch):
-                        global_index = batch_index + i
-
-                        try:
-                            if config.properties_template:
-                                rendered = render_template(
-                                    config.properties_template, record
-                                )
-                                contact = json.loads(rendered)
-                            else:
-                                contact = record
-
-                            if "email" not in contact:
-                                raise ValueError("Missing required field: email")
-
-                            contacts.append(contact)
-                            row_map.append(global_index)
-
-                        except Exception as e:
-                            result.failed += 1
-                            result.row_errors.append(
-                                RowError(
-                                    batch_index=global_index,
-                                    record_preview=json.dumps(record)[:200],
-                                    http_status=None,
-                                    error_message=str(e),
-                                )
-                            )
-
-                    if not contacts:
-                        continue
-
-                    payload: dict[str, Any] = {"contacts": contacts}
-
-                    if getattr(config, "list_ids", None):
+                    # --- Optional list_ids (explicit field) ---
+                    if config.list_ids:
                         payload["list_ids"] = config.list_ids
 
-                    def upsert_contacts() -> httpx.Response:
-                        response = client.put(
-                            _SENDGRID_CONTACTS_API,
-                            json=payload,
+                    # --- HTTP send with retry ---
+                    def do_post() -> httpx.Response:
+                        response = client.post(
+                            self.SENDGRID_API_URL,
                             headers=headers,
+                            json=payload,
                         )
                         response.raise_for_status()
                         return response
 
-                    try:
-                        with_retry(upsert_contacts, _DEFAULT_RETRY)
-                        result.success += len(contacts)
+                    with_retry(do_post, _DEFAULT_RETRY)
+                    result.success += 1
 
-                    except httpx.HTTPStatusError as e:
-                        for idx in row_map:
-                            result.failed += 1
-                            result.row_errors.append(
-                                RowError(
-                                    batch_index=idx,
-                                    record_preview="batch item",
-                                    http_status=e.response.status_code,
-                                    error_message=e.response.text[:500],
-                                )
-                            )
-
-                    except Exception as e:
-                        for idx in row_map:
-                            result.failed += 1
-                            result.row_errors.append(
-                                RowError(
-                                    batch_index=idx,
-                                    record_preview="batch item",
-                                    http_status=None,
-                                    error_message=str(e),
-                                )
-                            )
+                except httpx.HTTPStatusError as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=e.response.status_code,
+                            error_message=e.response.text[:500],
+                        )
+                    )
+                except httpx.RequestError as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=None,
+                            error_message=f"Request error: {str(e)}",
+                        )
+                    )
+                except Exception as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=None,
+                            error_message=str(e),
+                        )
+                    )
 
         return result
+    

--- a/tests/unit/test_sendgrid.py
+++ b/tests/unit/test_sendgrid.py
@@ -1,140 +1,163 @@
 """Unit tests for SendGrid destination."""
 
-# test_sendgrid.py
-import json
-import pytest
+from __future__ import annotations
+
 from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
 from drt.config.models import (
     SendGridDestinationConfig,
-    BearerAuth,
-    SyncOptions,
     RateLimitConfig,
+    SyncOptions,
+    BearerAuth,
 )
 from drt.destinations.sendgrid import SendGridDestination
-from drt.destinations.base import SyncResult
 
-# ---------------------------------
-# Subclass for email-mode testing
-# ---------------------------------
-class TestSendGridDestinationConfig(SendGridDestinationConfig):
-    from_email: str
-    from_name: str | None = None
-    subject_template: str
-    body_template: str
 
-# ---------------------------------
-# Fixtures
-# ---------------------------------
-@pytest.fixture
-def dummy_records():
-    return [
-        {"email": "alice@example.com", "first_name": "Alice", "last_name": "Smith"},
-        {"email": "bob@example.com", "first_name": "Bob", "last_name": "Jones"},
-    ]
+def _config(**overrides):
+    defaults = {
+        "type": "sendgrid",
+        "from_email": "noreply@example.com",
+        "from_name": "My App",
+        "subject_template": "Hello {{ row.first_name }}",
+        "body_template": "Welcome {{ row.first_name }}",
+        "to_email_field": "email",
+        "list_ids": None,
+        "auth": BearerAuth(type="bearer", token="test-api-key"),
+    }
+    defaults.update(overrides)
+    return SendGridDestinationConfig(**defaults)
 
-@pytest.fixture
-def email_config():
-    return TestSendGridDestinationConfig(
-        type="sendgrid",
-        from_email="noreply@test.com",
-        from_name="Test Sender",
-        subject_template="Hello {{ row.first_name }}",
-        body_template="Welcome {{ row.first_name }}!",
-        auth=BearerAuth(type="bearer", token=None, token_env="SENDGRID_API_KEY"),
-        properties_template=None
-    )
 
-@pytest.fixture
-def contacts_config():
-    return SendGridDestinationConfig(
-        type="sendgrid",
-        properties_template='{"email": "{{ row.email }}", "first_name": "{{ row.first_name }}"}',
-        auth=BearerAuth(type="bearer", token=None, token_env="SENDGRID_API_KEY"),
-    )
-
-@pytest.fixture
-def sync_options():
+def _sync_options():
     return SyncOptions(
-        rate_limit=RateLimitConfig(requests_per_second=10),
-        batch_size=2
+        mode="full",
+        batch_size=100,
+        on_error="skip",
+        rate_limit=RateLimitConfig(requests_per_second=0),
     )
 
-# ---------------------------------
-# Fake SendGridDestination
-# ---------------------------------
-class FakeSendGridDestination(SendGridDestination):
-    """Simulate SendGridDestination without real HTTP calls."""
-    def __init__(self):
-        super().__init__()
-        self.sent_emails = []
-        self.upserted_contacts = []
 
-    def load(self, records, config, sync_options):
-        result = SyncResult()
-        is_email_mode = hasattr(config, "subject_template") and hasattr(config, "body_template")
-        if is_email_mode:
-            for record in records:
-                if not record.get("email"):
-                    result.failed += 1
-                    continue
-                self.sent_emails.append(record)
-                result.success += 1
-        else:
-            for record in records:
-                rendered = config.properties_template.replace("{{ row.email }}", record["email"]) \
-                                                     .replace("{{ row.first_name }}", record["first_name"])
-                contact = json.loads(rendered)
-                self.upserted_contacts.append(contact)
-                result.success += 1
-        return result
+@pytest.fixture
+def mock_sendgrid_client():
+    with patch("drt.destinations.sendgrid.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
 
-# ---------------------------------
-# Tests
-# ---------------------------------
-def test_sendgrid_email_mode_success(dummy_records, email_config, sync_options):
-    dest = FakeSendGridDestination()
-    with patch("sendgrid.render_template", side_effect=lambda template, row: template.replace("{{ row.first_name }}", row["first_name"])):
-        result = dest.load(dummy_records, email_config, sync_options)
-    assert result.success == len(dummy_records)
-    assert result.failed == 0
-    assert len(dest.sent_emails) == len(dummy_records)
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
 
-def test_sendgrid_contacts_mode_success(dummy_records, contacts_config, sync_options):
-    dest = FakeSendGridDestination()
-    with patch("sendgrid.render_template", side_effect=lambda template, row: template.replace("{{ row.first_name }}", row["first_name"]).replace("{{ row.email }}", row["email"])):
-        result = dest.load(dummy_records, contacts_config, sync_options)
-    assert result.success == len(dummy_records)
-    assert result.failed == 0
-    assert len(dest.upserted_contacts) == len(dummy_records)
+        mock_client.post.return_value = mock_response
 
-def test_sendgrid_missing_email_fails(dummy_records, email_config, sync_options):
-    dest = FakeSendGridDestination()
-    dummy_records[0].pop("email")
-    with patch("sendgrid.render_template", side_effect=lambda template, row: template.replace("{{ row.first_name }}", row["first_name"])):
-        result = dest.load(dummy_records, email_config, sync_options)
-    assert result.success == 1
-    assert result.failed == 1
-    assert len(dest.sent_emails) == 1
+        yield mock_client, mock_response
 
-def test_sendgrid_simulated_failure(dummy_records, contacts_config, sync_options):
-    class FailingDestination(FakeSendGridDestination):
-        def load(self, records, config, sync_options):
-            result = super().load(records, config, sync_options)
-            if records:
-                result.success -= 1
-                result.failed += 1
-            return result
-    dest = FailingDestination()
-    with patch("sendgrid.render_template", side_effect=lambda template, row: template.replace("{{ row.first_name }}", row["first_name"]).replace("{{ row.email }}", row["email"])):
-        result = dest.load(dummy_records, contacts_config, sync_options)
-    assert result.success == len(dummy_records) - 1
-    assert result.failed == 1
 
-def test_render_template_called_with_correct_args(dummy_records, email_config, sync_options):
-    dest = FakeSendGridDestination()
-    mock_render = MagicMock(side_effect=lambda template, row: template.replace("{{ row.first_name }}", row["first_name"]))
-    with patch("sendgrid.render_template", mock_render):
-        dest.load(dummy_records, email_config, sync_options)
-    for record in dummy_records:
-        mock_render.assert_any_call(email_config.subject_template, record)
-        mock_render.assert_any_call(email_config.body_template, record)
+class TestSendGridDestination:
+    def test_sends_email_success(self, mock_sendgrid_client):
+        mock_client, _ = mock_sendgrid_client
+
+        dest = SendGridDestination()
+        result = dest.load(
+            [{"first_name": "Alice", "email": "alice@example.com"}],
+            _config(),
+            _sync_options(),
+        )
+
+        assert result.success == 1
+        assert result.failed == 0
+
+        mock_client.post.assert_called_once()
+        payload = mock_client.post.call_args[1]["json"]
+
+        assert payload["personalizations"][0]["to"][0]["email"] == "alice@example.com"
+        assert payload["personalizations"][0]["subject"] == "Hello Alice"
+        assert payload["content"][0]["value"] == "Welcome Alice"
+
+    def test_auth_error_missing_api_key(self):
+        dest = SendGridDestination()
+
+        config = _config(auth=BearerAuth(type="bearer", token=None, token_env=None))
+
+        with pytest.raises(ValueError, match="missing API key"):
+            dest.load(
+                [{"first_name": "Alice", "email": "alice@example.com"}],
+                config,
+                _sync_options(),
+            )
+
+    def test_template_error(self, mock_sendgrid_client):
+        with patch(
+            "drt.destinations.sendgrid.render_template",
+            side_effect=Exception("Template failed"),
+        ):
+            dest = SendGridDestination()
+
+            result = dest.load(
+                [{"first_name": "Alice", "email": "alice@example.com"}],
+                _config(),
+                _sync_options(),
+            )
+
+        assert result.success == 0
+        assert result.failed == 1
+        assert "Template failed" in result.row_errors[0].error_message
+
+    def test_rate_limit_called_per_record(self, mock_sendgrid_client):
+        with patch("drt.destinations.sendgrid.RateLimiter") as mock_rl_cls:
+            mock_rl = MagicMock()
+            mock_rl_cls.return_value = mock_rl
+
+            dest = SendGridDestination()
+            records = [
+                {"first_name": f"user{i}", "email": f"user{i}@example.com"}
+                for i in range(3)
+            ]
+
+            dest.load(records, _config(), _sync_options())
+
+            assert mock_rl.acquire.call_count == 3
+
+    def test_retry_on_failure(self, mock_sendgrid_client):
+        mock_client, mock_response = mock_sendgrid_client
+
+        error_response = MagicMock()
+        error_response.status_code = 500
+        error_response.text = "Server Error"
+
+        def fail_once_then_succeed(*args, **kwargs):
+            if not hasattr(fail_once_then_succeed, "called"):
+                fail_once_then_succeed.called = True
+                raise httpx.HTTPStatusError(
+                    "500", request=MagicMock(), response=error_response
+                )
+            return mock_response
+
+        mock_client.post.side_effect = fail_once_then_succeed
+
+        dest = SendGridDestination()
+        result = dest.load(
+            [{"first_name": "Alice", "email": "alice@example.com"}],
+            _config(),
+            _sync_options(),
+        )
+
+        assert result.success == 1
+        assert result.failed == 0
+        assert mock_client.post.call_count >= 2
+
+    def test_missing_email_field_fails(self, mock_sendgrid_client):
+        dest = SendGridDestination()
+
+        result = dest.load(
+            [{"first_name": "Alice"}],  # no email
+            _config(),
+            _sync_options(),
+        )
+
+        assert result.success == 0
+        assert result.failed == 1
+        assert "missing 'email'" in result.row_errors[0].error_message
+        

--- a/tests/unit/test_sendgrid.py
+++ b/tests/unit/test_sendgrid.py
@@ -1,0 +1,140 @@
+"""Unit tests for SendGrid destination."""
+
+# test_sendgrid.py
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+from drt.config.models import (
+    SendGridDestinationConfig,
+    BearerAuth,
+    SyncOptions,
+    RateLimitConfig,
+)
+from drt.destinations.sendgrid import SendGridDestination
+from drt.destinations.base import SyncResult
+
+# ---------------------------------
+# Subclass for email-mode testing
+# ---------------------------------
+class TestSendGridDestinationConfig(SendGridDestinationConfig):
+    from_email: str
+    from_name: str | None = None
+    subject_template: str
+    body_template: str
+
+# ---------------------------------
+# Fixtures
+# ---------------------------------
+@pytest.fixture
+def dummy_records():
+    return [
+        {"email": "alice@example.com", "first_name": "Alice", "last_name": "Smith"},
+        {"email": "bob@example.com", "first_name": "Bob", "last_name": "Jones"},
+    ]
+
+@pytest.fixture
+def email_config():
+    return TestSendGridDestinationConfig(
+        type="sendgrid",
+        from_email="noreply@test.com",
+        from_name="Test Sender",
+        subject_template="Hello {{ row.first_name }}",
+        body_template="Welcome {{ row.first_name }}!",
+        auth=BearerAuth(type="bearer", token=None, token_env="SENDGRID_API_KEY"),
+        properties_template=None
+    )
+
+@pytest.fixture
+def contacts_config():
+    return SendGridDestinationConfig(
+        type="sendgrid",
+        properties_template='{"email": "{{ row.email }}", "first_name": "{{ row.first_name }}"}',
+        auth=BearerAuth(type="bearer", token=None, token_env="SENDGRID_API_KEY"),
+    )
+
+@pytest.fixture
+def sync_options():
+    return SyncOptions(
+        rate_limit=RateLimitConfig(requests_per_second=10),
+        batch_size=2
+    )
+
+# ---------------------------------
+# Fake SendGridDestination
+# ---------------------------------
+class FakeSendGridDestination(SendGridDestination):
+    """Simulate SendGridDestination without real HTTP calls."""
+    def __init__(self):
+        super().__init__()
+        self.sent_emails = []
+        self.upserted_contacts = []
+
+    def load(self, records, config, sync_options):
+        result = SyncResult()
+        is_email_mode = hasattr(config, "subject_template") and hasattr(config, "body_template")
+        if is_email_mode:
+            for record in records:
+                if not record.get("email"):
+                    result.failed += 1
+                    continue
+                self.sent_emails.append(record)
+                result.success += 1
+        else:
+            for record in records:
+                rendered = config.properties_template.replace("{{ row.email }}", record["email"]) \
+                                                     .replace("{{ row.first_name }}", record["first_name"])
+                contact = json.loads(rendered)
+                self.upserted_contacts.append(contact)
+                result.success += 1
+        return result
+
+# ---------------------------------
+# Tests
+# ---------------------------------
+def test_sendgrid_email_mode_success(dummy_records, email_config, sync_options):
+    dest = FakeSendGridDestination()
+    with patch("sendgrid.render_template", side_effect=lambda template, row: template.replace("{{ row.first_name }}", row["first_name"])):
+        result = dest.load(dummy_records, email_config, sync_options)
+    assert result.success == len(dummy_records)
+    assert result.failed == 0
+    assert len(dest.sent_emails) == len(dummy_records)
+
+def test_sendgrid_contacts_mode_success(dummy_records, contacts_config, sync_options):
+    dest = FakeSendGridDestination()
+    with patch("sendgrid.render_template", side_effect=lambda template, row: template.replace("{{ row.first_name }}", row["first_name"]).replace("{{ row.email }}", row["email"])):
+        result = dest.load(dummy_records, contacts_config, sync_options)
+    assert result.success == len(dummy_records)
+    assert result.failed == 0
+    assert len(dest.upserted_contacts) == len(dummy_records)
+
+def test_sendgrid_missing_email_fails(dummy_records, email_config, sync_options):
+    dest = FakeSendGridDestination()
+    dummy_records[0].pop("email")
+    with patch("sendgrid.render_template", side_effect=lambda template, row: template.replace("{{ row.first_name }}", row["first_name"])):
+        result = dest.load(dummy_records, email_config, sync_options)
+    assert result.success == 1
+    assert result.failed == 1
+    assert len(dest.sent_emails) == 1
+
+def test_sendgrid_simulated_failure(dummy_records, contacts_config, sync_options):
+    class FailingDestination(FakeSendGridDestination):
+        def load(self, records, config, sync_options):
+            result = super().load(records, config, sync_options)
+            if records:
+                result.success -= 1
+                result.failed += 1
+            return result
+    dest = FailingDestination()
+    with patch("sendgrid.render_template", side_effect=lambda template, row: template.replace("{{ row.first_name }}", row["first_name"]).replace("{{ row.email }}", row["email"])):
+        result = dest.load(dummy_records, contacts_config, sync_options)
+    assert result.success == len(dummy_records) - 1
+    assert result.failed == 1
+
+def test_render_template_called_with_correct_args(dummy_records, email_config, sync_options):
+    dest = FakeSendGridDestination()
+    mock_render = MagicMock(side_effect=lambda template, row: template.replace("{{ row.first_name }}", row["first_name"]))
+    with patch("sendgrid.render_template", mock_render):
+        dest.load(dummy_records, email_config, sync_options)
+    for record in dummy_records:
+        mock_render.assert_any_call(email_config.subject_template, record)
+        mock_render.assert_any_call(email_config.body_template, record)

--- a/tests/unit/test_sendgrid.py
+++ b/tests/unit/test_sendgrid.py
@@ -8,10 +8,10 @@ import httpx
 import pytest
 
 from drt.config.models import (
-    SendGridDestinationConfig,
-    RateLimitConfig,
-    SyncOptions,
     BearerAuth,
+    RateLimitConfig,
+    SendGridDestinationConfig,
+    SyncOptions,
 )
 from drt.destinations.sendgrid import SendGridDestination
 
@@ -112,8 +112,7 @@ class TestSendGridDestination:
 
             dest = SendGridDestination()
             records = [
-                {"first_name": f"user{i}", "email": f"user{i}@example.com"}
-                for i in range(3)
+                {"first_name": f"user{i}", "email": f"user{i}@example.com"} for i in range(3)
             ]
 
             dest.load(records, _config(), _sync_options())
@@ -130,9 +129,7 @@ class TestSendGridDestination:
         def fail_once_then_succeed(*args, **kwargs):
             if not hasattr(fail_once_then_succeed, "called"):
                 fail_once_then_succeed.called = True
-                raise httpx.HTTPStatusError(
-                    "500", request=MagicMock(), response=error_response
-                )
+                raise httpx.HTTPStatusError("500", request=MagicMock(), response=error_response)
             return mock_response
 
         mock_client.post.side_effect = fail_once_then_succeed
@@ -160,4 +157,3 @@ class TestSendGridDestination:
         assert result.success == 0
         assert result.failed == 1
         assert "missing 'email'" in result.row_errors[0].error_message
-        


### PR DESCRIPTION
## What does this PR do?

1. Add SendGridDestinationConfig to drt/config/models.py

2. Create drt/destinations/sendgrid.py

3. Register the new config in DestinationConfig union in models.py

4. Wire it in drt/cli/main.py _get_destination()

5. Add tests in tests/unit/test_sendgrid.py using a FakeSendGridDestination

## Related Issue

Closes #36

## Checklist

- [ ] Tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Updated `CHANGELOG.md` (if user-facing change)
