### PR TITLE
feat: add drt test command for post-sync validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ make fmt      # ruff format + fix
 ## Current Status
 
 - **v0.5 in progress** — Snowflake source, ClickHouse / Parquet / Teams / CSV+JSON destinations, Docker, test coverage
-- CLI fully wired: `init`, `run`, `list`, `validate`, `status`, `mcp run`
+- CLI fully wired: `init`, `run`, `list`, `validate`, `status`, `test`, `mcp run`
 - Sources: BigQuery, DuckDB, PostgreSQL, Redshift, SQLite, ClickHouse
 - Destinations: REST API, Slack, Discord, GitHub Actions, HubSpot, Google Sheets, PostgreSQL, MySQL, ClickHouse, Parquet, Microsoft Teams, CSV/JSON/JSONL
 - Integrations: MCP Server (`drt-core[mcp]`), dagster-drt, dbt manifest reader

--- a/docs/llm/API_REFERENCE.md
+++ b/docs/llm/API_REFERENCE.md
@@ -88,6 +88,13 @@ sync:                       # optional: all fields have defaults
     backoff_multiplier: 2.0 # default: 2.0
     max_backoff: 60.0       # default: 60.0 seconds
     retryable_status_codes: [429, 500, 502, 503, 504]  # default as shown
+
+tests:                      # optional: post-sync validation (DB destinations only)
+  - row_count:
+      min: 1                # optional: minimum expected rows
+      max: 10000            # optional: maximum expected rows
+  - not_null:
+      columns: [id, name]   # required: columns that must not contain NULLs
 ```
 
 ---

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -50,6 +50,9 @@ from drt.cli.output import (
     print_sync_result,
     print_sync_start,
     print_sync_table,
+    print_test_header,
+    print_test_result,
+    print_test_skip,
     print_validation_error,
     print_validation_ok,
 )
@@ -303,6 +306,95 @@ def status(
         print_status_verbose(states, {})
     else:
         print_status_table(states)
+
+
+# ---------------------------------------------------------------------------
+# test
+# ---------------------------------------------------------------------------
+
+
+@app.command(name="test")
+def test_syncs(
+    select: str = typer.Option(
+        None, "--select", "-s", help="Test a specific sync by name."
+    ),
+) -> None:
+    """Run post-sync validation tests."""
+    from drt.config.parser import load_syncs
+    from drt.destinations.query import (
+        execute_test_query,
+        get_table_name,
+        is_queryable,
+    )
+    from drt.engine.test_runner import build_test_query
+
+    syncs = load_syncs(Path("."))
+    if not syncs:
+        console.print("[dim]No syncs found.[/dim]")
+        return
+
+    if select:
+        syncs = [s for s in syncs if s.name == select]
+        if not syncs:
+            print_error(f"No sync named '{select}' found.")
+            raise typer.Exit(1)
+
+    syncs_with_tests = [s for s in syncs if s.tests]
+    if not syncs_with_tests:
+        console.print("[dim]No tests defined in any sync.[/dim]")
+        return
+
+    had_failures = False
+
+    for sync in syncs_with_tests:
+        print_test_header(sync.name)
+
+        if not is_queryable(sync.destination):
+            print_test_skip(
+                sync.name,
+                f"tests not supported for {sync.destination.type}"
+                " destinations",
+            )
+            continue
+
+        table = get_table_name(sync.destination)
+        for test_def in sync.tests:
+            test_name = _test_display_name(test_def)
+            try:
+                query, check = build_test_query(test_def, table)
+                result_val = execute_test_query(
+                    sync.destination, query
+                )
+                passed = check(result_val)
+                print_test_result(
+                    test_name, passed, str(result_val)
+                )
+                if not passed:
+                    had_failures = True
+            except Exception as e:
+                print_test_result(test_name, False, str(e))
+                had_failures = True
+
+    if had_failures:
+        raise typer.Exit(1)
+
+
+def _test_display_name(test_def: object) -> str:
+    """Human-readable name for a test definition."""
+    from drt.config.models import SyncTest
+
+    assert isinstance(test_def, SyncTest)
+    if test_def.row_count is not None:
+        parts = []
+        if test_def.row_count.min is not None:
+            parts.append(f"min={test_def.row_count.min}")
+        if test_def.row_count.max is not None:
+            parts.append(f"max={test_def.row_count.max}")
+        return f"row_count({', '.join(parts)})"
+    if test_def.not_null is not None:
+        cols = ", ".join(test_def.not_null.columns)
+        return f"not_null({cols})"
+    return "unknown"
 
 
 # ---------------------------------------------------------------------------

--- a/drt/cli/output.py
+++ b/drt/cli/output.py
@@ -111,6 +111,25 @@ def print_validation_error(sync_name: str, errors: list[str]) -> None:
 
 
 # ---------------------------------------------------------------------------
+# test
+# ---------------------------------------------------------------------------
+
+def print_test_header(sync_name: str) -> None:
+    console.print(f"\n[bold]{sync_name}[/bold]")
+
+
+def print_test_result(
+    test_name: str, passed: bool, message: str
+) -> None:
+    mark = "[green]✓[/green]" if passed else "[red]✗[/red]"
+    console.print(f"  {mark} {test_name}: {message}")
+
+
+def print_test_skip(sync_name: str, reason: str) -> None:
+    console.print(f"  [dim]⏭ {sync_name}: {reason}[/dim]")
+
+
+# ---------------------------------------------------------------------------
 # status
 # ---------------------------------------------------------------------------
 

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -294,9 +294,24 @@ class SyncOptions(BaseModel):
         return self
 
 
+class RowCountTest(BaseModel):
+    min: int | None = None
+    max: int | None = None
+
+
+class NotNullTest(BaseModel):
+    columns: list[str]
+
+
+class SyncTest(BaseModel):
+    row_count: RowCountTest | None = None
+    not_null: NotNullTest | None = None
+
+
 class SyncConfig(BaseModel):
     name: str
     description: str = ""
     model: str
     destination: DestinationConfig
     sync: SyncOptions = Field(default_factory=SyncOptions)
+    tests: list[SyncTest] = Field(default_factory=list)

--- a/drt/destinations/query.py
+++ b/drt/destinations/query.py
@@ -1,0 +1,92 @@
+"""Query destination databases for test validation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from drt.config.models import (
+    ClickHouseDestinationConfig,
+    DestinationConfig,
+    MySQLDestinationConfig,
+    PostgresDestinationConfig,
+)
+
+_QUERYABLE_TYPES = (
+    PostgresDestinationConfig,
+    MySQLDestinationConfig,
+    ClickHouseDestinationConfig,
+)
+
+
+def is_queryable(config: DestinationConfig) -> bool:
+    """Return True if we can run validation queries against this destination."""
+    return isinstance(config, _QUERYABLE_TYPES)
+
+
+def get_table_name(config: DestinationConfig) -> str:
+    """Extract the target table name from a DB destination config."""
+    if isinstance(config, PostgresDestinationConfig):
+        return config.table
+    if isinstance(config, MySQLDestinationConfig):
+        return config.table
+    if isinstance(config, ClickHouseDestinationConfig):
+        return config.table
+    raise TypeError(
+        f"Cannot get table name from {type(config).__name__}"
+    )
+
+
+def execute_test_query(config: DestinationConfig, query: str) -> int:
+    """Execute a query against a DB destination and return a single int."""
+    if isinstance(config, PostgresDestinationConfig):
+        return _query_postgres(config, query)
+    if isinstance(config, MySQLDestinationConfig):
+        return _query_mysql(config, query)
+    if isinstance(config, ClickHouseDestinationConfig):
+        return _query_clickhouse(config, query)
+    raise TypeError(f"Cannot query {type(config).__name__}")
+
+
+def _query_postgres(
+    config: PostgresDestinationConfig, query: str
+) -> int:
+    from drt.destinations.postgres import PostgresDestination
+
+    conn = PostgresDestination._connect(config)
+    try:
+        cur = conn.cursor()
+        cur.execute(query)
+        result: Any = cur.fetchone()[0]
+        return int(result)
+    finally:
+        conn.close()
+
+
+def _query_mysql(config: MySQLDestinationConfig, query: str) -> int:
+    from drt.destinations.mysql import MySQLDestination
+
+    conn = MySQLDestination._connect(config)
+    try:
+        cur = conn.cursor()
+        cur.execute(query)
+        row = cur.fetchone()
+        val: Any = (
+            row[0] if isinstance(row, tuple) else list(row.values())[0]
+        )
+        return int(val)
+    finally:
+        conn.close()
+
+
+def _query_clickhouse(
+    config: ClickHouseDestinationConfig, query: str
+) -> int:
+    from drt.destinations.clickhouse import ClickHouseDestination
+
+    client = ClickHouseDestination._connect(config)
+    try:
+        result = client.query(query)
+        val: Any = result.result_rows[0][0]
+        return int(val)
+    finally:
+        client.close()

--- a/drt/engine/test_runner.py
+++ b/drt/engine/test_runner.py
@@ -1,0 +1,59 @@
+"""Test runner — builds validation queries for drt test."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from drt.config.models import SyncTest
+
+
+@dataclass
+class TestResult:
+    test_name: str
+    passed: bool
+    message: str
+
+
+def _safe_table(table: str) -> str:
+    """Basic table name validation."""
+    for ch in table:
+        if not (ch.isalnum() or ch in "._"):
+            raise ValueError(f"Invalid character in table name: {ch!r}")
+    return table
+
+
+def build_test_query(
+    test: SyncTest, table: str
+) -> tuple[str, Callable[[int], bool]]:
+    """Return (SQL query, check_function) for a test.
+
+    The query returns a single integer.
+    The check function returns True if the test passes.
+    """
+    safe_table = _safe_table(table)
+
+    if test.row_count is not None:
+        rc = test.row_count
+        query = f"SELECT COUNT(*) FROM {safe_table}"
+
+        def check_row_count(val: int) -> bool:
+            if rc.min is not None and val < rc.min:
+                return False
+            if rc.max is not None and val > rc.max:
+                return False
+            return True
+
+        return query, check_row_count
+
+    if test.not_null is not None:
+        nn = test.not_null
+        conditions = " OR ".join(f"{col} IS NULL" for col in nn.columns)
+        query = f"SELECT COUNT(*) FROM {safe_table} WHERE {conditions}"
+
+        def check_not_null(val: int) -> bool:
+            return val == 0
+
+        return query, check_not_null
+
+    raise ValueError("No test type defined in SyncTest.")

--- a/drt/engine/test_runner.py
+++ b/drt/engine/test_runner.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 from drt.config.models import SyncTest
 

--- a/tests/unit/test_cli_test_command.py
+++ b/tests/unit/test_cli_test_command.py
@@ -1,0 +1,81 @@
+"""Tests for drt test CLI command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from drt.cli.main import app
+
+runner = CliRunner()
+
+
+def _write_sync(tmp_path: Path, data: dict) -> None:
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir(exist_ok=True)
+    with (syncs_dir / "sync.yml").open("w") as f:
+        yaml.dump(data, f)
+
+
+def test_drt_test_no_syncs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["test"])
+    assert "No syncs found" in result.output
+
+
+def test_drt_test_no_tests_defined(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_sync(tmp_path, {
+        "name": "no-tests",
+        "model": "SELECT 1",
+        "destination": {
+            "type": "rest_api",
+            "url": "http://example.com",
+            "method": "POST",
+        },
+    })
+    result = runner.invoke(app, ["test"])
+    assert "No tests defined" in result.output
+
+
+def test_drt_test_skips_non_queryable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_sync(tmp_path, {
+        "name": "api-sync",
+        "model": "SELECT 1",
+        "destination": {
+            "type": "rest_api",
+            "url": "http://example.com",
+            "method": "POST",
+        },
+        "tests": [{"row_count": {"min": 1}}],
+    })
+    result = runner.invoke(app, ["test"])
+    assert "not supported" in result.output.lower()
+
+
+def test_drt_test_select_not_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_sync(tmp_path, {
+        "name": "existing",
+        "model": "SELECT 1",
+        "destination": {
+            "type": "rest_api",
+            "url": "http://example.com",
+            "method": "POST",
+        },
+        "tests": [{"row_count": {"min": 1}}],
+    })
+    result = runner.invoke(app, ["test", "--select", "nonexistent"])
+    assert result.exit_code == 1

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -20,6 +20,7 @@ from drt.config.models import (
     SslConfig,
     SyncConfig,
     SyncOptions,
+    SyncTest,
 )
 from drt.config.parser import load_project, load_syncs
 
@@ -384,3 +385,42 @@ def test_mysql_config_no_connection_method_raises() -> None:
             table="scores",
             upsert_key=["id"],
         )
+
+
+# ---------------------------------------------------------------------------
+# SyncConfig tests
+# ---------------------------------------------------------------------------
+
+
+def test_sync_config_with_tests() -> None:
+    data = {
+        "name": "s",
+        "model": "SELECT 1",
+        "destination": {
+            "type": "rest_api",
+            "url": "http://x",
+            "method": "POST",
+        },
+        "tests": [
+            {"row_count": {"min": 1}},
+            {"not_null": {"columns": ["id", "name"]}},
+        ],
+    }
+    sync = SyncConfig.model_validate(data)
+    assert len(sync.tests) == 2
+    assert sync.tests[0].row_count is not None
+    assert sync.tests[1].not_null is not None
+
+
+def test_sync_config_without_tests() -> None:
+    data = {
+        "name": "s",
+        "model": "SELECT 1",
+        "destination": {
+            "type": "rest_api",
+            "url": "http://x",
+            "method": "POST",
+        },
+    }
+    sync = SyncConfig.model_validate(data)
+    assert sync.tests == []

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -20,7 +20,6 @@ from drt.config.models import (
     SslConfig,
     SyncConfig,
     SyncOptions,
-    SyncTest,
 )
 from drt.config.parser import load_project, load_syncs
 

--- a/tests/unit/test_destination_query.py
+++ b/tests/unit/test_destination_query.py
@@ -1,0 +1,40 @@
+"""Tests for destination query helpers."""
+
+from __future__ import annotations
+
+from drt.config.models import (
+    PostgresDestinationConfig,
+    RestApiDestinationConfig,
+)
+from drt.destinations.query import get_table_name, is_queryable
+
+
+def test_postgres_is_queryable() -> None:
+    config = PostgresDestinationConfig(
+        type="postgres",
+        host="localhost",
+        dbname="test",
+        table="public.users",
+        upsert_key=["id"],
+    )
+    assert is_queryable(config) is True
+
+
+def test_rest_api_is_not_queryable() -> None:
+    config = RestApiDestinationConfig(
+        type="rest_api",
+        url="http://example.com",
+        method="POST",
+    )
+    assert is_queryable(config) is False
+
+
+def test_get_table_name_postgres() -> None:
+    config = PostgresDestinationConfig(
+        type="postgres",
+        host="localhost",
+        dbname="test",
+        table="public.users",
+        upsert_key=["id"],
+    )
+    assert get_table_name(config) == "public.users"

--- a/tests/unit/test_test_runner.py
+++ b/tests/unit/test_test_runner.py
@@ -1,0 +1,53 @@
+"""Tests for drt test runner."""
+
+from __future__ import annotations
+
+import pytest
+
+from drt.config.models import NotNullTest, RowCountTest, SyncTest
+from drt.engine.test_runner import build_test_query
+
+
+def test_build_row_count_min() -> None:
+    t = SyncTest(row_count=RowCountTest(min=1))
+    query, check = build_test_query(t, "public.users")
+    assert "COUNT(*)" in query
+    assert check(5) is True
+    assert check(0) is False
+
+
+def test_build_row_count_max() -> None:
+    t = SyncTest(row_count=RowCountTest(max=100))
+    _, check = build_test_query(t, "public.users")
+    assert check(50) is True
+    assert check(101) is False
+
+
+def test_build_row_count_min_max() -> None:
+    t = SyncTest(row_count=RowCountTest(min=10, max=100))
+    _, check = build_test_query(t, "public.users")
+    assert check(50) is True
+    assert check(5) is False
+    assert check(101) is False
+
+
+def test_build_not_null() -> None:
+    t = SyncTest(not_null=NotNullTest(columns=["id", "name"]))
+    query, check = build_test_query(t, "public.users")
+    assert "id" in query
+    assert "name" in query
+    assert "NULL" in query.upper()
+    assert check(0) is True
+    assert check(3) is False
+
+
+def test_build_unknown_test_raises() -> None:
+    t = SyncTest()
+    with pytest.raises(ValueError, match="No test type"):
+        build_test_query(t, "public.users")
+
+
+def test_safe_table_rejects_injection() -> None:
+    t = SyncTest(row_count=RowCountTest(min=1))
+    with pytest.raises(ValueError, match="Invalid character"):
+        build_test_query(t, "users; DROP TABLE")


### PR DESCRIPTION
## Summary

Add `drt test` command for post-sync data validation, inspired by dbt's `dbt test`.

- **`row_count`** test: validate min/max row count in destination table
- **`not_null`** test: validate specified columns have no NULL values
- DB destinations supported: PostgreSQL, MySQL, ClickHouse
- Non-DB destinations (REST API, Slack, etc.) skipped with warning
- SQL injection protection via table name validation

Closes #141. See #233 for future test types (freshness, unique, accepted_values).

### Usage

```yaml
# syncs/users.yml
name: sync_users
model: SELECT * FROM users
destination:
  type: postgres
  ...
tests:
  - row_count:
      min: 1
  - not_null:
      columns: [user_id, email]
```

```bash
drt test                     # run all tests
drt test --select sync_users # run tests for specific sync
```

### Output
```
sync_users
  ✓ row_count(min=1): 42
  ✗ not_null(user_id, email): 3
```

### Files
| File | Change |
|------|--------|
| `drt/config/models.py` | Add `RowCountTest`, `NotNullTest`, `SyncTest` models; `tests` field on `SyncConfig` |
| `drt/engine/test_runner.py` | New — SQL query builder + result checker |
| `drt/destinations/query.py` | New — execute SELECT against DB destinations |
| `drt/cli/main.py` | Add `drt test` command |
| `drt/cli/output.py` | Add test output helpers |
| 4 test files | 15 new tests |

## Test plan
- [x] 275 total tests passing
- [x] ruff + mypy clean
- [x] SQL injection protection tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)