### PR TITLE
docs: add "Your First Connector" step-by-step tutorial

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ chore: bump dependencies
 
 This walkthrough builds a complete destination connector from scratch. We'll create a simple **Console** destination that prints records to stdout — a useful debugging tool and a template for real connectors.
 
-By the end you'll have touched every file a new connector requires.
+By the end you'll have touched the core files needed to add a new connector. Before opening a PR, also check the checklist above for any additional required updates, such as adding an example under `examples/`.
 
 ### Step 1: Define the config model
 
@@ -218,7 +218,7 @@ class ConsoleDestination:
 - The class does **not** inherit from anything — it implements the `Destination` Protocol
 - `load()` must accept `records`, `config`, and `sync_options` with exact signatures
 - Use `assert isinstance(config, YourConfig)` for type narrowing
-- Return `SyncResult` — track `success`, `failed`, `errors`, and `row_errors`
+- Return `SyncResult` — track `success` and `failed`, use `errors` for general/batch-level failures, and use `row_errors` only when you have row-level context to report
 - Handle empty records as an early return
 - Use `try/finally` to close connections (see `PostgresDestination` for the pattern)
 
@@ -305,6 +305,14 @@ class TestConsoleDestinationLoad:
         result = ConsoleDestination().load([], _config(), _options())
         assert result.success == 0
         assert result.failed == 0
+
+    def test_error_handling(self, monkeypatch) -> None:
+        # Force json.dumps to fail
+        import json
+        monkeypatch.setattr(json, "dumps", lambda *a, **kw: (_ for _ in ()).throw(ValueError("boom")))
+        result = ConsoleDestination().load([{"id": 1}], _config(), _options())
+        assert result.failed == 1
+        assert "boom" in result.errors[0]
 ```
 
 **Test patterns to follow:**
@@ -320,7 +328,6 @@ If your destination needs an extra dependency:
 
 ```toml
 [project.optional-dependencies]
-console = []  # no extras needed for console
 clickhouse = ["clickhouse-connect>=0.7.0"]  # example with a real dependency
 ```
 
@@ -342,9 +349,7 @@ Add an entry under `[Unreleased] > Added`:
 git checkout -b feat/console-destination
 git add drt/destinations/console.py drt/config/models.py drt/cli/main.py \
         tests/unit/test_console_destination.py CHANGELOG.md
-git commit -m "feat: add Console destination connector
-
-Closes #NNN"
+git commit -m "feat: add Console destination connector" -m "Closes #NNN"
 make lint   # ruff + mypy must pass
 make test   # all tests must pass
 git push origin feat/console-destination

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,10 +129,243 @@ docs: update quickstart example
 chore: bump dependencies
 ```
 
-## Adding a Connector
+## Your First Connector — Step-by-Step Tutorial
 
