### PR TITLE
feat(destination): add Jira connector with create/update support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Jira destination connector** (#158): Create and update Jira issues via REST API v3 with env-based auth (`base_url_env`, `email_env`, `token_env`) and Jinja2 templates for issue fields.
 - **Microsoft Teams destination** (#85): Send messages to Teams channels via Incoming Webhook. Supports plain text and Adaptive Card payloads via Jinja2 templates. 10 unit tests. No extra dependencies.
 - **ClickHouse destination connector** (#166): Insert rows into ClickHouse tables using `clickhouse-connect` (HTTP client). Supports host, database, user, password (with `_env` variants), connection string, table, and HTTPS via `secure` flag. Deduplication relies on ClickHouse's ReplacingMergeTree engine. 16 unit tests. Install: `pip install drt-core[clickhouse]`.
 - **Parquet file destination** (#171): Write sync results to local Parquet files using pandas + pyarrow. Supports snappy/gzip/zstd compression and partition columns. 11 unit tests. Install: `pip install drt-core[parquet]`.
@@ -163,26 +164,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 #### MCP Server
+
 - `drt mcp run` — start a FastMCP server (stdio transport) for Claude Desktop, Cursor, and any MCP-compatible client
 - 5 MCP tools: `drt_list_syncs`, `drt_run_sync`, `drt_get_status`, `drt_validate`, `drt_get_schema`
 - Install: `pip install drt-core[mcp]`
 
 #### AI Skills for Claude Code
+
 - `.claude/commands/drt-create-sync.md` — `/drt-create-sync` skill: generate sync YAML from user intent
 - `.claude/commands/drt-debug.md` — `/drt-debug` skill: diagnose and fix failing syncs
 - `.claude/commands/drt-init.md` — `/drt-init` skill: guide through project initialization
 - `.claude/commands/drt-migrate.md` — `/drt-migrate` skill: migrate from Census/Hightouch to drt
 
 #### LLM-readable Docs
+
 - `docs/llm/CONTEXT.md` — architecture, key concepts, state file format (optimized for LLM consumption)
 - `docs/llm/API_REFERENCE.md` — all config fields with types, defaults, and full YAML examples
 
 #### Row-level Error Details
+
 - `RowError` dataclass: `batch_index`, `record_preview` (200-char PII-safe), `http_status`, `error_message`, `timestamp`
 - `drt run --verbose` and `drt status --verbose` show per-row error details
 - `RestApiDestination` now populates `row_errors` on each failure
 
 ### Tests
+
 - 82 tests total (up from 53 in v0.2)
 - MCP server tests auto-skip when `fastmcp` not installed
 
@@ -191,19 +197,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 #### Incremental Sync
+
 - `sync.mode: incremental` — watermark-based incremental sync using a `cursor_field`
 - Saves `last_cursor_value` in `.drt/state.json` after each run
 - Injects `WHERE {cursor_field} > '{last_cursor_value}'` automatically on next run
 - Works with both `ref('table')` and raw SQL models
 
 #### Retry Configuration
+
 - `sync.retry` is now fully configurable per-sync in YAML (`max_attempts`, `initial_backoff`, `backoff_multiplier`, `max_backoff`, `retryable_status_codes`)
 - Previously used a hardcoded default; now reads from `SyncOptions.retry`
 
 ### Fixed
+
 - Removed duplicate `RetryConfig` dataclass from `destinations/retry.py` (was shadowing the Pydantic model in `config/models.py`)
 
 ### Tests
+
 - 6 new unit tests for incremental sync (resolver + engine)
 - Integration test suite cleaned up: removed monkey-patching of internal `_DEFAULT_RETRY`
 
@@ -218,6 +228,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 #### CLI
+
 - `drt init` — interactive project wizard (supports BigQuery, DuckDB, PostgreSQL)
 - `drt run` — run all syncs or a specific sync (`--select`)
 - `drt run --dry-run` — preview without writing data
@@ -226,17 +237,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `drt status` — show recent sync run results
 
 #### Sources
+
 - BigQuery (`pip install drt-core[bigquery]`)
 - DuckDB (`pip install drt-core[duckdb]`)
 - PostgreSQL (`pip install drt-core[postgres]`)
 
 #### Destinations
+
 - REST API (core) — generic HTTP with Jinja2 body templates, auth, rate limiting, retry
 - Slack Incoming Webhook (core)
 - GitHub Actions `workflow_dispatch` trigger (core)
 - HubSpot Contacts / Deals / Companies upsert (core)
 
 #### Configuration
+
 - `profiles.yml` credential management (dbt-style, stored in `~/.drt/`)
 - Declarative sync YAML with Jinja2 templating
 - Auth: Bearer token, API key, Basic auth

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from drt.destinations.github_actions import GitHubActionsDestination
     from drt.destinations.google_sheets import GoogleSheetsDestination
     from drt.destinations.hubspot import HubSpotDestination
+    from drt.destinations.jira import JiraDestination
     from drt.destinations.mysql import MySQLDestination
     from drt.destinations.parquet import ParquetDestination
     from drt.destinations.postgres import PostgresDestination
@@ -499,6 +500,7 @@ def _get_destination(
     | DiscordDestination
     | GitHubActionsDestination
     | HubSpotDestination
+    | JiraDestination
     | GoogleSheetsDestination
     | PostgresDestination
     | MySQLDestination
@@ -514,6 +516,7 @@ def _get_destination(
         GitHubActionsDestinationConfig,
         GoogleSheetsDestinationConfig,
         HubSpotDestinationConfig,
+        JiraDestinationConfig,
         MySQLDestinationConfig,
         ParquetDestinationConfig,
         PostgresDestinationConfig,
@@ -525,6 +528,7 @@ def _get_destination(
     from drt.destinations.discord import DiscordDestination
     from drt.destinations.github_actions import GitHubActionsDestination
     from drt.destinations.hubspot import HubSpotDestination
+    from drt.destinations.jira import JiraDestination
     from drt.destinations.mysql import MySQLDestination
     from drt.destinations.postgres import PostgresDestination
     from drt.destinations.rest_api import RestApiDestination
@@ -541,6 +545,8 @@ def _get_destination(
         return GitHubActionsDestination()
     if isinstance(dest, HubSpotDestinationConfig):
         return HubSpotDestination()
+    if isinstance(dest, JiraDestinationConfig):
+        return JiraDestination()
     if isinstance(dest, GoogleSheetsDestinationConfig):
         from drt.destinations.google_sheets import GoogleSheetsDestination
 

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -201,6 +201,18 @@ class TeamsDestinationConfig(BaseModel):
     adaptive_card: bool = False
 
 
+class JiraDestinationConfig(BaseModel):
+    type: Literal["jira"]
+    base_url_env: str  # e.g. JIRA_BASE_URL -> https://myorg.atlassian.net
+    email_env: str  # Jira account email env var
+    token_env: str  # Jira API token env var
+    project_key: str  # can include Jinja2 template syntax
+    issue_type: str = "Task"  # can include Jinja2 template syntax
+    summary_template: str
+    description_template: str
+    issue_id_field: str = "issue_id"  # row key that indicates update mode
+
+
 class ClickHouseDestinationConfig(BaseModel):
     type: Literal["clickhouse"]
     connection_string_env: str | None = None
@@ -255,6 +267,7 @@ DestinationConfig = Annotated[
     | PostgresDestinationConfig
     | MySQLDestinationConfig
     | TeamsDestinationConfig
+    | JiraDestinationConfig
     | ClickHouseDestinationConfig
     | ParquetDestinationConfig
     | FileDestinationConfig,

--- a/drt/destinations/jira.py
+++ b/drt/destinations/jira.py
@@ -1,0 +1,199 @@
+"""Jira destination — create/update issues via Jira REST API v3.
+
+Uses Basic auth (email + API token) with environment-variable configuration.
+For each record:
+- If issue_id_field exists in row (default: issue_id), update that issue.
+- Otherwise, create a new issue.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+import httpx
+
+from drt.config.models import DestinationConfig, JiraDestinationConfig, RetryConfig, SyncOptions
+from drt.destinations.base import SyncResult
+from drt.destinations.rate_limiter import RateLimiter
+from drt.destinations.retry import with_retry
+from drt.destinations.row_errors import RowError
+from drt.templates.renderer import render_template
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_RETRY = RetryConfig(
+    max_attempts=3,
+    initial_backoff=1.0,
+    retryable_status_codes=(429, 500, 502, 503, 504),
+)
+
+
+class JiraDestination:
+    """Create or update Jira issues from sync records."""
+
+    _client: httpx.Client | None = None
+    _config: JiraDestinationConfig | None = None
+    _auth: httpx.BasicAuth | None = None
+
+    def create_issue(self, row: dict[str, Any]) -> None:
+        """Create a new Jira issue for one row."""
+        if self._client is None or self._config is None or self._auth is None:
+            raise RuntimeError("JiraDestination is not initialized. Call load() first.")
+
+        client = self._client
+        config = self._config
+        auth = self._auth
+        assert client is not None
+        assert config is not None
+        assert auth is not None
+
+        project_key = render_template(config.project_key, row)
+        issue_type = render_template(config.issue_type, row)
+        summary = render_template(config.summary_template, row)
+        description = render_template(config.description_template, row)
+
+        payload = {
+            "fields": {
+                "project": {"key": project_key},
+                "issuetype": {"name": issue_type},
+                "summary": summary,
+                "description": _to_adf(description),
+            }
+        }
+        url = f"{_base_url(config)}/rest/api/3/issue"
+
+        def do_post() -> httpx.Response:
+            response = client.post(url, json=payload, auth=auth)
+            response.raise_for_status()
+            return response
+
+        with_retry(do_post, _DEFAULT_RETRY)
+
+    def update_issue(self, row: dict[str, Any], issue_id: str) -> None:
+        """Update an existing Jira issue for one row."""
+        if self._client is None or self._config is None or self._auth is None:
+            raise RuntimeError("JiraDestination is not initialized. Call load() first.")
+
+        client = self._client
+        config = self._config
+        auth = self._auth
+        assert client is not None
+        assert config is not None
+        assert auth is not None
+
+        project_key = render_template(config.project_key, row)
+        issue_type = render_template(config.issue_type, row)
+        summary = render_template(config.summary_template, row)
+        description = render_template(config.description_template, row)
+
+        payload = {
+            "fields": {
+                "project": {"key": project_key},
+                "issuetype": {"name": issue_type},
+                "summary": summary,
+                "description": _to_adf(description),
+            }
+        }
+        url = f"{_base_url(config)}/rest/api/3/issue/{issue_id}"
+
+        def do_put() -> httpx.Response:
+            response = client.put(url, json=payload, auth=auth)
+            response.raise_for_status()
+            return response
+
+        with_retry(do_put, _DEFAULT_RETRY)
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, JiraDestinationConfig)
+
+        base_url = os.environ.get(config.base_url_env)
+        email = os.environ.get(config.email_env)
+        token = os.environ.get(config.token_env)
+        if not base_url:
+            raise ValueError(
+                f"Jira destination: env var '{config.base_url_env}' is required."
+            )
+        if not email:
+            raise ValueError(
+                f"Jira destination: env var '{config.email_env}' is required."
+            )
+        if not token:
+            raise ValueError(
+                f"Jira destination: env var '{config.token_env}' is required."
+            )
+
+        result = SyncResult()
+        rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
+        auth = httpx.BasicAuth(username=email, password=token)
+
+        with httpx.Client(timeout=30.0) as client:
+            self._client = client
+            self._config = config
+            self._auth = auth
+
+            for i, row in enumerate(records):
+                rate_limiter.acquire()
+                issue_id = row.get(config.issue_id_field)
+
+                try:
+                    if issue_id is not None and str(issue_id).strip():
+                        self.update_issue(row, str(issue_id))
+                        logger.info("Jira issue updated: %s", issue_id)
+                    else:
+                        self.create_issue(row)
+                        logger.info("Jira issue created for row index %s", i)
+                    result.success += 1
+                except httpx.HTTPStatusError as e:
+                    result.failed += 1
+                    logger.warning("Jira request failed for row %s: %s", i, e)
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(row)[:200],
+                            http_status=e.response.status_code,
+                            error_message=e.response.text[:500],
+                        )
+                    )
+                except Exception as e:
+                    result.failed += 1
+                    logger.warning("Jira destination failed for row %s: %s", i, e)
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(row)[:200],
+                            http_status=None,
+                            error_message=str(e),
+                        )
+                    )
+
+        self._client = None
+        self._config = None
+        self._auth = None
+        return result
+
+
+def _base_url(config: JiraDestinationConfig) -> str:
+    base_url = os.environ[config.base_url_env].rstrip("/")
+    return base_url
+
+
+def _to_adf(text: str) -> dict[str, Any]:
+    """Convert plain text to Atlassian Document Format (ADF)."""
+    return {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": text}],
+            }
+        ],
+    }

--- a/drt/destinations/jira.py
+++ b/drt/destinations/jira.py
@@ -34,21 +34,16 @@ _DEFAULT_RETRY = RetryConfig(
 class JiraDestination:
     """Create or update Jira issues from sync records."""
 
-    _client: httpx.Client | None = None
-    _config: JiraDestinationConfig | None = None
-    _auth: httpx.BasicAuth | None = None
-
-    def create_issue(self, row: dict[str, Any]) -> None:
+    def create_issue(
+        self,
+        row: dict[str, Any],
+        *,
+        client: httpx.Client,
+        config: JiraDestinationConfig,
+        auth: httpx.BasicAuth,
+        retry_config: RetryConfig,
+    ) -> None:
         """Create a new Jira issue for one row."""
-        if self._client is None or self._config is None or self._auth is None:
-            raise RuntimeError("JiraDestination is not initialized. Call load() first.")
-
-        client = self._client
-        config = self._config
-        auth = self._auth
-        assert client is not None
-        assert config is not None
-        assert auth is not None
 
         project_key = render_template(config.project_key, row)
         issue_type = render_template(config.issue_type, row)
@@ -70,29 +65,24 @@ class JiraDestination:
             response.raise_for_status()
             return response
 
-        with_retry(do_post, _DEFAULT_RETRY)
+        with_retry(do_post, retry_config)
 
-    def update_issue(self, row: dict[str, Any], issue_id: str) -> None:
+    def update_issue(
+        self,
+        row: dict[str, Any],
+        issue_id: str,
+        *,
+        client: httpx.Client,
+        config: JiraDestinationConfig,
+        auth: httpx.BasicAuth,
+        retry_config: RetryConfig,
+    ) -> None:
         """Update an existing Jira issue for one row."""
-        if self._client is None or self._config is None or self._auth is None:
-            raise RuntimeError("JiraDestination is not initialized. Call load() first.")
-
-        client = self._client
-        config = self._config
-        auth = self._auth
-        assert client is not None
-        assert config is not None
-        assert auth is not None
-
-        project_key = render_template(config.project_key, row)
-        issue_type = render_template(config.issue_type, row)
         summary = render_template(config.summary_template, row)
         description = render_template(config.description_template, row)
 
         payload = {
             "fields": {
-                "project": {"key": project_key},
-                "issuetype": {"name": issue_type},
                 "summary": summary,
                 "description": _to_adf(description),
             }
@@ -104,7 +94,7 @@ class JiraDestination:
             response.raise_for_status()
             return response
 
-        with_retry(do_put, _DEFAULT_RETRY)
+        with_retry(do_put, retry_config)
 
     def load(
         self,
@@ -133,22 +123,32 @@ class JiraDestination:
         result = SyncResult()
         rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
         auth = httpx.BasicAuth(username=email, password=token)
+        retry_config = sync_options.retry if sync_options.retry else _DEFAULT_RETRY
 
         with httpx.Client(timeout=30.0) as client:
-            self._client = client
-            self._config = config
-            self._auth = auth
-
             for i, row in enumerate(records):
                 rate_limiter.acquire()
                 issue_id = row.get(config.issue_id_field)
 
                 try:
                     if issue_id is not None and str(issue_id).strip():
-                        self.update_issue(row, str(issue_id))
+                        self.update_issue(
+                            row,
+                            str(issue_id),
+                            client=client,
+                            config=config,
+                            auth=auth,
+                            retry_config=retry_config,
+                        )
                         logger.info("Jira issue updated: %s", issue_id)
                     else:
-                        self.create_issue(row)
+                        self.create_issue(
+                            row,
+                            client=client,
+                            config=config,
+                            auth=auth,
+                            retry_config=retry_config,
+                        )
                         logger.info("Jira issue created for row index %s", i)
                     result.success += 1
                 except httpx.HTTPStatusError as e:
@@ -157,26 +157,26 @@ class JiraDestination:
                     result.row_errors.append(
                         RowError(
                             batch_index=i,
-                            record_preview=json.dumps(row)[:200],
+                            record_preview=_record_preview(row),
                             http_status=e.response.status_code,
                             error_message=e.response.text[:500],
                         )
                     )
+                    if sync_options.on_error == "fail":
+                        break
                 except Exception as e:
                     result.failed += 1
                     logger.warning("Jira destination failed for row %s: %s", i, e)
                     result.row_errors.append(
                         RowError(
                             batch_index=i,
-                            record_preview=json.dumps(row)[:200],
+                            record_preview=_record_preview(row),
                             http_status=None,
                             error_message=str(e),
                         )
                     )
-
-        self._client = None
-        self._config = None
-        self._auth = None
+                    if sync_options.on_error == "fail":
+                        break
         return result
 
 
@@ -197,3 +197,8 @@ def _to_adf(text: str) -> dict[str, Any]:
             }
         ],
     }
+
+
+def _record_preview(row: dict[str, Any]) -> str:
+    """Best-effort JSON preview that tolerates non-serializable values."""
+    return json.dumps(row, default=str)[:200]

--- a/examples/jira_test/jira_test_sync.yml
+++ b/examples/jira_test/jira_test_sync.yml
@@ -1,0 +1,21 @@
+name: jira_test_sync
+description: "Safe Jira destination smoke test (use dry-run)"
+
+# Reads from a table you can populate with the sample rows in test_data.py
+model: ref('jira_test_rows')
+
+destination:
+  type: jira
+  base_url_env: JIRA_BASE_URL
+  email_env: JIRA_EMAIL
+  token_env: JIRA_API_TOKEN
+  project_key: "ENG"
+  issue_type: "Task"
+  summary_template: "[drt test] {{ row.metric }} exceeded threshold"
+  description_template: "Value: {{ row.value }}, Threshold: {{ row.threshold }}"
+  issue_id_field: "issue_id"
+
+sync:
+  mode: full
+  batch_size: 10
+  on_error: fail

--- a/examples/jira_test/test_data.py
+++ b/examples/jira_test/test_data.py
@@ -1,0 +1,37 @@
+"""Example rows for Jira destination smoke testing.
+
+This file intentionally avoids any direct Jira API calls.
+Use these rows to populate a source table (e.g. DuckDB table: jira_test_rows),
+then run drt with --dry-run for a safe local verification.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+EXAMPLE_ROWS: list[dict[str, Any]] = [
+    {
+        # No issue_id -> create path when running non-dry mode
+        "issue_id": None,
+        "metric": "cpu_usage",
+        "value": 95,
+        "threshold": 80,
+    },
+    {
+        # Has issue_id -> update path when running non-dry mode
+        "issue_id": "ENG-123",
+        "metric": "memory_usage",
+        "value": 88,
+        "threshold": 75,
+    },
+]
+
+
+def print_rows() -> None:
+    """Quick preview helper."""
+    for row in EXAMPLE_ROWS:
+        print(row)
+
+
+if __name__ == "__main__":
+    print_rows()

--- a/tests/destinations/test_jira.py
+++ b/tests/destinations/test_jira.py
@@ -1,0 +1,137 @@
+"""Unit tests for JiraDestination with mocked httpx client."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from drt.config.models import JiraDestinationConfig, RateLimitConfig, RetryConfig, SyncOptions
+from drt.destinations.jira import JiraDestination
+
+
+def _options() -> SyncOptions:
+    return SyncOptions(
+        rate_limit=RateLimitConfig(requests_per_second=1000),
+        retry=RetryConfig(max_attempts=1, initial_backoff=0.0, backoff_multiplier=1.0),
+        on_error="skip",
+    )
+
+
+def _config(**overrides: object) -> JiraDestinationConfig:
+    data: dict[str, object] = {
+        "type": "jira",
+        "base_url_env": "JIRA_BASE_URL",
+        "email_env": "JIRA_EMAIL",
+        "token_env": "JIRA_API_TOKEN",
+        "project_key": "ENG",
+        "issue_type": "Task",
+        "summary_template": "Alert: {{ row.metric }} exceeded threshold",
+        "description_template": "Value: {{ row.value }}, Threshold: {{ row.threshold }}",
+    }
+    data.update(overrides)
+    return JiraDestinationConfig(**data)
+
+
+class TestJiraDestination:
+    def test_create_issue_uses_post(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JIRA_BASE_URL", "https://myorg.atlassian.net")
+        monkeypatch.setenv("JIRA_EMAIL", "bot@example.com")
+        monkeypatch.setenv("JIRA_API_TOKEN", "token-123")
+
+        row = {"metric": "cpu", "value": 95, "threshold": 80}
+        config = _config()
+
+        with patch("drt.destinations.jira.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            response = MagicMock()
+            response.raise_for_status.return_value = None
+            mock_client.post.return_value = response
+
+            result = JiraDestination().load([row], config, _options())
+
+        assert result.success == 1
+        assert result.failed == 0
+        mock_client.post.assert_called_once()
+        args, kwargs = mock_client.post.call_args
+        assert args[0] == "https://myorg.atlassian.net/rest/api/3/issue"
+        assert kwargs["json"]["fields"]["project"]["key"] == "ENG"
+        assert kwargs["json"]["fields"]["issuetype"]["name"] == "Task"
+        assert kwargs["json"]["fields"]["summary"] == "Alert: cpu exceeded threshold"
+
+    def test_update_issue_uses_put_when_issue_id_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("JIRA_BASE_URL", "https://myorg.atlassian.net")
+        monkeypatch.setenv("JIRA_EMAIL", "bot@example.com")
+        monkeypatch.setenv("JIRA_API_TOKEN", "token-123")
+
+        row = {
+            "issue_id": "ENG-123",
+            "metric": "memory",
+            "value": 88,
+            "threshold": 75,
+        }
+        config = _config()
+
+        with patch("drt.destinations.jira.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            response = MagicMock()
+            response.raise_for_status.return_value = None
+            mock_client.put.return_value = response
+
+            result = JiraDestination().load([row], config, _options())
+
+        assert result.success == 1
+        assert result.failed == 0
+        mock_client.put.assert_called_once()
+        args, kwargs = mock_client.put.call_args
+        assert args[0] == "https://myorg.atlassian.net/rest/api/3/issue/ENG-123"
+        assert kwargs["json"]["fields"]["summary"] == "Alert: memory exceeded threshold"
+
+    def test_templates_render_for_project_and_issue_type(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("JIRA_BASE_URL", "https://myorg.atlassian.net")
+        monkeypatch.setenv("JIRA_EMAIL", "bot@example.com")
+        monkeypatch.setenv("JIRA_API_TOKEN", "token-123")
+
+        row = {
+            "project": "OPS",
+            "itype": "Bug",
+            "metric": "latency",
+            "value": 420,
+            "threshold": 200,
+        }
+        config = _config(
+            project_key="{{ row.project }}",
+            issue_type="{{ row.itype }}",
+        )
+
+        with patch("drt.destinations.jira.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            response = MagicMock()
+            response.raise_for_status.return_value = None
+            mock_client.post.return_value = response
+
+            result = JiraDestination().load([row], config, _options())
+
+        assert result.success == 1
+        _, kwargs = mock_client.post.call_args
+        assert kwargs["json"]["fields"]["project"]["key"] == "OPS"
+        assert kwargs["json"]["fields"]["issuetype"]["name"] == "Bug"
+
+    def test_missing_env_var_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("JIRA_BASE_URL", raising=False)
+        monkeypatch.setenv("JIRA_EMAIL", "bot@example.com")
+        monkeypatch.setenv("JIRA_API_TOKEN", "token-123")
+
+        with pytest.raises(ValueError, match="JIRA_BASE_URL"):
+            JiraDestination().load(
+                [{"metric": "cpu", "value": 90, "threshold": 80}],
+                _config(),
+                _options(),
+            )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -13,6 +13,7 @@ from drt.config.models import (
     BasicAuth,
     BearerAuth,
     GoogleSheetsDestinationConfig,
+    JiraDestinationConfig,
     MySQLDestinationConfig,
     PostgresDestinationConfig,
     ProjectConfig,
@@ -302,6 +303,21 @@ def test_google_sheets_destination_defaults() -> None:
     assert cfg.mode == "overwrite"
     assert cfg.credentials_path is None
     assert cfg.credentials_env is None
+
+
+def test_jira_destination_defaults() -> None:
+    cfg = JiraDestinationConfig(
+        type="jira",
+        base_url_env="JIRA_BASE_URL",
+        email_env="JIRA_EMAIL",
+        token_env="JIRA_API_TOKEN",
+        project_key="ENG",
+        summary_template="Alert: {{ row.metric }}",
+        description_template="Value: {{ row.value }}",
+    )
+    assert cfg.type == "jira"
+    assert cfg.issue_type == "Task"
+    assert cfg.issue_id_field == "issue_id"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_jira_destination.py
+++ b/tests/unit/test_jira_destination.py
@@ -2,19 +2,21 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from drt.config.models import JiraDestinationConfig, RateLimitConfig, RetryConfig, SyncOptions
 from drt.destinations.jira import JiraDestination
 
 
-def _options() -> SyncOptions:
+def _options(on_error: str = "skip") -> SyncOptions:
     return SyncOptions(
         rate_limit=RateLimitConfig(requests_per_second=1000),
         retry=RetryConfig(max_attempts=1, initial_backoff=0.0, backoff_multiplier=1.0),
-        on_error="skip",
+        on_error=on_error,
     )
 
 
@@ -31,6 +33,19 @@ def _config(**overrides: object) -> JiraDestinationConfig:
     }
     data.update(overrides)
     return JiraDestinationConfig(**data)
+
+
+def _http_error(status: int, text: str) -> httpx.HTTPStatusError:
+    response = httpx.Response(
+        status_code=status,
+        text=text,
+        request=httpx.Request("POST", "http://x"),
+    )
+    return httpx.HTTPStatusError(
+        message=f"HTTP {status}",
+        request=response.request,
+        response=response,
+    )
 
 
 class TestJiraDestination:
@@ -89,6 +104,9 @@ class TestJiraDestination:
         mock_client.put.assert_called_once()
         args, kwargs = mock_client.put.call_args
         assert args[0] == "https://myorg.atlassian.net/rest/api/3/issue/ENG-123"
+        # Updates should not attempt project/type reassignment by default.
+        assert "project" not in kwargs["json"]["fields"]
+        assert "issuetype" not in kwargs["json"]["fields"]
         assert kwargs["json"]["fields"]["summary"] == "Alert: memory exceeded threshold"
 
     def test_templates_render_for_project_and_issue_type(
@@ -135,3 +153,47 @@ class TestJiraDestination:
                 _config(),
                 _options(),
             )
+
+    def test_on_error_fail_stops_within_batch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JIRA_BASE_URL", "https://myorg.atlassian.net")
+        monkeypatch.setenv("JIRA_EMAIL", "bot@example.com")
+        monkeypatch.setenv("JIRA_API_TOKEN", "token-123")
+
+        rows = [
+            {"metric": "cpu", "value": 95, "threshold": 80},
+            {"metric": "memory", "value": 88, "threshold": 75},
+        ]
+
+        with patch("drt.destinations.jira.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.side_effect = _http_error(400, "bad request")
+
+            result = JiraDestination().load(rows, _config(), _options(on_error="fail"))
+
+        assert result.failed == 1
+        assert result.success == 0
+        assert mock_client.post.call_count == 1
+
+    def test_non_serializable_row_preview_is_safe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JIRA_BASE_URL", "https://myorg.atlassian.net")
+        monkeypatch.setenv("JIRA_EMAIL", "bot@example.com")
+        monkeypatch.setenv("JIRA_API_TOKEN", "token-123")
+
+        row = {
+            "metric": "cpu",
+            "value": 95,
+            "threshold": 80,
+            "seen_at": datetime(2026, 1, 1, 12, 0, 0),
+        }
+
+        with patch("drt.destinations.jira.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.side_effect = _http_error(400, "bad request")
+
+            result = JiraDestination().load([row], _config(), _options())
+
+        assert result.failed == 1
+        assert result.row_errors
+        assert "seen_at" in result.row_errors[0].record_preview


### PR DESCRIPTION
# What does this PR do?

Adds a new **Jira destination connector** to `drt`, with support for:

- Creating Jira issues (`POST /rest/api/3/issue`)
- Updating Jira issues (`PUT /rest/api/3/issue/{issueIdOrKey}`)

It also includes:

- New **Jira destination config model** (`type: jira`) with env-based auth fields
- **CLI destination wiring** so Jira can be selected from sync YAML
- **Unit tests** for create/update behavior, template rendering, and missing env var handling
- Minimal **Jira example files** for local smoke testing

---

## Issues Closes

Closes #158

---

## Checklist

- [x] Tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Updated `CHANGELOG.md` 