### PR TITLE
docs: add package name labels to download badges

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -15,8 +15,8 @@
 
 [![CI](https://github.com/drt-hub/drt/actions/workflows/ci.yml/badge.svg)](https://github.com/drt-hub/drt/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/drt-core)](https://pypi.org/project/drt-core/)
-[![Downloads](https://static.pepy.tech/badge/drt-core)](https://pepy.tech/projects/drt-core)
-[![Downloads](https://static.pepy.tech/badge/dagster-drt)](https://pepy.tech/projects/dagster-drt)
+[![drt-core downloads](https://img.shields.io/pepy/dt/drt-core?label=drt-core%20downloads)](https://pepy.tech/projects/drt-core)
+[![dagster-drt downloads](https://img.shields.io/pepy/dt/dagster-drt?label=dagster-drt%20downloads)](https://pepy.tech/projects/dagster-drt)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Python](https://img.shields.io/pypi/pyversions/drt-core)](https://pypi.org/project/drt-core/)
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 [![CI](https://github.com/drt-hub/drt/actions/workflows/ci.yml/badge.svg)](https://github.com/drt-hub/drt/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/drt-core)](https://pypi.org/project/drt-core/)
-[![Downloads](https://static.pepy.tech/badge/drt-core)](https://pepy.tech/projects/drt-core)
-[![Downloads](https://static.pepy.tech/badge/dagster-drt)](https://pepy.tech/projects/dagster-drt)
+[![drt-core downloads](https://img.shields.io/pepy/dt/drt-core?label=drt-core%20downloads)](https://pepy.tech/projects/drt-core)
+[![dagster-drt downloads](https://img.shields.io/pepy/dt/dagster-drt?label=dagster-drt%20downloads)](https://pepy.tech/projects/dagster-drt)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Python](https://img.shields.io/pypi/pyversions/drt-core)](https://pypi.org/project/drt-core/)
 

--- a/integrations/dagster-drt/README.md
+++ b/integrations/dagster-drt/README.md
@@ -1,7 +1,7 @@
 # dagster-drt
 
 [![PyPI](https://img.shields.io/pypi/v/dagster-drt)](https://pypi.org/project/dagster-drt/)
-[![Downloads](https://static.pepy.tech/badge/dagster-drt)](https://pepy.tech/projects/dagster-drt)
+[![dagster-drt downloads](https://img.shields.io/pepy/dt/dagster-drt?label=dagster-drt%20downloads)](https://pepy.tech/projects/dagster-drt)
 
 Community-maintained [Dagster](https://dagster.io/) integration for [drt](https://github.com/drt-hub/drt) (data reverse tool).
 


### PR DESCRIPTION
## Summary
- Switch download badges from pepy.tech static to shields.io pepy integration
- Add package name labels: `drt-core downloads | 4k`, `dagster-drt downloads | 619`
- Applied to README.md, README.ja.md, and integrations/dagster-drt/README.md

## Test plan
- [ ] Verify badges render correctly with labels on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)