### PR TITLE
feat: add Linear destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Parquet file destination** (#171): Write sync results to local Parquet files using pandas + pyarrow. Supports snappy/gzip/zstd compression and partition columns. 11 unit tests. Install: `pip install drt-core[parquet]`.
 - **CSV/JSON/JSONL file destination** (#67): Write sync results to local CSV, JSON, or JSONL files. No extra dependencies — uses stdlib csv and json. 12 unit tests.
 - **Snowflake source connector** (#162): Extract data from Snowflake using `snowflake-connector-python`. Supports account, user, password/password_env, database, schema, warehouse, and optional role. Install: `pip install drt-core[snowflake]`.
+- **Linear destination connector** (#195): Create Linear issues via GraphQL API with Jinja2 templates for title and description. Supports team ID, label IDs, and assignee via env vars.
 - **SendGrid email destination** (#194): Send transactional emails via SendGrid's v3 Mail Send API. Supports Jinja2 templates for subject and body, configurable recipient field, and bearer auth via env var.
 - **Dry-run summary** (#219): Enhanced `--dry-run` to show a summary including Source, Destination, Rows to sync, and Sync mode.
 - **Dockerfile and docker-compose example** (#161): Lightweight `python:3.12-slim` image with configurable `DRT_EXTRAS` build arg, non-root user, and pinned version. Includes `docker-compose.yml` and `.dockerignore`.

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from drt.destinations.google_sheets import GoogleSheetsDestination
     from drt.destinations.hubspot import HubSpotDestination
     from drt.destinations.jira import JiraDestination
+    from drt.destinations.linear import LinearDestination
     from drt.destinations.mysql import MySQLDestination
     from drt.destinations.parquet import ParquetDestination
     from drt.destinations.postgres import PostgresDestination
@@ -33,7 +34,6 @@ if TYPE_CHECKING:
     from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.slack import SlackDestination
     from drt.destinations.teams import TeamsDestination
-    from drt.destinations.linear import LinearDestination
     from drt.sources.bigquery import BigQuerySource
     from drt.sources.clickhouse import ClickHouseSource
     from drt.sources.duckdb import DuckDBSource
@@ -523,6 +523,7 @@ def _get_destination(
         GoogleSheetsDestinationConfig,
         HubSpotDestinationConfig,
         JiraDestinationConfig,
+        LinearDestinationConfig,
         MySQLDestinationConfig,
         ParquetDestinationConfig,
         PostgresDestinationConfig,
@@ -530,19 +531,18 @@ def _get_destination(
         SendGridDestinationConfig,
         SlackDestinationConfig,
         TeamsDestinationConfig,
-        LinearDestinationConfig,
     )
     from drt.destinations.clickhouse import ClickHouseDestination
     from drt.destinations.discord import DiscordDestination
     from drt.destinations.github_actions import GitHubActionsDestination
     from drt.destinations.hubspot import HubSpotDestination
     from drt.destinations.jira import JiraDestination
+    from drt.destinations.linear import LinearDestination
     from drt.destinations.mysql import MySQLDestination
     from drt.destinations.postgres import PostgresDestination
     from drt.destinations.rest_api import RestApiDestination
     from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.slack import SlackDestination
-    from drt.destinations.linear import LinearDestination
 
     dest = sync.destination
     if isinstance(dest, RestApiDestinationConfig):
@@ -561,6 +561,7 @@ def _get_destination(
         return SendGridDestination()
     if isinstance(dest, GoogleSheetsDestinationConfig):
         from drt.destinations.google_sheets import GoogleSheetsDestination
+
         return GoogleSheetsDestination()
     if isinstance(dest, PostgresDestinationConfig):
         return PostgresDestination()

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.slack import SlackDestination
     from drt.destinations.teams import TeamsDestination
+    from drt.destinations.linear import LinearDestination
     from drt.sources.bigquery import BigQuerySource
     from drt.sources.clickhouse import ClickHouseSource
     from drt.sources.duckdb import DuckDBSource
@@ -512,6 +513,7 @@ def _get_destination(
     | ClickHouseDestination
     | ParquetDestination
     | FileDestination
+    | LinearDestination
 ):
     from drt.config.models import (
         ClickHouseDestinationConfig,
@@ -528,6 +530,7 @@ def _get_destination(
         SendGridDestinationConfig,
         SlackDestinationConfig,
         TeamsDestinationConfig,
+        LinearDestinationConfig,
     )
     from drt.destinations.clickhouse import ClickHouseDestination
     from drt.destinations.discord import DiscordDestination
@@ -539,6 +542,7 @@ def _get_destination(
     from drt.destinations.rest_api import RestApiDestination
     from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.slack import SlackDestination
+    from drt.destinations.linear import LinearDestination
 
     dest = sync.destination
     if isinstance(dest, RestApiDestinationConfig):
@@ -557,7 +561,6 @@ def _get_destination(
         return SendGridDestination()
     if isinstance(dest, GoogleSheetsDestinationConfig):
         from drt.destinations.google_sheets import GoogleSheetsDestination
-
         return GoogleSheetsDestination()
     if isinstance(dest, PostgresDestinationConfig):
         return PostgresDestination()
@@ -577,4 +580,6 @@ def _get_destination(
         from drt.destinations.file import FileDestination
 
         return FileDestination()
+    if isinstance(dest, LinearDestinationConfig):
+        return LinearDestination()
     raise ValueError(f"Unsupported destination type: {dest.type}")

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -160,6 +160,16 @@ class SendGridDestinationConfig(BaseModel):
         return f"sendgrid ({self.from_email})"
 
 
+class LinearDestinationConfig(BaseModel):
+    type: Literal["linear"]
+    team_id_env: str
+    title_template: str
+    description_template: str
+    label_ids: list[str] = []
+    assignee_id: str | None = None
+    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
+    
+    
 class SslConfig(BaseModel):
     """SSL/TLS connection options for DB destinations."""
 
@@ -317,6 +327,7 @@ DestinationConfig = Annotated[
     | GitHubActionsDestinationConfig
     | HubSpotDestinationConfig
     | SendGridDestinationConfig
+    | LinearDestinationConfig
     | GoogleSheetsDestinationConfig
     | PostgresDestinationConfig
     | MySQLDestinationConfig

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -162,15 +162,18 @@ class SendGridDestinationConfig(BaseModel):
 
 class LinearDestinationConfig(BaseModel):
     type: Literal["linear"]
-    team_id_env: str
-    team_id: str | None = None 
+    team_id: str | None = None
+    team_id_env: str | None = None
     title_template: str
     description_template: str
     label_ids: list[str] = []
     assignee_id: str | None = None
     auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
-    
-    
+
+    def describe(self) -> str:
+        return "linear (issue)"
+
+
 class SslConfig(BaseModel):
     """SSL/TLS connection options for DB destinations."""
 

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -163,6 +163,7 @@ class SendGridDestinationConfig(BaseModel):
 class LinearDestinationConfig(BaseModel):
     type: Literal["linear"]
     team_id_env: str
+    team_id: str | None = None 
     title_template: str
     description_template: str
     label_ids: list[str] = []

--- a/drt/destinations/linear.py
+++ b/drt/destinations/linear.py
@@ -1,0 +1,155 @@
+"""Linear destination — create or update Linear issues from DWH rows.
+
+Upserts issues into Linear via the GraphQL API.
+
+Requires: LINEAR_API_KEY (Personal API key with write access).
+
+Example sync YAML — creating alerts/issues:
+
+    destination:
+      type: linear
+      team_id_env: LINEAR_TEAM_ID
+      title_template: "[Alert] {{ row.metric }} exceeded threshold"
+      description_template: |
+        **Value:** {{ row.value }}
+        **Threshold:** {{ row.threshold }}
+        **Detected at:** {{ row.detected_at }}
+      label_ids: []          # optional: list of Linear label UUIDs
+      assignee_id: null      # optional: Linear user UUID
+      auth:
+        type: bearer
+        token_env: LINEAR_API_KEY
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+from drt.config.credentials import resolve_env
+from drt.config.models import DestinationConfig, LinearDestinationConfig, RetryConfig, SyncOptions
+from drt.destinations.base import SyncResult
+from drt.destinations.rate_limiter import RateLimiter
+from drt.destinations.retry import with_retry
+from drt.destinations.row_errors import RowError
+from drt.templates.renderer import render_template
+
+_LINEAR_API = "https://api.linear.app/graphql"
+_DEFAULT_RETRY = RetryConfig(
+    max_attempts=3,
+    initial_backoff=1.0,
+    retryable_status_codes=(429, 500, 502, 503, 504),
+)
+
+_ISSUE_CREATE_MUTATION = """
+mutation IssueCreate($input: IssueCreateInput!) {
+  issueCreate(input: $input) {
+    success
+    issue { id title }
+  }
+}
+"""
+
+
+class LinearDestination:
+    """Create or update Linear issues via the GraphQL API."""
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, LinearDestinationConfig)
+        api_key = resolve_env(config.auth.token, config.auth.token_env)
+        team_id = resolve_env(config.team_id, config.team_id_env)
+
+        if not api_key:
+            raise ValueError(
+                "Linear destination: set LINEAR_API_KEY env var "
+                "or provide auth.token_env in the sync config."
+            )
+        if not team_id:
+            raise ValueError(
+                "Linear destination: set LINEAR_TEAM_ID env var "
+                "or provide team_id_env in the sync config."
+            )
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        result = SyncResult()
+        rate_limiter = RateLimiter(min(sync_options.rate_limit.requests_per_second, 9))
+
+        with httpx.Client(timeout=30.0) as client:
+            for i, record in enumerate(records):
+                rate_limiter.acquire()
+
+                # Render title and description
+                try:
+                    title = render_template(config.title_template, record)
+                    description = render_template(
+                        config.description_template, record
+                    ) if config.description_template else ""
+                except Exception as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=None,
+                            error_message=f"Template rendering error: {e}",
+                        )
+                    )
+                    continue
+
+                payload = {
+                    "query": _ISSUE_CREATE_MUTATION,
+                    "variables": {
+                        "input": {
+                            "teamId": team_id,
+                            "title": title,
+                            "description": description,
+                            "labelIds": config.label_ids or [],
+                            "assigneeId": config.assignee_id,
+                        }
+                    },
+                }
+
+                def do_create(_payload=payload):
+                    response = client.post(_LINEAR_API, json=_payload, headers=headers)
+                    response.raise_for_status()
+                    data = response.json()
+                    if not data.get("data", {}).get("issueCreate", {}).get("success", False):
+                        raise Exception(f"Linear issue creation failed: {data}")
+                    return data
+
+                try:
+                    with_retry(do_create, _DEFAULT_RETRY)
+                    result.success += 1
+                except httpx.HTTPStatusError as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=e.response.status_code,
+                            error_message=e.response.text[:500],
+                        )
+                    )
+                except Exception as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=None,
+                            error_message=str(e),
+                        )
+                    )
+
+        return result

--- a/drt/destinations/linear.py
+++ b/drt/destinations/linear.py
@@ -1,26 +1,3 @@
-"""Linear destination — create or update Linear issues from DWH rows.
-
-Upserts issues into Linear via the GraphQL API.
-
-Requires: LINEAR_API_KEY (Personal API key with write access).
-
-Example sync YAML — creating alerts/issues:
-
-    destination:
-      type: linear
-      team_id_env: LINEAR_TEAM_ID
-      title_template: "[Alert] {{ row.metric }} exceeded threshold"
-      description_template: |
-        **Value:** {{ row.value }}
-        **Threshold:** {{ row.threshold }}
-        **Detected at:** {{ row.detected_at }}
-      label_ids: []          # optional: list of Linear label UUIDs
-      assignee_id: null      # optional: Linear user UUID
-      auth:
-        type: bearer
-        token_env: LINEAR_API_KEY
-"""
-
 from __future__ import annotations
 
 import json
@@ -37,6 +14,8 @@ from drt.destinations.row_errors import RowError
 from drt.templates.renderer import render_template
 
 _LINEAR_API = "https://api.linear.app/graphql"
+
+# Retry configuration for transient errors
 _DEFAULT_RETRY = RetryConfig(
     max_attempts=3,
     initial_backoff=1.0,
@@ -64,7 +43,7 @@ class LinearDestination:
     ) -> SyncResult:
         assert isinstance(config, LinearDestinationConfig)
         api_key = resolve_env(config.auth.token, config.auth.token_env)
-        team_id = resolve_env(config.team_id, config.team_id_env)
+        team_id = resolve_env(None, config.team_id_env)
 
         if not api_key:
             raise ValueError(
@@ -85,71 +64,75 @@ class LinearDestination:
         result = SyncResult()
         rate_limiter = RateLimiter(min(sync_options.rate_limit.requests_per_second, 9))
 
+        def create_issue(record: dict[str, Any], batch_index: int):
+            """Render and send a Linear issue, with retry."""
+            # Render title and description
+            try:
+                title = render_template(config.title_template, record)
+                description = render_template(
+                    config.description_template, record
+                ) if config.description_template else ""
+            except Exception as e:
+                result.failed += 1
+                result.row_errors.append(
+                    RowError(
+                        batch_index=batch_index,
+                        record_preview=json.dumps(record)[:200],
+                        http_status=None,
+                        error_message=f"Template rendering error: {e}",
+                    )
+                )
+                return
+
+            payload = {
+                "query": _ISSUE_CREATE_MUTATION,
+                "variables": {
+                    "input": {
+                        "teamId": team_id,
+                        "title": title,
+                        "description": description,
+                        "labelIds": config.label_ids or [],
+                        "assigneeId": config.assignee_id,
+                    }
+                },
+            }
+
+            def do_post():
+                rate_limiter.acquire()
+                response = client.post(_LINEAR_API, json=payload, headers=headers)
+                # Retry should handle 429/5xx automatically
+                response.raise_for_status()
+                data = response.json()
+                if not data.get("data", {}).get("issueCreate", {}).get("success", False):
+                    raise Exception(f"Linear issue creation failed: {data}")
+                return data
+
+            try:
+                with_retry(do_post, _DEFAULT_RETRY)
+                result.success += 1
+            except httpx.HTTPStatusError as e:
+                result.failed += 1
+                result.row_errors.append(
+                    RowError(
+                        batch_index=batch_index,
+                        record_preview=json.dumps(record)[:200],
+                        http_status=e.response.status_code,
+                        error_message=e.response.text[:500],
+                    )
+                )
+            except Exception as e:
+                result.failed += 1
+                result.row_errors.append(
+                    RowError(
+                        batch_index=batch_index,
+                        record_preview=json.dumps(record)[:200],
+                        http_status=None,
+                        error_message=str(e),
+                    )
+                )
+
         with httpx.Client(timeout=30.0) as client:
             for i, record in enumerate(records):
-                rate_limiter.acquire()
-
-                # Render title and description
-                try:
-                    title = render_template(config.title_template, record)
-                    description = render_template(
-                        config.description_template, record
-                    ) if config.description_template else ""
-                except Exception as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record)[:200],
-                            http_status=None,
-                            error_message=f"Template rendering error: {e}",
-                        )
-                    )
-                    continue
-
-                payload = {
-                    "query": _ISSUE_CREATE_MUTATION,
-                    "variables": {
-                        "input": {
-                            "teamId": team_id,
-                            "title": title,
-                            "description": description,
-                            "labelIds": config.label_ids or [],
-                            "assigneeId": config.assignee_id,
-                        }
-                    },
-                }
-
-                def do_create(_payload=payload):
-                    response = client.post(_LINEAR_API, json=_payload, headers=headers)
-                    response.raise_for_status()
-                    data = response.json()
-                    if not data.get("data", {}).get("issueCreate", {}).get("success", False):
-                        raise Exception(f"Linear issue creation failed: {data}")
-                    return data
-
-                try:
-                    with_retry(do_create, _DEFAULT_RETRY)
-                    result.success += 1
-                except httpx.HTTPStatusError as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record)[:200],
-                            http_status=e.response.status_code,
-                            error_message=e.response.text[:500],
-                        )
-                    )
-                except Exception as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record)[:200],
-                            http_status=None,
-                            error_message=str(e),
-                        )
-                    )
+                create_issue(record, i)
 
         return result

--- a/drt/destinations/linear.py
+++ b/drt/destinations/linear.py
@@ -1,6 +1,31 @@
+"""Linear destination — create issues via the Linear GraphQL API.
+
+Sends one issue per record using Linear's GraphQL API.
+Supports title + description templating via Jinja2.
+
+No extra dependencies required (uses httpx from core).
+
+Example sync YAML:
+
+    destination:
+      type: linear
+      team_id_env: LINEAR_TEAM_ID
+      title_template: "Alert: {{ row.metric }}"
+      description_template: "Value: {{ row.value }}"
+      auth:
+        type: bearer
+        token_env: LINEAR_API_KEY
+
+Linear API reference:
+    Endpoint: POST https://api.linear.app/graphql
+    Docs: https://developers.linear.app/docs/graphql/working-with-the-graphql-api
+    Auth: Authorization: Bearer <LINEAR_API_KEY>
+"""
+
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 import httpx
@@ -13,9 +38,10 @@ from drt.destinations.retry import with_retry
 from drt.destinations.row_errors import RowError
 from drt.templates.renderer import render_template
 
+logger = logging.getLogger(__name__)
+
 _LINEAR_API = "https://api.linear.app/graphql"
 
-# Retry configuration for transient errors
 _DEFAULT_RETRY = RetryConfig(
     max_attempts=3,
     initial_backoff=1.0,
@@ -32,8 +58,12 @@ mutation IssueCreate($input: IssueCreateInput!) {
 """
 
 
+def _record_preview(row: dict[str, Any]) -> str:
+    return json.dumps(row, default=str)[:200]
+
+
 class LinearDestination:
-    """Create or update Linear issues via the GraphQL API."""
+    """Create Linear issues via the GraphQL API."""
 
     def load(
         self,
@@ -42,8 +72,9 @@ class LinearDestination:
         sync_options: SyncOptions,
     ) -> SyncResult:
         assert isinstance(config, LinearDestinationConfig)
+
         api_key = resolve_env(config.auth.token, config.auth.token_env)
-        team_id = resolve_env(None, config.team_id_env)
+        team_id = resolve_env(config.team_id, config.team_id_env)
 
         if not api_key:
             raise ValueError(
@@ -53,86 +84,89 @@ class LinearDestination:
         if not team_id:
             raise ValueError(
                 "Linear destination: set LINEAR_TEAM_ID env var "
-                "or provide team_id_env in the sync config."
+                "or provide team_id / team_id_env in the sync config."
             )
+
+        retry_config = sync_options.retry or _DEFAULT_RETRY
+        result = SyncResult()
+        rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
 
         headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
         }
 
-        result = SyncResult()
-        rate_limiter = RateLimiter(min(sync_options.rate_limit.requests_per_second, 9))
-
-        def create_issue(record: dict[str, Any], batch_index: int):
-            """Render and send a Linear issue, with retry."""
-            # Render title and description
-            try:
-                title = render_template(config.title_template, record)
-                description = render_template(
-                    config.description_template, record
-                ) if config.description_template else ""
-            except Exception as e:
-                result.failed += 1
-                result.row_errors.append(
-                    RowError(
-                        batch_index=batch_index,
-                        record_preview=json.dumps(record)[:200],
-                        http_status=None,
-                        error_message=f"Template rendering error: {e}",
+        with httpx.Client(timeout=30.0) as client:
+            for i, record in enumerate(records):
+                rate_limiter.acquire()
+                try:
+                    title = render_template(config.title_template, record)
+                    description = (
+                        render_template(config.description_template, record)
+                        if config.description_template
+                        else ""
                     )
-                )
-                return
 
-            payload = {
-                "query": _ISSUE_CREATE_MUTATION,
-                "variables": {
-                    "input": {
+                    issue_input: dict[str, Any] = {
                         "teamId": team_id,
                         "title": title,
                         "description": description,
                         "labelIds": config.label_ids or [],
-                        "assigneeId": config.assignee_id,
                     }
-                },
-            }
+                    if config.assignee_id is not None:
+                        issue_input["assigneeId"] = config.assignee_id
 
-            def do_post():
-                rate_limiter.acquire()
-                response = client.post(_LINEAR_API, json=payload, headers=headers)
-                # Retry should handle 429/5xx automatically
-                response.raise_for_status()
-                data = response.json()
-                if not data.get("data", {}).get("issueCreate", {}).get("success", False):
-                    raise Exception(f"Linear issue creation failed: {data}")
-                return data
+                    payload = {
+                        "query": _ISSUE_CREATE_MUTATION,
+                        "variables": {"input": issue_input},
+                    }
 
-            try:
-                with_retry(do_post, _DEFAULT_RETRY)
-                result.success += 1
-            except httpx.HTTPStatusError as e:
-                result.failed += 1
-                result.row_errors.append(
-                    RowError(
-                        batch_index=batch_index,
-                        record_preview=json.dumps(record)[:200],
-                        http_status=e.response.status_code,
-                        error_message=e.response.text[:500],
+                    def do_post(_payload: dict[str, Any] = payload) -> Any:
+                        response = client.post(_LINEAR_API, json=_payload, headers=headers)
+                        response.raise_for_status()
+                        data = response.json()
+                        if not data.get("data", {}).get("issueCreate", {}).get("success", False):
+                            raise Exception(f"Linear issue creation failed: {data}")
+                        return data
+
+                    with_retry(do_post, retry_config)
+                    result.success += 1
+
+                except httpx.HTTPStatusError as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=_record_preview(record),
+                            http_status=e.response.status_code,
+                            error_message=e.response.text[:500],
+                        )
                     )
-                )
-            except Exception as e:
-                result.failed += 1
-                result.row_errors.append(
-                    RowError(
-                        batch_index=batch_index,
-                        record_preview=json.dumps(record)[:200],
-                        http_status=None,
-                        error_message=str(e),
+                    if sync_options.on_error == "fail":
+                        break
+                except httpx.RequestError as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=_record_preview(record),
+                            http_status=None,
+                            error_message=f"Request error: {e}",
+                        )
                     )
-                )
-
-        with httpx.Client(timeout=30.0) as client:
-            for i, record in enumerate(records):
-                create_issue(record, i)
+                    if sync_options.on_error == "fail":
+                        break
+                except Exception as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=_record_preview(record),
+                            http_status=None,
+                            error_message=str(e),
+                        )
+                    )
+                    if sync_options.on_error == "fail":
+                        break
 
         return result

--- a/tests/unit/test_linear_destination.py
+++ b/tests/unit/test_linear_destination.py
@@ -1,154 +1,153 @@
-import os
-import pytest
-from unittest.mock import patch, MagicMock
-from httpx import Response, HTTPStatusError
+"""Unit tests for Linear destination."""
 
-from drt.config.models import LinearDestinationConfig, SyncOptions, RateLimitConfig, BearerAuth
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from drt.config.models import (
+    BearerAuth,
+    LinearDestinationConfig,
+    RateLimitConfig,
+    SyncOptions,
+)
 from drt.destinations.linear import LinearDestination
 from drt.destinations.row_errors import RowError
 
 
-# --- Correct fixture for LinearDestinationConfig ---
+def _config(**overrides):
+    defaults = {
+        "type": "linear",
+        "team_id_env": "LINEAR_TEAM_ID",
+        "title_template": "Issue: {{ row.metric }}",
+        "description_template": "Value: {{ row.value }}",
+        "label_ids": [],
+        "assignee_id": None,
+        "auth": BearerAuth(type="bearer", token="test-api-key"),
+    }
+    defaults.update(overrides)
+    return LinearDestinationConfig(**defaults)
+
+
+def _options(**overrides):
+    defaults = {
+        "mode": "full",
+        "batch_size": 100,
+        "on_error": "skip",
+        "rate_limit": RateLimitConfig(requests_per_second=0),
+    }
+    defaults.update(overrides)
+    return SyncOptions(**defaults)
+
+
+RECORDS = [
+    {"metric": "cpu_usage", "value": 90},
+    {"metric": "memory_usage", "value": 80},
+]
+
+
 @pytest.fixture
-def mock_config():
-    return LinearDestinationConfig(
-        type="linear",
-        team_id_env="LINEAR_TEAM_ID",
-        title_template="Issue: {{ row.metric }}",
-        description_template="Value: {{ row.value }}",
-        label_ids=[],
-        assignee_id=None,
-        auth=BearerAuth(type="bearer", token_env="LINEAR_API_KEY"),
-    )
+def mock_linear_client(monkeypatch):
+    monkeypatch.setenv("LINEAR_TEAM_ID", "team123")
 
+    with patch("drt.destinations.linear.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
 
-# --- Records to load ---
-@pytest.fixture
-def mock_records():
-    return [
-        {"metric": "cpu_usage", "value": 90},
-        {"metric": "memory_usage", "value": 80},
-    ]
-
-
-# --- SyncOptions fixture ---
-@pytest.fixture
-def sync_options():
-    return SyncOptions(rate_limit=RateLimitConfig(requests_per_second=5))
-
-
-# --- Test: successful creation ---
-def test_successful_issue_creation(mock_config, mock_records, sync_options):
-    os.environ["LINEAR_API_KEY"] = "key123"
-    os.environ["LINEAR_TEAM_ID"] = "team123"
-
-    dest = LinearDestination()
-
-    with patch("drt.destinations.linear.httpx.Client.post") as mock_post:
         mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
         mock_response.json.return_value = {"data": {"issueCreate": {"success": True}}}
-        mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
+        mock_client.post.return_value = mock_response
 
-        result = dest.load(mock_records, mock_config, sync_options)
+        yield mock_client, mock_response
+
+
+class TestLinearDestination:
+    def test_successful_issue_creation(self, mock_linear_client):
+        mock_client, _ = mock_linear_client
+
+        dest = LinearDestination()
+        result = dest.load(RECORDS, _config(), _options())
 
         assert result.success == 2
         assert result.failed == 0
         assert result.row_errors == []
+        assert mock_client.post.call_count == 2
 
+    def test_template_rendering_error(self, mock_linear_client):
+        dest = LinearDestination()
+        config = _config(title_template="{{ row.nonexistent }}")
 
-# --- Test: template rendering error ---
-def test_template_rendering_error(mock_records, sync_options):
-    os.environ["LINEAR_API_KEY"] = "key123"
-    os.environ["LINEAR_TEAM_ID"] = "team123"
+        result = dest.load(RECORDS, config, _options())
 
-    bad_config = LinearDestinationConfig(
-        type="linear",
-        team_id_env="LINEAR_TEAM_ID",
-        title_template="{{ row.nonexistent }}",  # this will fail
-        description_template="Some description",
-        label_ids=[],
-        assignee_id=None,
-        auth=BearerAuth(type="bearer", token_env="LINEAR_API_KEY"),
-    )
+        assert result.success == 0
+        assert result.failed == 2
+        assert all(isinstance(err, RowError) for err in result.row_errors)
 
-    dest = LinearDestination()
-    result = dest.load(mock_records, bad_config, sync_options)
-
-    assert result.success == 0
-    assert result.failed == 2
-    assert all(isinstance(err, RowError) for err in result.row_errors)
-    assert all("Template rendering error" in err.error_message for err in result.row_errors)
-
-
-# --- Test: HTTP error triggers retry ---
-def test_http_error_retry(mock_config, mock_records, sync_options):
-    os.environ["LINEAR_API_KEY"] = "key123"
-    os.environ["LINEAR_TEAM_ID"] = "team123"
-
-    dest = LinearDestination()
-
-    with patch("drt.destinations.linear.httpx.Client.post") as mock_post:
-        # first attempt fails with HTTPStatusError (500), second succeeds
-        mock_response_fail = MagicMock()
-        mock_response_fail.response = Response(500)
-        mock_response_fail.raise_for_status.side_effect = HTTPStatusError(
-            "500 Server Error",
-            request=MagicMock(),
-            response=mock_response_fail.response,
-        )
-
-        mock_response_success = MagicMock()
-        mock_response_success.raise_for_status.return_value = None
-        mock_response_success.json.return_value = {"data": {"issueCreate": {"success": True}}}
-
-        # alternate fail/success for each record
-        mock_post.side_effect = [mock_response_fail, mock_response_success] * len(mock_records)
-
-        result = dest.load(mock_records, mock_config, sync_options)
-
-        # all records should eventually succeed
-        assert result.success == len(mock_records)
-        assert result.failed == 0
-        assert result.row_errors == []
-
-
-# --- Test: Linear API returns failure (issue not created) ---
-def test_linear_issue_creation_failure(mock_config, mock_records, sync_options):
-    os.environ["LINEAR_API_KEY"] = "key123"
-    os.environ["LINEAR_TEAM_ID"] = "team123"
-
-    dest = LinearDestination()
-
-    with patch("drt.destinations.linear.httpx.Client.post") as mock_post:
-        mock_response = MagicMock()
-        mock_response.raise_for_status.return_value = None
+    def test_linear_api_failure(self, mock_linear_client):
+        mock_client, mock_response = mock_linear_client
         mock_response.json.return_value = {"data": {"issueCreate": {"success": False}}}
-        mock_post.return_value = mock_response
 
-        result = dest.load(mock_records, mock_config, sync_options)
+        dest = LinearDestination()
+        result = dest.load(RECORDS, _config(), _options())
 
         assert result.success == 0
         assert result.failed == 2
         assert all("Linear issue creation failed" in err.error_message for err in result.row_errors)
 
+    def test_http_error(self, mock_linear_client):
+        mock_client, _ = mock_linear_client
 
-# --- Test: Rate limiter is called for each record ---
-def test_rate_limiter_called(mock_config, mock_records, sync_options):
-    os.environ["LINEAR_API_KEY"] = "key123"
-    os.environ["LINEAR_TEAM_ID"] = "team123"
+        error_response = MagicMock()
+        error_response.status_code = 500
+        error_response.text = "Server Error"
 
-    dest = LinearDestination()
+        mock_client.post.side_effect = httpx.HTTPStatusError(
+            "500", request=MagicMock(), response=error_response
+        )
 
-    with patch("drt.destinations.linear.RateLimiter.acquire") as mock_acquire:
-        with patch("drt.destinations.linear.httpx.Client.post") as mock_post:
-            mock_response = MagicMock()
-            mock_response.raise_for_status.return_value = None
-            mock_response.json.return_value = {"data": {"issueCreate": {"success": True}}}
-            mock_post.return_value = mock_response
+        dest = LinearDestination()
+        result = dest.load(RECORDS, _config(), _options())
 
-            result = dest.load(mock_records, mock_config, sync_options)
+        assert result.failed == 2
+        assert result.row_errors[0].http_status == 500
 
-            # RateLimiter.acquire should be called once per record
-            assert mock_acquire.call_count == len(mock_records)
-            assert result.success == 2
+    def test_on_error_fail_stops(self, mock_linear_client):
+        mock_client, _ = mock_linear_client
+
+        error_response = MagicMock()
+        error_response.status_code = 400
+        error_response.text = "Bad Request"
+
+        mock_client.post.side_effect = httpx.HTTPStatusError(
+            "400", request=MagicMock(), response=error_response
+        )
+
+        dest = LinearDestination()
+        result = dest.load(RECORDS, _config(), _options(on_error="fail"))
+
+        # Only 1 record processed — on_error="fail" stops after first failure
+        assert result.failed == 1
+        assert mock_client.post.call_count == 1
+
+    def test_missing_api_key(self, monkeypatch):
+        monkeypatch.setenv("LINEAR_TEAM_ID", "team123")
+
+        dest = LinearDestination()
+        config = _config(auth=BearerAuth(type="bearer", token=None, token_env=None))
+
+        with pytest.raises(ValueError, match="LINEAR_API_KEY"):
+            dest.load(RECORDS, config, _options())
+
+    def test_rate_limiter_called_per_record(self, mock_linear_client):
+        with patch("drt.destinations.linear.RateLimiter") as mock_rl_cls:
+            mock_rl = MagicMock()
+            mock_rl_cls.return_value = mock_rl
+
+            dest = LinearDestination()
+            dest.load(RECORDS, _config(), _options())
+
+            assert mock_rl.acquire.call_count == 2

--- a/tests/unit/test_linear_destination.py
+++ b/tests/unit/test_linear_destination.py
@@ -1,0 +1,154 @@
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from httpx import Response, HTTPStatusError
+
+from drt.config.models import LinearDestinationConfig, SyncOptions, RateLimitConfig, BearerAuth
+from drt.destinations.linear import LinearDestination
+from drt.destinations.row_errors import RowError
+
+
+# --- Correct fixture for LinearDestinationConfig ---
+@pytest.fixture
+def mock_config():
+    return LinearDestinationConfig(
+        type="linear",
+        team_id_env="LINEAR_TEAM_ID",
+        title_template="Issue: {{ row.metric }}",
+        description_template="Value: {{ row.value }}",
+        label_ids=[],
+        assignee_id=None,
+        auth=BearerAuth(type="bearer", token_env="LINEAR_API_KEY"),
+    )
+
+
+# --- Records to load ---
+@pytest.fixture
+def mock_records():
+    return [
+        {"metric": "cpu_usage", "value": 90},
+        {"metric": "memory_usage", "value": 80},
+    ]
+
+
+# --- SyncOptions fixture ---
+@pytest.fixture
+def sync_options():
+    return SyncOptions(rate_limit=RateLimitConfig(requests_per_second=5))
+
+
+# --- Test: successful creation ---
+def test_successful_issue_creation(mock_config, mock_records, sync_options):
+    os.environ["LINEAR_API_KEY"] = "key123"
+    os.environ["LINEAR_TEAM_ID"] = "team123"
+
+    dest = LinearDestination()
+
+    with patch("drt.destinations.linear.httpx.Client.post") as mock_post:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": {"issueCreate": {"success": True}}}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        result = dest.load(mock_records, mock_config, sync_options)
+
+        assert result.success == 2
+        assert result.failed == 0
+        assert result.row_errors == []
+
+
+# --- Test: template rendering error ---
+def test_template_rendering_error(mock_records, sync_options):
+    os.environ["LINEAR_API_KEY"] = "key123"
+    os.environ["LINEAR_TEAM_ID"] = "team123"
+
+    bad_config = LinearDestinationConfig(
+        type="linear",
+        team_id_env="LINEAR_TEAM_ID",
+        title_template="{{ row.nonexistent }}",  # this will fail
+        description_template="Some description",
+        label_ids=[],
+        assignee_id=None,
+        auth=BearerAuth(type="bearer", token_env="LINEAR_API_KEY"),
+    )
+
+    dest = LinearDestination()
+    result = dest.load(mock_records, bad_config, sync_options)
+
+    assert result.success == 0
+    assert result.failed == 2
+    assert all(isinstance(err, RowError) for err in result.row_errors)
+    assert all("Template rendering error" in err.error_message for err in result.row_errors)
+
+
+# --- Test: HTTP error triggers retry ---
+def test_http_error_retry(mock_config, mock_records, sync_options):
+    os.environ["LINEAR_API_KEY"] = "key123"
+    os.environ["LINEAR_TEAM_ID"] = "team123"
+
+    dest = LinearDestination()
+
+    with patch("drt.destinations.linear.httpx.Client.post") as mock_post:
+        # first attempt fails with HTTPStatusError (500), second succeeds
+        mock_response_fail = MagicMock()
+        mock_response_fail.response = Response(500)
+        mock_response_fail.raise_for_status.side_effect = HTTPStatusError(
+            "500 Server Error",
+            request=MagicMock(),
+            response=mock_response_fail.response,
+        )
+
+        mock_response_success = MagicMock()
+        mock_response_success.raise_for_status.return_value = None
+        mock_response_success.json.return_value = {"data": {"issueCreate": {"success": True}}}
+
+        # alternate fail/success for each record
+        mock_post.side_effect = [mock_response_fail, mock_response_success] * len(mock_records)
+
+        result = dest.load(mock_records, mock_config, sync_options)
+
+        # all records should eventually succeed
+        assert result.success == len(mock_records)
+        assert result.failed == 0
+        assert result.row_errors == []
+
+
+# --- Test: Linear API returns failure (issue not created) ---
+def test_linear_issue_creation_failure(mock_config, mock_records, sync_options):
+    os.environ["LINEAR_API_KEY"] = "key123"
+    os.environ["LINEAR_TEAM_ID"] = "team123"
+
+    dest = LinearDestination()
+
+    with patch("drt.destinations.linear.httpx.Client.post") as mock_post:
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"data": {"issueCreate": {"success": False}}}
+        mock_post.return_value = mock_response
+
+        result = dest.load(mock_records, mock_config, sync_options)
+
+        assert result.success == 0
+        assert result.failed == 2
+        assert all("Linear issue creation failed" in err.error_message for err in result.row_errors)
+
+
+# --- Test: Rate limiter is called for each record ---
+def test_rate_limiter_called(mock_config, mock_records, sync_options):
+    os.environ["LINEAR_API_KEY"] = "key123"
+    os.environ["LINEAR_TEAM_ID"] = "team123"
+
+    dest = LinearDestination()
+
+    with patch("drt.destinations.linear.RateLimiter.acquire") as mock_acquire:
+        with patch("drt.destinations.linear.httpx.Client.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {"data": {"issueCreate": {"success": True}}}
+            mock_post.return_value = mock_response
+
+            result = dest.load(mock_records, mock_config, sync_options)
+
+            # RateLimiter.acquire should be called once per record
+            assert mock_acquire.call_count == len(mock_records)
+            assert result.success == 2


### PR DESCRIPTION
## What does this PR do?

1. Add LinearDestinationConfig to drt/config/models.py

2. Create drt/destinations/linear.py

3. Register in DestinationConfig union and _get_destination() in CLI

## Related Issue

Closes #37

## Checklist

- [ ] Tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Updated `CHANGELOG.md` (if user-facing change)
