### PR TITLE
chore: add codecov integration and coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,10 @@ jobs:
         run: make check-i18n || echo "::warning::Some translations are stale. Run 'make check-i18n' for details."
 
       - name: Test (pytest)
-        run: pytest
+        run: pytest --cov=drt --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml

--- a/README.ja.md
+++ b/README.ja.md
@@ -14,6 +14,7 @@
 > コードファーストのデータスタック向けのリバースETLツール。
 
 [![CI](https://github.com/drt-hub/drt/actions/workflows/ci.yml/badge.svg)](https://github.com/drt-hub/drt/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/drt-hub/drt/graph/badge.svg)](https://codecov.io/gh/drt-hub/drt)
 [![PyPI](https://img.shields.io/pypi/v/drt-core)](https://pypi.org/project/drt-core/)
 [![drt-core downloads](https://img.shields.io/pepy/dt/drt-core?label=drt-core%20downloads)](https://pepy.tech/projects/drt-core)
 [![dagster-drt downloads](https://img.shields.io/pepy/dt/dagster-drt?label=dagster-drt%20downloads)](https://pepy.tech/projects/dagster-drt)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 > Reverse ETL for the code-first data stack.
 
 [![CI](https://github.com/drt-hub/drt/actions/workflows/ci.yml/badge.svg)](https://github.com/drt-hub/drt/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/drt-hub/drt/graph/badge.svg)](https://codecov.io/gh/drt-hub/drt)
 [![PyPI](https://img.shields.io/pypi/v/drt-core)](https://pypi.org/project/drt-core/)
 [![drt-core downloads](https://img.shields.io/pepy/dt/drt-core?label=drt-core%20downloads)](https://pepy.tech/projects/drt-core)
 [![dagster-drt downloads](https://img.shields.io/pepy/dt/dagster-drt?label=dagster-drt%20downloads)](https://pepy.tech/projects/dagster-drt)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ mcp = ["fastmcp>=2.0"]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
+    "pytest-cov>=5.0",
     "pytest-httpserver>=1.0",
     "mypy>=1.10,<2",
     "ruff>=0.4,<1",


### PR DESCRIPTION
## Summary
- Add `pytest-cov` to dev dependencies
- Update CI to run `pytest --cov=drt --cov-report=xml` and upload to Codecov (Python 3.12 matrix only)
- Add codecov badge to README.md and README.ja.md

Closes #103.

## Test plan
- [ ] CI passes with coverage generation
- [ ] Codecov receives the upload and shows coverage report
- [ ] Badge renders on README

🤖 Generated with [Claude Code](https://claude.com/claude-code)