### PR TITLE
feat: add env var substitution in sync YAML model field

### DIFF
--- a/drt/engine/resolver.py
+++ b/drt/engine/resolver.py
@@ -10,6 +10,7 @@ Resolution order:
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
@@ -90,6 +91,9 @@ def resolve_model_ref(
         # Not a ref() — treat as raw SQL or bare table name
         base_sql = model_str
 
+    # Expand environment variables: ${VAR} syntax
+    base_sql = _expand_env_vars(base_sql)
+
     # Inject incremental WHERE clause when cursor info is available
     if cursor_field and last_cursor_value:
         safe_field = _validate_cursor_field(cursor_field)
@@ -111,6 +115,26 @@ def _resolve_from_dbt(table_name: str, project_dir: Path) -> str | None:
     from drt.integrations.dbt import resolve_ref_from_manifest
 
     return resolve_ref_from_manifest(table_name, project_dir)
+
+
+_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+
+def _expand_env_vars(sql: str) -> str:
+    """Expand ``${VAR}`` placeholders with environment variable values.
+
+    Raises ``ValueError`` if a referenced variable is not set.
+    """
+    def _replace(match: re.Match[str]) -> str:
+        var = match.group(1)
+        val = os.environ.get(var)
+        if val is None:
+            raise ValueError(
+                f"Environment variable ${{{var}}} is not set"
+            )
+        return val
+
+    return _ENV_VAR_PATTERN.sub(_replace, sql)
 
 
 _SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from drt.config.credentials import BigQueryProfile
 from drt.engine.resolver import parse_ref, resolve_model_ref
 
@@ -159,3 +161,50 @@ def test_resolve_incremental_raw_sql(tmp_path: Path) -> None:
     )
     assert "WHERE updated_at > '2024-06-01'" in sql
     assert raw in sql
+
+
+# ---------------------------------------------------------------------------
+# environment variable substitution
+# ---------------------------------------------------------------------------
+
+def test_env_var_substitution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("BQ_DATASET", "analytics")
+    sql = resolve_model_ref(
+        "SELECT * FROM `${BQ_DATASET}`.users",
+        tmp_path,
+        _profile(),
+    )
+    assert sql == "SELECT * FROM `analytics`.users"
+
+
+def test_env_var_multiple(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GCP_PROJECT", "my-proj")
+    monkeypatch.setenv("BQ_DATASET", "raw")
+    sql = resolve_model_ref(
+        "SELECT * FROM `${GCP_PROJECT}.${BQ_DATASET}.users`",
+        tmp_path,
+        _profile(),
+    )
+    assert sql == "SELECT * FROM `my-proj.raw.users`"
+
+
+def test_env_var_missing_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="NONEXISTENT_VAR"):
+        resolve_model_ref(
+            "SELECT * FROM ${NONEXISTENT_VAR}.users",
+            tmp_path,
+            _profile(),
+        )
+
+
+def test_env_var_no_expansion_without_syntax(tmp_path: Path) -> None:
+    sql = resolve_model_ref(
+        "SELECT * FROM users",
+        tmp_path,
+        _profile(),
+    )
+    assert sql == "SELECT * FROM users"


### PR DESCRIPTION
## Summary
- Support `${VAR}` syntax in `model:` field for environment-specific SQL
- Raises `ValueError` if a referenced variable is not set
- Lower-priority complement to #238 (profile override) and #239 (dbt manifest)

```yaml
model: SELECT * FROM `${GCP_PROJECT}.${BQ_DATASET}.users`
```

Closes #240.

## Test plan
- [x] 4 new tests (single var, multiple vars, missing var, no expansion)
- [x] 16 resolver tests passing
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)