-See `drt/sources/base.py` and `drt/destinations/base.py` for the Protocol interfaces.
-Implement the protocol, add tests under `tests/`, and add an example under `examples/`.
+This walkthrough builds a complete destination connector from scratch. We'll create a simple **Console** destination that prints records to stdout — a useful debugging tool and a template for real connectors.
+
+By the end you'll have touched every file a new connector requires.
+
+### Step 1: Define the config model
+
+Open `drt/config/models.py`. Add your config class after the existing destinations:
+
+```python
+class ConsoleDestinationConfig(BaseModel):
+    type: Literal["console"]
+    pretty: bool = True  # pretty-print JSON output
+```
+
+Then add it to the `DestinationConfig` union:
+
+```python
+DestinationConfig = Annotated[
+    RestApiDestinationConfig
+    | SlackDestinationConfig
+    # ... existing destinations ...
+    | ConsoleDestinationConfig,  # <-- add here
+    Field(discriminator="type"),
+]
+```
+
+**Key rules:**
+- `type` must be a `Literal` — this is how Pydantic discriminates between destination types
+- Use `_env` suffix fields for secrets (e.g. `api_key_env: str | None = None`)
+- Add a `@model_validator` if fields depend on each other (see `PostgresDestinationConfig` for an example)
+
+### Step 2: Implement the destination
+
+Create `drt/destinations/console.py`:
+
+```python
+"""Console destination — prints records to stdout for debugging.
+
+No extra dependencies required.
+
+Example sync YAML:
+
+    destination:
+      type: console
+      pretty: true
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from drt.config.models import ConsoleDestinationConfig, DestinationConfig, SyncOptions
+from drt.destinations.base import SyncResult
+
+
+class ConsoleDestination:
+    """Print records to stdout."""
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, ConsoleDestinationConfig)
+        if not records:
+            return SyncResult()
+
+        result = SyncResult()
+        indent = 2 if config.pretty else None
+
+        for record in records:
+            try:
+                print(json.dumps(record, indent=indent, default=str))
+                result.success += 1
+            except Exception as e:
+                result.failed += 1
+                result.errors.append(str(e))
+
+        return result
+```
+
+**Key rules:**
+- The class does **not** inherit from anything — it implements the `Destination` Protocol
+- `load()` must accept `records`, `config`, and `sync_options` with exact signatures
+- Use `assert isinstance(config, YourConfig)` for type narrowing
+- Return `SyncResult` — track `success`, `failed`, `errors`, and `row_errors`
+- Handle empty records as an early return
+- Use `try/finally` to close connections (see `PostgresDestination` for the pattern)
+
+### Step 3: Register in the CLI
+
+Open `drt/cli/main.py`. Three changes:
+
+**a) Add to `TYPE_CHECKING` imports (top of file):**
+
+```python
+if TYPE_CHECKING:
+    from drt.destinations.console import ConsoleDestination
+    # ... existing imports ...
+```
+
+**b) Add to `_get_destination()` return type:**
+
+```python
+def _get_destination(sync: SyncConfig) -> (
+    RestApiDestination
+    # ... existing types ...
+    | ConsoleDestination  # <-- add here
+):
+```
+
+**c) Add the isinstance check inside `_get_destination()`:**
+
+```python
+    if isinstance(dest, ConsoleDestinationConfig):
+        from drt.destinations.console import ConsoleDestination
+        return ConsoleDestination()
+```
+
+Also add `ConsoleDestinationConfig` to the lazy imports inside the function body.
+
+**Why lazy imports?** Destinations may have heavy optional dependencies (e.g. `clickhouse-connect`). Importing them at module level would force every user to install every extra. Lazy imports inside the function keep startup fast.
+
+### Step 4: Write tests
+
+Create `tests/unit/test_console_destination.py`:
+
+```python
+"""Unit tests for Console destination."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from drt.config.models import ConsoleDestinationConfig, SyncOptions
+from drt.destinations.console import ConsoleDestination
+
+
+def _options(**kwargs: Any) -> SyncOptions:
+    return SyncOptions(**kwargs)
+
+
+def _config(**overrides: Any) -> ConsoleDestinationConfig:
+    defaults: dict[str, Any] = {"type": "console", "pretty": True}
+    defaults.update(overrides)
+    return ConsoleDestinationConfig(**defaults)
+
+
+class TestConsoleDestinationConfig:
+    def test_valid_config(self) -> None:
+        config = _config()
+        assert config.type == "console"
+        assert config.pretty is True
+
+    def test_pretty_false(self) -> None:
+        config = _config(pretty=False)
+        assert config.pretty is False
+
+
+class TestConsoleDestinationLoad:
+    def test_success(self, capsys) -> None:
+        records = [{"id": 1, "name": "alice"}, {"id": 2, "name": "bob"}]
+        result = ConsoleDestination().load(records, _config(), _options())
+        assert result.success == 2
+        assert result.failed == 0
+        output = capsys.readouterr().out
+        assert "alice" in output
+
+    def test_empty_records(self) -> None:
+        result = ConsoleDestination().load([], _config(), _options())
+        assert result.success == 0
+        assert result.failed == 0
+```
+
+**Test patterns to follow:**
+- `_config()` helper with defaults — easy to override per test
+- `_options()` wraps `SyncOptions` with kwargs
+- Test config validation, success path, empty records, and error handling
+- For HTTP destinations, use `pytest-httpserver` (see `test_teams_destination.py`)
+- For DB destinations, mock the connection (see `test_postgres_destination.py`)
+
+### Step 5: Add to pyproject.toml (if needed)
+
+If your destination needs an extra dependency:
+
+```toml
+[project.optional-dependencies]
+console = []  # no extras needed for console
+clickhouse = ["clickhouse-connect>=0.7.0"]  # example with a real dependency
+```
+
+Users install with: `pip install drt-core[clickhouse]`
+
+If your destination uses only stdlib or core dependencies, skip this step.
+
+### Step 6: Update CHANGELOG.md
+
+Add an entry under `[Unreleased] > Added`:
+
+```markdown
+- **Console destination** (#NNN): Print sync records to stdout for debugging. No extra dependencies. N unit tests.
+```
+
+### Step 7: Submit your PR
+
+```bash
+git checkout -b feat/console-destination
+git add drt/destinations/console.py drt/config/models.py drt/cli/main.py \
+        tests/unit/test_console_destination.py CHANGELOG.md
+git commit -m "feat: add Console destination connector
+
+Closes #NNN"
+make lint   # ruff + mypy must pass
+make test   # all tests must pass
+git push origin feat/console-destination
+```
+
+Open a PR with:
+- What it does (1-2 sentences)
+- `Closes #NNN`
+- Checklist items checked
+
+### Quick reference — files to touch
+
+```
+New connector checklist:
+  drt/config/models.py           → add YourDestinationConfig + add to union
+  drt/destinations/your_dest.py  → implement load() method
+  drt/cli/main.py                → TYPE_CHECKING import + return type + isinstance check
+  tests/unit/test_your_dest.py   → config + load tests
+  pyproject.toml                 → add [your_dest] extra (if external deps)
+  CHANGELOG.md                   → document under [Unreleased]
+```
 
 Do **not** change the `Source` or `Destination` protocol signatures without prior discussion — these are stable interfaces designed for a future Rust rewrite.
 


### PR DESCRIPTION
Replaces the 2-line "Adding a Connector" section with a complete 7-step walkthrough using a Console destination as the example. Covers config model, destination class, CLI registration, tests, pyproject.toml extras, changelog, and PR submission.

Closes #216


## Checklist

- [ ] Tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Updated `CHANGELOG.md` (if user-facing change)
