### PR TITLE
chore: set codecov checks to informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: auto
+        informational: true
     patch:
       default:
         informational: true


### PR DESCRIPTION
## Summary

Set both `project` and `patch` coverage checks to `informational` — they report on PRs but do not block merges.

Closes #212.

## Decision rationale

The original issue proposed enforcing 80% coverage threshold. After experience with Codecov in v0.5 development, we're taking a different approach:

| Factor | Observation |
|--------|-------------|
| DB connector code | `_connect()`, `_query_*()` etc. require real DB connections — cannot be unit tested |
| Contributor activity | Active connector PRs (#148, #194, #195, etc.) would be blocked by thresholds |
| Patch coverage | Already caused CI friction on #231, resolved by setting patch to informational |
| Coverage visibility | PR comment reports are already working and provide sufficient awareness |
| Project phase | v0.5, growing contributors — reducing friction > enforcing floor |

**What we keep:** Codecov badge on README (64%), PR comment reports showing coverage changes.

**What we don't do:** Block PRs based on coverage numbers.

This can be revisited post-v1.0 when the API stabilizes and integration test infrastructure is in place.

## Test plan
- [x] `codecov.yml` syntax valid
- [ ] CI passes
- [ ] Codecov checks show as informational (not blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)