### PR TITLE
feat: add secrets.toml for local secret management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,5 @@ Thumbs.db
 *.pem
 *.key
 credentials.json
+secrets.toml
 service_account.json

--- a/drt/config/credentials.py
+++ b/drt/config/credentials.py
@@ -193,12 +193,55 @@ def _config_dir(override: Path | None = None) -> Path:
     return override if override is not None else Path.home() / ".drt"
 
 
+def _load_secrets(project_dir: Path | None = None) -> dict[str, Any]:
+    """Load .drt/secrets.toml if it exists.
+
+    Returns a nested dict matching the TOML structure.
+    """
+    secrets_path = (project_dir or Path(".")) / ".drt" / "secrets.toml"
+    if not secrets_path.exists():
+        return {}
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # Python 3.10
+        try:
+            import tomli as tomllib  # type: ignore[no-redef]
+        except ModuleNotFoundError:
+            return {}
+    with secrets_path.open("rb") as f:
+        data: dict[str, Any] = tomllib.load(f)
+    return data
+
+
+def _lookup_secrets_toml(env_var: str) -> str | None:
+    """Look up an env-var-style key in secrets.toml.
+
+    Walks all nested dicts searching for a matching key.
+    """
+    secrets = _load_secrets()
+
+    def _search(d: dict[str, Any]) -> str | None:
+        for k, v in d.items():
+            if k == env_var and isinstance(v, str):
+                return v
+            if isinstance(v, dict):
+                found = _search(v)
+                if found is not None:
+                    return found
+        return None
+
+    return _search(secrets)
+
+
 def resolve_env(value: str | None, env_var: str | None) -> str | None:
-    """Resolve a secret value: explicit value → env var → None."""
+    """Resolve a secret value: explicit value → env var → secrets.toml → None."""
     if value is not None:
         return value
     if env_var is not None:
-        return os.environ.get(env_var)
+        env_val = os.environ.get(env_var)
+        if env_val is not None:
+            return env_val
+        return _lookup_secrets_toml(env_var)
     return None
 
 

--- a/tests/unit/test_secrets_toml.py
+++ b/tests/unit/test_secrets_toml.py
@@ -1,0 +1,84 @@
+"""Tests for secrets.toml support in resolve_env()."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from drt.config.credentials import _load_secrets, resolve_env
+
+# ---------------------------------------------------------------------------
+# _load_secrets
+# ---------------------------------------------------------------------------
+
+
+def test_load_secrets_missing_file(tmp_path: Path) -> None:
+    assert _load_secrets(tmp_path) == {}
+
+
+def test_load_secrets_valid(tmp_path: Path) -> None:
+    secrets_dir = tmp_path / ".drt"
+    secrets_dir.mkdir()
+    (secrets_dir / "secrets.toml").write_text(
+        '[destinations.mysql]\nMYSQL_PASSWORD = "secret123"\n'
+    )
+    data = _load_secrets(tmp_path)
+    assert data["destinations"]["mysql"]["MYSQL_PASSWORD"] == "secret123"
+
+
+# ---------------------------------------------------------------------------
+# resolve_env with secrets.toml
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_env_explicit_value() -> None:
+    assert resolve_env("explicit", "SOME_VAR") == "explicit"
+
+
+def test_resolve_env_from_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_SECRET", "from_env")
+    assert resolve_env(None, "MY_SECRET") == "from_env"
+
+
+def test_resolve_env_from_secrets_toml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("TOML_SECRET", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    secrets_dir = tmp_path / ".drt"
+    secrets_dir.mkdir()
+    (secrets_dir / "secrets.toml").write_text(
+        '[destinations]\nTOML_SECRET = "from_toml"\n'
+    )
+
+    result = resolve_env(None, "TOML_SECRET")
+    assert result == "from_toml"
+
+
+def test_resolve_env_env_var_beats_secrets_toml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MY_VAR", "from_env")
+    monkeypatch.chdir(tmp_path)
+
+    secrets_dir = tmp_path / ".drt"
+    secrets_dir.mkdir()
+    (secrets_dir / "secrets.toml").write_text(
+        '[destinations]\nMY_VAR = "from_toml"\n'
+    )
+
+    result = resolve_env(None, "MY_VAR")
+    assert result == "from_env"
+
+
+def test_resolve_env_none_when_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("NONEXISTENT", raising=False)
+    assert resolve_env(None, "NONEXISTENT") is None
+
+
+def test_resolve_env_none_when_no_env_var() -> None:
+    assert resolve_env(None, None) is None


### PR DESCRIPTION
## Summary

Add `.drt/secrets.toml` as a local secret store, inspired by dlt's `.dlt/secrets.toml`.

### Resolution order
1. Explicit value (`password:` in YAML)
2. Environment variable (`password_env:`)
3. **`.drt/secrets.toml`** (new)
4. None

### Example
```toml
# .drt/secrets.toml (gitignored)
[destinations.mysql]
MYSQL_PASSWORD = "local-dev-password"

[destinations.github_actions]
GH_TOKEN = "ghp_xxxx"
```

No code changes needed in destinations — `resolve_env()` handles the fallback automatically.

Closes #143.

## Test plan
- [x] 8 new tests for secrets.toml loading, resolve_env precedence
- [x] 382 total tests passing
- [x] ruff clean
- [x] `secrets.toml` added to `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)