### PR TITLE
docs: add BigQuery to Discord alert pipeline example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Python 3.13 support** (#225): Added to CI matrix and classifiers
 - **`duration_seconds` in SyncResult** (#226): Track sync execution time
 
+#### Examples
+- **BigQuery → Discord example** (#266): Alert pipeline that queries BigQuery for error spikes and posts a Discord notification via Incoming Webhook using incremental sync. Includes `examples/bigquery_to_discord/`.
+
 ### Tests
 - 382+ tests (up from 170+ in v0.4.3)
 - Source and destination protocol contract tests (#209, #210)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## drt-core
 
+## [Unreleased]
+
+#### Examples
+- **BigQuery → Discord example** (#266): Alert pipeline that queries BigQuery for error spikes and posts a Discord notification via Incoming Webhook using incremental sync. Includes `examples/bigquery_to_discord/`.
+
 ## [0.5.0] - 2026-04-13
 
 ### Added
@@ -70,9 +75,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Pre-commit hooks** (#105): ruff + mypy
 - **Python 3.13 support** (#225): Added to CI matrix and classifiers
 - **`duration_seconds` in SyncResult** (#226): Track sync execution time
-
-#### Examples
-- **BigQuery → Discord example** (#266): Alert pipeline that queries BigQuery for error spikes and posts a Discord notification via Incoming Webhook using incremental sync. Includes `examples/bigquery_to_discord/`.
 
 ### Tests
 - 382+ tests (up from 170+ in v0.4.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-#### Examples
-- **BigQuery → Discord example** (#266): Alert pipeline that queries BigQuery for error spikes and posts a Discord notification via Incoming Webhook using incremental sync. Includes `examples/bigquery_to_discord/`.
+### Added
+
+- **Airflow integration** (#70): Built-in `run_drt_sync()` helper and `DrtRunOperator` for Apache Airflow. No extra package needed — included in drt-core.
+- **Google Ads destination** (#217): Upload offline click conversions. Supports partial failure handling and OAuth2 auth.
+- **OAuth2 Client Credentials auth** (#259): Token exchange with caching for REST API destination.
+- **`drt init --from-dbt`** (#215): Generate sync YAML scaffolds from dbt `manifest.json`.
+- **`--output json` for validate/list** (#230): Structured JSON output for `drt validate` and `drt list`.
+- **MCP Server: `drt_list_connectors`** (#262): New tool listing all available sources and destinations.
+- **MCP Server: improved `drt_validate`** (#262): Per-file error reporting via `load_syncs_safe()`.
+- **BigQuery → Discord example** (#266): Alert pipeline that queries BigQuery for recent error rows and posts a Discord notification per row via Incoming Webhook using incremental sync. Includes `examples/bigquery_to_discord/`.
 
 ## [0.5.0] - 2026-04-13
 

--- a/examples/bigquery_to_discord/README.md
+++ b/examples/bigquery_to_discord/README.md
@@ -1,0 +1,53 @@
+# BigQuery → Discord Alert Pipeline
+
+Send a Discord notification whenever new errors are detected in your BigQuery table.
+
+## What it does
+
+1. Queries BigQuery for recent error records
+2. Sends a Discord message per error via Incoming Webhook
+3. Uses incremental sync — only processes new errors since last run
+
+## Setup
+
+### 1. Configure your BigQuery connection
+
+```bash
+drt init   # select "bigquery" as source
+```
+
+Edit `~/.drt/profiles.yml`:
+
+```yaml
+default:
+  type: bigquery
+  project: your_gcp_project_id
+  dataset: your_dataset
+  keyfile_env: GOOGLE_APPLICATION_CREDENTIALS
+```
+
+### 2. Set your Discord webhook
+
+Create an [Incoming Webhook](https://support.discord.com/hc/en-us/articles/228383668) in Discord, then set the environment variable:
+
+```bash
+export DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/YOUR/WEBHOOK"
+```
+
+### 3. Run
+
+```bash
+drt run
+```
+
+## Files
+
+```
+bigquery_to_discord/
+├── drt_project.yml
+├── syncs/
+│   ├── alert_errors.yml
+│   └── models/
+│       └── recent_errors.sql
+└── README.md
+```

--- a/examples/bigquery_to_discord/README.md
+++ b/examples/bigquery_to_discord/README.md
@@ -23,7 +23,15 @@ default:
   type: bigquery
   project: your_gcp_project_id
   dataset: your_dataset
-  keyfile_env: GOOGLE_APPLICATION_CREDENTIALS
+  method: application_default
+```
+
+Then authenticate via Application Default Credentials:
+
+```bash
+gcloud auth application-default login
+# or set a service account key file:
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 ```
 
 ### 2. Set your Discord webhook

--- a/examples/bigquery_to_discord/drt_project.yml
+++ b/examples/bigquery_to_discord/drt_project.yml
@@ -1,0 +1,3 @@
+name: bigquery-to-discord
+version: "0.1"
+profile: default

--- a/examples/bigquery_to_discord/syncs/alert_errors.yml
+++ b/examples/bigquery_to_discord/syncs/alert_errors.yml
@@ -1,0 +1,14 @@
+name: alert_errors
+description: "Notify Discord when errors are detected in BigQuery"
+model: ref('recent_errors')
+destination:
+  type: discord
+  webhook_url_env: DISCORD_WEBHOOK_URL
+  message_template: "🚨 **{{ row.service_name }}** — {{ row.error_message }} (Error #{{ row.id }})"
+sync:
+  mode: incremental
+  cursor_field: created_at
+  batch_size: 1  # Discord: send one message at a time
+  rate_limit:
+    requests_per_second: 2
+  on_error: skip

--- a/examples/bigquery_to_discord/syncs/models/recent_errors.sql
+++ b/examples/bigquery_to_discord/syncs/models/recent_errors.sql
@@ -6,4 +6,3 @@ SELECT
     created_at
 FROM `your_project.your_dataset.app_logs`
 WHERE status = 'error'
-ORDER BY created_at DESC

--- a/examples/bigquery_to_discord/syncs/models/recent_errors.sql
+++ b/examples/bigquery_to_discord/syncs/models/recent_errors.sql
@@ -1,0 +1,9 @@
+-- Replace with your actual BigQuery project, dataset, and table
+SELECT
+    id,
+    error_message,
+    service_name,
+    created_at
+FROM `your_project.your_dataset.app_logs`
+WHERE status = 'error'
+ORDER BY created_at DESC


### PR DESCRIPTION
## What it does
Adds a new example pipeline that queries BigQuery for error spikes
and sends a Discord alert via Incoming Webhook using incremental sync.

## Files added
- `examples/bigquery_to_discord/drt_project.yml`
- `examples/bigquery_to_discord/syncs/alert_errors.yml`
- `examples/bigquery_to_discord/syncs/models/recent_errors.sql`
- `examples/bigquery_to_discord/README.md`

Closes #266

## Checklist
- [x] Tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] `CHANGELOG.md` updated