### PR TITLE
feat: connect dbt manifest reader to resolver for ref() resolution

### DIFF
--- a/drt/engine/resolver.py
+++ b/drt/engine/resolver.py
@@ -3,10 +3,9 @@
 Mirrors dbt's ref() concept but without requiring a dbt manifest.
 Resolution order:
   1. syncs/models/{name}.sql  — raw SQL file wins
-  2. ref('name')              — SELECT * FROM {dataset}.{name}
-  3. anything else            — used as SQL directly
-
-Future: integrate with dbt manifest.json for full dbt compatibility.
+  2. dbt target/manifest.json — fully-qualified relation_name from dbt
+  3. ref('name')              — SELECT * FROM {dataset}.{name}
+  4. anything else            — used as SQL directly
 """
 
 from __future__ import annotations
@@ -67,10 +66,13 @@ def resolve_model_ref(
     table_name = parse_ref(model_str)
 
     if table_name is not None:
-        # Check for a hand-written SQL file first
+        # 1. Check for a hand-written SQL file first
         sql_file = project_dir / "syncs" / "models" / f"{table_name}.sql"
         if sql_file.exists():
             base_sql = sql_file.read_text().strip()
+        # 2. Check dbt manifest.json
+        elif (dbt_table := _resolve_from_dbt(table_name, project_dir)) is not None:
+            base_sql = f"SELECT * FROM {dbt_table}"
         elif isinstance(profile, BigQueryProfile):
             base_sql = f"SELECT * FROM `{profile.dataset}`.`{table_name}`"
         elif isinstance(profile, DuckDBProfile):
@@ -103,6 +105,13 @@ def resolve_model_ref(
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _resolve_from_dbt(table_name: str, project_dir: Path) -> str | None:
+    """Try to resolve a table name from dbt manifest.json."""
+    from drt.integrations.dbt import resolve_ref_from_manifest
+
+    return resolve_ref_from_manifest(table_name, project_dir)
+
 
 _SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
 

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -92,6 +92,62 @@ def test_resolve_no_cursor_returns_base_sql(tmp_path: Path) -> None:
     assert "WHERE" not in sql
 
 
+# ---------------------------------------------------------------------------
+# dbt manifest resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_ref_from_dbt_manifest(tmp_path: Path) -> None:
+    """ref() should resolve from dbt manifest.json when available."""
+    import json
+
+    target = tmp_path / "target"
+    target.mkdir()
+    manifest = {
+        "nodes": {
+            "model.my_project.users": {
+                "name": "users",
+                "relation_name": '"analytics"."public"."users"',
+            }
+        }
+    }
+    (target / "manifest.json").write_text(json.dumps(manifest))
+
+    sql = resolve_model_ref("ref('users')", tmp_path, _profile())
+    assert sql == 'SELECT * FROM "analytics"."public"."users"'
+
+
+def test_resolve_ref_dbt_manifest_not_found_falls_back(tmp_path: Path) -> None:
+    """Without manifest.json, ref() falls back to profile-based resolution."""
+    sql = resolve_model_ref("ref('users')", tmp_path, _profile("ds"))
+    assert sql == "SELECT * FROM `ds`.`users`"
+
+
+def test_resolve_ref_sql_file_beats_dbt_manifest(tmp_path: Path) -> None:
+    """SQL file should take priority over dbt manifest."""
+    import json
+
+    # Create SQL file
+    models = tmp_path / "syncs" / "models"
+    models.mkdir(parents=True)
+    (models / "users.sql").write_text("SELECT id, name FROM raw.users")
+
+    # Create dbt manifest
+    target = tmp_path / "target"
+    target.mkdir()
+    manifest = {
+        "nodes": {
+            "model.proj.users": {
+                "name": "users",
+                "relation_name": '"analytics"."users"',
+            }
+        }
+    }
+    (target / "manifest.json").write_text(json.dumps(manifest))
+
+    sql = resolve_model_ref("ref('users')", tmp_path, _profile())
+    assert sql == "SELECT id, name FROM raw.users"
+
+
 def test_resolve_incremental_raw_sql(tmp_path: Path) -> None:
     raw = "SELECT * FROM events WHERE active = true"
     sql = resolve_model_ref(


### PR DESCRIPTION
## Summary
- `ref('model_name')` now resolves from dbt `target/manifest.json` when available
- Resolution order: SQL file > dbt manifest > profile-based expansion
- Uses existing `resolve_ref_from_manifest()` from `drt/integrations/dbt.py`

Closes #239.

## Test plan
- [x] 3 new tests (manifest resolution, fallback, SQL file priority)
- [x] 15 resolver tests passing
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)