### PR TITLE
chore: add secret file patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ Thumbs.db
 *.env
 .env*
 !.env.example
+*.pem
+*.key
+credentials.json
+service_account.json


### PR DESCRIPTION
## Summary
- Add `*.pem`, `*.key`, `credentials.json`, `service_account.json` to `.gitignore` to prevent accidental commit of sensitive files

Part of #118.

## Security settings audit result

| Check | Status | Action |
|-------|--------|--------|
| Dependabot alerts | ✅ Enabled | — |
| Dependabot security updates | ✅ Enabled | — |
| `dependabot.yml` | ✅ Exists (pip + github-actions, weekly) | — |
| Secret scanning | ✅ Enabled | — |
| Push protection | ⏭️ Skipped | See below |
| `.gitignore` secrets | ⚠️ Missing patterns | **This PR** |

### Push protection — skipped

Push protection can cause false positives on token-like strings, requiring admin bypass approval on each occurrence. Since secret scanning is already enabled (detects leaks post-push), the risk/burden tradeoff doesn't justify enabling it for a small OSS project at this stage.

## Test plan
- [ ] Verify `git status` does not track `*.pem`, `*.key`, `credentials.json`, `service_account.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)