### PR TITLE
feat: add CSV/JSON/JSONL file destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CSV/JSON/JSONL file destination** (#67): Write sync results to local CSV, JSON, or JSONL files. No extra dependencies — uses stdlib csv and json. 14 unit tests.
 - **Snowflake source connector** (#162): Extract data from Snowflake using `snowflake-connector-python`. Supports account, user, password/password_env, database, schema, warehouse, and optional role. Install: `pip install drt-core[snowflake]`.
 - **Dockerfile and docker-compose example** (#161): Lightweight `python:3.12-slim` image with configurable `DRT_EXTRAS` build arg, non-root user, and pinned version. Includes `docker-compose.yml` and `.dockerignore`.
 

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     )
     from drt.config.models import SyncConfig
     from drt.destinations.discord import DiscordDestination
+    from drt.destinations.file import FileDestination
     from drt.destinations.github_actions import GitHubActionsDestination
     from drt.destinations.google_sheets import GoogleSheetsDestination
     from drt.destinations.hubspot import HubSpotDestination
@@ -328,9 +329,11 @@ def _get_destination(
     | GoogleSheetsDestination
     | PostgresDestination
     | MySQLDestination
+    | FileDestination
 ):
     from drt.config.models import (
         DiscordDestinationConfig,
+        FileDestinationConfig,
         GitHubActionsDestinationConfig,
         GoogleSheetsDestinationConfig,
         HubSpotDestinationConfig,
@@ -366,4 +369,8 @@ def _get_destination(
         return PostgresDestination()
     if isinstance(dest, MySQLDestinationConfig):
         return MySQLDestination()
+    if isinstance(dest, FileDestinationConfig):
+        from drt.destinations.file import FileDestination
+
+        return FileDestination()
     raise ValueError(f"Unsupported destination type: {dest.type}")

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -191,6 +191,12 @@ class MySQLDestinationConfig(BaseModel):
         return self
 
 
+class FileDestinationConfig(BaseModel):
+    type: Literal["file"]
+    path: str  # output file path, e.g. "output/data.csv"
+    format: Literal["csv", "json", "jsonl"] = "csv"
+
+
 # Discriminated union — add new destination types here
 DestinationConfig = Annotated[
     RestApiDestinationConfig
@@ -200,7 +206,8 @@ DestinationConfig = Annotated[
     | HubSpotDestinationConfig
     | GoogleSheetsDestinationConfig
     | PostgresDestinationConfig
-    | MySQLDestinationConfig,
+    | MySQLDestinationConfig
+    | FileDestinationConfig,
     Field(discriminator="type"),
 ]
 

--- a/drt/destinations/file.py
+++ b/drt/destinations/file.py
@@ -1,0 +1,83 @@
+"""File destination — write records to CSV, JSON, or JSONL files.
+
+No extra dependencies required (uses stdlib csv/json + built-in I/O).
+
+Example sync YAML:
+
+    destination:
+      type: file
+      path: output/users.csv
+      format: csv
+
+    destination:
+      type: file
+      path: output/users.json
+      format: json
+
+    destination:
+      type: file
+      path: output/users.jsonl
+      format: jsonl
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+from typing import Any
+
+from drt.config.models import DestinationConfig, FileDestinationConfig, SyncOptions
+from drt.destinations.base import SyncResult
+
+
+class FileDestination:
+    """Write records to a CSV, JSON, or JSONL file."""
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, FileDestinationConfig)
+        if not records:
+            return SyncResult()
+
+        result = SyncResult()
+
+        try:
+            os.makedirs(os.path.dirname(config.path) or ".", exist_ok=True)
+
+            if config.format == "csv":
+                self._write_csv(config.path, records)
+            elif config.format == "json":
+                self._write_json(config.path, records)
+            elif config.format == "jsonl":
+                self._write_jsonl(config.path, records)
+
+            result.success = len(records)
+        except Exception as e:
+            result.failed = len(records)
+            result.errors.append(str(e))
+
+        return result
+
+    @staticmethod
+    def _write_csv(path: str, records: list[dict[str, Any]]) -> None:
+        columns = list(records[0].keys())
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=columns)
+            writer.writeheader()
+            writer.writerows(records)
+
+    @staticmethod
+    def _write_json(path: str, records: list[dict[str, Any]]) -> None:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(records, f, indent=2, default=str)
+
+    @staticmethod
+    def _write_jsonl(path: str, records: list[dict[str, Any]]) -> None:
+        with open(path, "w", encoding="utf-8") as f:
+            for record in records:
+                f.write(json.dumps(record, default=str) + "\n")

--- a/tests/unit/test_file_destination.py
+++ b/tests/unit/test_file_destination.py
@@ -1,0 +1,167 @@
+"""Unit tests for CSV/JSON/JSONL file destination.
+
+Uses tmp_path for real file writes — no mocking needed, no extra dependencies.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from drt.config.models import FileDestinationConfig, SyncOptions
+from drt.destinations.file import FileDestination
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _options(**kwargs: Any) -> SyncOptions:
+    return SyncOptions(**kwargs)
+
+
+def _config(tmp_path: Path, **overrides: Any) -> FileDestinationConfig:
+    defaults: dict[str, Any] = {
+        "type": "file",
+        "path": str(tmp_path / "output.csv"),
+        "format": "csv",
+    }
+    defaults.update(overrides)
+    return FileDestinationConfig(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestFileDestinationConfig:
+    def test_valid_csv_config(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        assert config.format == "csv"
+
+    def test_json_format(self, tmp_path: Path) -> None:
+        config = _config(tmp_path, format="json")
+        assert config.format == "json"
+
+    def test_jsonl_format(self, tmp_path: Path) -> None:
+        config = _config(tmp_path, format="jsonl")
+        assert config.format == "jsonl"
+
+    def test_invalid_format_rejected(self, tmp_path: Path) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="format"):
+            _config(tmp_path, format="xml")
+
+
+# ---------------------------------------------------------------------------
+# CSV
+# ---------------------------------------------------------------------------
+
+
+class TestCsvDestination:
+    def test_csv_write(self, tmp_path: Path) -> None:
+        records = [
+            {"id": 1, "name": "alice", "score": 95},
+            {"id": 2, "name": "bob", "score": 80},
+        ]
+        config = _config(tmp_path)
+        result = FileDestination().load(records, config, _options())
+
+        assert result.success == 2
+        assert result.failed == 0
+        assert Path(config.path).exists()
+
+    def test_csv_content_readable(self, tmp_path: Path) -> None:
+        records = [
+            {"id": 1, "name": "alice"},
+            {"id": 2, "name": "bob"},
+        ]
+        config = _config(tmp_path)
+        FileDestination().load(records, config, _options())
+
+        with open(config.path, newline="", encoding="utf-8") as f:
+            reader = list(csv.DictReader(f))
+        assert len(reader) == 2
+        assert reader[0]["name"] == "alice"
+        assert reader[1]["name"] == "bob"
+
+    def test_csv_creates_parent_dirs(self, tmp_path: Path) -> None:
+        deep_path = str(tmp_path / "a" / "b" / "output.csv")
+        config = _config(tmp_path, path=deep_path)
+        result = FileDestination().load([{"id": 1}], config, _options())
+
+        assert result.success == 1
+        assert Path(deep_path).exists()
+
+
+# ---------------------------------------------------------------------------
+# JSON
+# ---------------------------------------------------------------------------
+
+
+class TestJsonDestination:
+    def test_json_write(self, tmp_path: Path) -> None:
+        records = [{"id": 1, "name": "alice"}, {"id": 2, "name": "bob"}]
+        config = _config(tmp_path, format="json", path=str(tmp_path / "out.json"))
+        result = FileDestination().load(records, config, _options())
+
+        assert result.success == 2
+        with open(config.path, encoding="utf-8") as f:
+            data = json.load(f)
+        assert len(data) == 2
+        assert data[0]["name"] == "alice"
+
+    def test_json_handles_non_serializable(self, tmp_path: Path) -> None:
+        from datetime import datetime
+
+        records = [{"id": 1, "ts": datetime(2026, 1, 1)}]
+        config = _config(tmp_path, format="json", path=str(tmp_path / "out.json"))
+        result = FileDestination().load(records, config, _options())
+
+        assert result.success == 1  # default=str handles it
+
+
+# ---------------------------------------------------------------------------
+# JSONL
+# ---------------------------------------------------------------------------
+
+
+class TestJsonlDestination:
+    def test_jsonl_write(self, tmp_path: Path) -> None:
+        records = [{"id": 1, "name": "alice"}, {"id": 2, "name": "bob"}]
+        config = _config(tmp_path, format="jsonl", path=str(tmp_path / "out.jsonl"))
+        result = FileDestination().load(records, config, _options())
+
+        assert result.success == 2
+        with open(config.path, encoding="utf-8") as f:
+            lines = [json.loads(line) for line in f]
+        assert len(lines) == 2
+        assert lines[1]["name"] == "bob"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestFileDestinationEdgeCases:
+    def test_empty_records(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        result = FileDestination().load([], config, _options())
+
+        assert result.success == 0
+        assert result.failed == 0
+        assert not Path(config.path).exists()
+
+    def test_error_returns_failure(self, tmp_path: Path) -> None:
+        config = _config(tmp_path, path="")
+        result = FileDestination().load([{"id": 1}], config, _options())
+
+        assert result.failed == 1
+        assert len(result.errors) > 0


### PR DESCRIPTION
Adds CSV/JSON/JSONL file destination (#67). Uses stdlib csv/json, no extra deps. 12 unit tests.
