### PR TITLE
refactor: extract httpx mock fixture in Discord tests

### DIFF
--- a/tests/unit/test_discord.py
+++ b/tests/unit/test_discord.py
@@ -31,68 +31,54 @@ def _sync_options():
     )
 
 
+@pytest.fixture
+def mock_discord_client():
+    with patch("drt.destinations.discord.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_client.post.return_value = mock_response
+        yield mock_client, mock_response
+
+
 class TestDiscordDestination:
-    def test_sends_plain_text_message(self):
+    def test_sends_plain_text_message(self, mock_discord_client):
+        mock_client, _ = mock_discord_client
         dest = DiscordDestination()
-        config = _config()
-        records = [{"name": "Alice"}]
-
-        with patch("drt.destinations.discord.httpx.Client") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
-            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
-            mock_response = MagicMock()
-            mock_response.raise_for_status = MagicMock()
-            mock_client.post.return_value = mock_response
-
-            result = dest.load(records, config, _sync_options())
+        result = dest.load([{"name": "Alice"}], _config(), _sync_options())
 
         assert result.success == 1
         assert result.failed == 0
         mock_client.post.assert_called_once()
-        call_kwargs = mock_client.post.call_args
-        assert call_kwargs[1]["json"] == {"content": "Hello Alice"}
+        assert mock_client.post.call_args[1]["json"] == {"content": "Hello Alice"}
 
-    def test_sends_embed_message(self):
+    def test_sends_embed_message(self, mock_discord_client):
+        mock_client, _ = mock_discord_client
         template = '{"embeds": [{"title": "{{ row.title }}"}]}'
         dest = DiscordDestination()
-        config = _config(embeds=True, message_template=template)
-        records = [{"title": "Test Embed"}]
-
-        with patch("drt.destinations.discord.httpx.Client") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
-            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
-            mock_response = MagicMock()
-            mock_response.raise_for_status = MagicMock()
-            mock_client.post.return_value = mock_response
-
-            result = dest.load(records, config, _sync_options())
+        result = dest.load(
+            [{"title": "Test Embed"}],
+            _config(embeds=True, message_template=template),
+            _sync_options(),
+        )
 
         assert result.success == 1
-        call_kwargs = mock_client.post.call_args
-        assert call_kwargs[1]["json"]["embeds"][0]["title"] == "Test Embed"
+        assert mock_client.post.call_args[1]["json"]["embeds"][0]["title"] == "Test Embed"
 
-    def test_handles_http_error(self):
-        dest = DiscordDestination()
-        config = _config()
-        records = [{"name": "Bob"}]
-
-        with patch("drt.destinations.discord.httpx.Client") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
-            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
-            mock_response = MagicMock()
-            mock_response.status_code = 401
-            mock_response.text = "Unauthorized"
-            mock_response.raise_for_status = MagicMock(
-                side_effect=httpx.HTTPStatusError(
-                    "401", request=MagicMock(), response=mock_response
-                )
+    def test_handles_http_error(self, mock_discord_client):
+        mock_client, mock_response = mock_discord_client
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+        mock_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "401", request=MagicMock(), response=mock_response
             )
-            mock_client.post.return_value = mock_response
+        )
 
-            result = dest.load(records, config, _sync_options())
+        dest = DiscordDestination()
+        result = dest.load([{"name": "Bob"}], _config(), _sync_options())
 
         assert result.failed == 1
         assert result.success == 0
@@ -105,39 +91,23 @@ class TestDiscordDestination:
         with pytest.raises(ValueError, match="provide 'webhook_url'"):
             dest.load([{"name": "test"}], config, _sync_options())
 
-    def test_webhook_url_from_env(self):
+    def test_webhook_url_from_env(self, mock_discord_client):
+        mock_client, _ = mock_discord_client
         dest = DiscordDestination()
         config = _config(webhook_url=None, webhook_url_env="DISCORD_URL")
-        records = [{"name": "Eve"}]
 
-        with patch("drt.destinations.discord.httpx.Client") as mock_client_cls, \
-             patch.dict("os.environ", {"DISCORD_URL": "https://discord.com/api/webhooks/env"}):
-            mock_client = MagicMock()
-            mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
-            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
-            mock_response = MagicMock()
-            mock_response.raise_for_status = MagicMock()
-            mock_client.post.return_value = mock_response
-
-            result = dest.load(records, config, _sync_options())
+        with patch.dict("os.environ", {"DISCORD_URL": "https://discord.com/api/webhooks/env"}):
+            result = dest.load([{"name": "Eve"}], config, _sync_options())
 
         assert result.success == 1
         assert mock_client.post.call_args[0][0] == "https://discord.com/api/webhooks/env"
 
-    def test_multiple_records(self):
+    def test_multiple_records(self, mock_discord_client):
+        mock_client, _ = mock_discord_client
         dest = DiscordDestination()
-        config = _config()
         records = [{"name": f"User{i}"} for i in range(5)]
 
-        with patch("drt.destinations.discord.httpx.Client") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
-            mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
-            mock_response = MagicMock()
-            mock_response.raise_for_status = MagicMock()
-            mock_client.post.return_value = mock_response
-
-            result = dest.load(records, config, _sync_options())
+        result = dest.load(records, _config(), _sync_options())
 
         assert result.success == 5
         assert mock_client.post.call_count == 5


### PR DESCRIPTION
## Summary
- Extract repeated `httpx.Client` mock setup into a `@pytest.fixture` across 5 tests
- Follow-up to #193 — no logic changes, just DRY cleanup (143 → 107 lines)

## Test plan
- [x] `make test` — 184 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)