### PR TITLE
fix: pass CODECOV_TOKEN for protected branch upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,4 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Pass `CODECOV_TOKEN` secret to codecov-action for authenticated upload
- Fixes "Token required because branch is protected" error on main branch

Follow-up to #207.

## Test plan
- [ ] CI passes
- [ ] Codecov upload succeeds (no "Token required" error in logs)
- [ ] Badge updates from "unknown" to coverage percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)