### PR TITLE
feat: add --profile CLI override and DRT_PROFILE env var

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -67,6 +68,21 @@ app = typer.Typer(
 )
 
 
+def _resolve_profile_name(
+    cli_flag: str | None, project_profile: str
+) -> str:
+    """Resolve which profile to use.
+
+    Precedence: --profile flag > DRT_PROFILE env var > drt_project.yml
+    """
+    if cli_flag:
+        return cli_flag
+    env = os.environ.get("DRT_PROFILE")
+    if env:
+        return env
+    return project_profile
+
+
 def version_callback(value: bool) -> None:
     if value:
         console.print(f"drt version {__version__}")
@@ -115,6 +131,9 @@ def run(
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview without writing data."),
     verbose: bool = typer.Option(False, "--verbose", help="Show row-level error details."),
     output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
+    profile_name: str = typer.Option(
+        None, "--profile", "-p", help="Override profile (default: drt_project.yml or DRT_PROFILE)."
+    ),
 ) -> None:
     """Run sync(s) defined in the project."""
     import json as json_mod
@@ -132,8 +151,9 @@ def run(
         print_error(str(e))
         raise typer.Exit(1)
 
+    resolved = _resolve_profile_name(profile_name, project.profile)
     try:
-        profile = load_profile(project.profile)
+        profile = load_profile(resolved)
     except (FileNotFoundError, KeyError, ValueError) as e:
         print_error(str(e))
         raise typer.Exit(1)

--- a/tests/unit/test_cli_profile_override.py
+++ b/tests/unit/test_cli_profile_override.py
@@ -1,0 +1,36 @@
+"""Tests for --profile CLI override and DRT_PROFILE env var."""
+
+from __future__ import annotations
+
+from drt.cli.main import _resolve_profile_name
+
+
+def test_cli_flag_takes_precedence() -> None:
+    assert _resolve_profile_name("prd", "default") == "prd"
+
+
+def test_env_var_overrides_project(monkeypatch: object) -> None:
+    import pytest
+
+    mp = pytest.MonkeyPatch()
+    mp.setenv("DRT_PROFILE", "staging")
+    assert _resolve_profile_name(None, "default") == "staging"
+    mp.undo()
+
+
+def test_project_profile_is_fallback(monkeypatch: object) -> None:
+    import pytest
+
+    mp = pytest.MonkeyPatch()
+    mp.delenv("DRT_PROFILE", raising=False)
+    assert _resolve_profile_name(None, "default") == "default"
+    mp.undo()
+
+
+def test_cli_flag_beats_env_var(monkeypatch: object) -> None:
+    import pytest
+
+    mp = pytest.MonkeyPatch()
+    mp.setenv("DRT_PROFILE", "staging")
+    assert _resolve_profile_name("prd", "default") == "prd"
+    mp.undo()


### PR DESCRIPTION
## Summary

Support runtime profile override for multi-environment setups (dev/stg/prd).

```bash
drt run --profile prd --select my_sync       # CLI flag
DRT_PROFILE=prd drt run --select my_sync     # env var (CI/Dagster)
```

### Precedence
1. `--profile` CLI flag (highest)
2. `DRT_PROFILE` environment variable
3. `drt_project.yml` `profile:` field (default)

Closes #238.

## Test plan
- [x] 4 tests for profile resolution precedence
- [x] 350 total tests passing
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)