### PR TITLE
test: add source and destination protocol contract tests

### DIFF
--- a/tests/unit/test_destination_contract.py
+++ b/tests/unit/test_destination_contract.py
@@ -1,0 +1,61 @@
+"""Contract tests — verify all Destination implementations conform to Protocol."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from drt.destinations.base import Destination, SyncResult
+from drt.destinations.clickhouse import ClickHouseDestination
+from drt.destinations.discord import DiscordDestination
+from drt.destinations.file import FileDestination
+from drt.destinations.github_actions import GitHubActionsDestination
+from drt.destinations.google_sheets import GoogleSheetsDestination
+from drt.destinations.hubspot import HubSpotDestination
+from drt.destinations.mysql import MySQLDestination
+from drt.destinations.parquet import ParquetDestination
+from drt.destinations.postgres import PostgresDestination
+from drt.destinations.rest_api import RestApiDestination
+from drt.destinations.slack import SlackDestination
+from drt.destinations.teams import TeamsDestination
+
+ALL_DESTINATIONS = [
+    ClickHouseDestination,
+    DiscordDestination,
+    FileDestination,
+    GitHubActionsDestination,
+    GoogleSheetsDestination,
+    HubSpotDestination,
+    MySQLDestination,
+    ParquetDestination,
+    PostgresDestination,
+    RestApiDestination,
+    SlackDestination,
+    TeamsDestination,
+]
+
+
+@pytest.mark.parametrize(
+    "cls", ALL_DESTINATIONS, ids=lambda c: c.__name__
+)
+def test_implements_destination_protocol(cls: type) -> None:
+    assert isinstance(cls(), Destination)
+
+
+@pytest.mark.parametrize(
+    "cls", ALL_DESTINATIONS, ids=lambda c: c.__name__
+)
+def test_load_method_signature(cls: type) -> None:
+    sig = inspect.signature(cls.load)
+    params = list(sig.parameters.keys())
+    assert params == ["self", "records", "config", "sync_options"]
+
+
+@pytest.mark.parametrize(
+    "cls", ALL_DESTINATIONS, ids=lambda c: c.__name__
+)
+def test_load_return_annotation(cls: type) -> None:
+    sig = inspect.signature(cls.load)
+    ann = sig.return_annotation
+    assert ann is SyncResult or ann == "SyncResult"

--- a/tests/unit/test_source_contract.py
+++ b/tests/unit/test_source_contract.py
@@ -1,0 +1,51 @@
+"""Contract tests — verify all Source implementations conform to Protocol."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from drt.sources.base import Source
+from drt.sources.bigquery import BigQuerySource
+from drt.sources.clickhouse import ClickHouseSource
+from drt.sources.duckdb import DuckDBSource
+from drt.sources.postgres import PostgresSource
+from drt.sources.redshift import RedshiftSource
+from drt.sources.snowflake import SnowflakeSource
+from drt.sources.sqlite import SQLiteSource
+
+ALL_SOURCES = [
+    BigQuerySource,
+    ClickHouseSource,
+    DuckDBSource,
+    PostgresSource,
+    RedshiftSource,
+    SnowflakeSource,
+    SQLiteSource,
+]
+
+
+@pytest.mark.parametrize(
+    "cls", ALL_SOURCES, ids=lambda c: c.__name__
+)
+def test_implements_source_protocol(cls: type) -> None:
+    assert isinstance(cls(), Source)
+
+
+@pytest.mark.parametrize(
+    "cls", ALL_SOURCES, ids=lambda c: c.__name__
+)
+def test_extract_method_signature(cls: type) -> None:
+    sig = inspect.signature(cls.extract)
+    params = list(sig.parameters.keys())
+    assert params == ["self", "query", "config"]
+
+
+@pytest.mark.parametrize(
+    "cls", ALL_SOURCES, ids=lambda c: c.__name__
+)
+def test_test_connection_method_signature(cls: type) -> None:
+    sig = inspect.signature(cls.test_connection)
+    params = list(sig.parameters.keys())
+    assert params == ["self", "config"]


### PR DESCRIPTION
## Summary
- **#209**: 36 parameterized tests verifying all 12 destinations conform to `Destination` Protocol (implements protocol, `load()` signature, return annotation)
- **#210**: 21 parameterized tests verifying all 7 sources conform to `Source` Protocol (implements protocol, `extract()` signature, `test_connection()` signature)

Ensures interface stability as connectors grow and prepares for future Rust migration.

Closes #209, closes #210.

## Test plan
- [x] 57 new contract tests passing
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)