### PR TITLE
fix: add id-token permission for Codecov OIDC upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission to CI workflow for Codecov OIDC tokenless authentication
- Fixes codecov badge showing "unknown" after #103

codecov-action v5 defaults to OIDC auth, which silently fails without this permission.

## Test plan
- [ ] CI passes
- [ ] Codecov receives coverage upload (check Codecov dashboard)
- [ ] Badge updates from "unknown" to coverage percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)