### PR TITLE
feat: add staged_upload destination for async bulk-upload APIs

### DIFF
--- a/.claude/commands/drt-create-sync.md
+++ b/.claude/commands/drt-create-sync.md
@@ -5,7 +5,7 @@ Create a drt sync YAML configuration file for the user.
 
 1. Ask the user for the following (or infer from context if already provided):
    - **Source table or SQL**: what data to sync (e.g. `ref('new_users')` or a SQL query)
-   - **Destination**: where to send it (Slack, Discord, Microsoft Teams, REST API, HubSpot, GitHub Actions, Google Sheets, PostgreSQL, MySQL, ClickHouse, Parquet, CSV/JSON/JSONL, Jira, Linear, SendGrid, or other)
+   - **Destination**: where to send it (Slack, Discord, Microsoft Teams, REST API, HubSpot, GitHub Actions, Google Sheets, PostgreSQL, MySQL, ClickHouse, Parquet, CSV/JSON/JSONL, Jira, Linear, SendGrid, Staged Upload (async bulk APIs), or other)
    - **Sync mode**: full (every run) or incremental (watermark-based, needs a cursor column)
    - **Frequency intent**: helps set `batch_size` and `rate_limit`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Prefect integration** (#213): Built-in `run_drt_sync()` helper and `drt_sync_task` for Prefect 2.x/3.x. No extra package needed — included in drt-core. Shares the runner with Airflow integration via `drt.integrations._runner`.
 - **Airflow integration** (#70): Built-in `run_drt_sync()` helper and `DrtRunOperator` for Apache Airflow. No extra package needed — included in drt-core.
 - **Google Ads destination** (#217): Upload offline click conversions. Supports partial failure handling and OAuth2 auth.
+- **Staged Upload destination** (#258): Async bulk-upload APIs (e.g. Amazon Marketing Cloud, Salesforce Bulk API). Declarative 3-phase YAML config: Stage (file upload) → Trigger (job kick) → Poll (completion wait). Supports CSV, JSON, JSONL. New `StagedDestination` Protocol.
 - **OAuth2 Client Credentials auth** (#259): Token exchange with caching for REST API destination.
 - **`drt init --from-dbt`** (#215): Generate sync YAML scaffolds from dbt `manifest.json`.
 - **`--output json` for validate/list** (#230): Structured JSON output for `drt validate` and `drt list`.

--- a/docs/llm/API_REFERENCE.md
+++ b/docs/llm/API_REFERENCE.md
@@ -405,6 +405,45 @@ destination:
   body_template: "{{ row.message }}"   # Jinja2 template for email body
 ```
 
+### `type: staged_upload`
+
+For APIs that require file upload → job trigger → poll for completion
+(e.g. Amazon Marketing Cloud, Salesforce Bulk API 2.0).
+
+```yaml
+destination:
+  type: staged_upload
+  format: csv                          # "csv" | "json" | "jsonl"
+  stage:
+    url: "https://upload.example.com/files"
+    method: POST
+    auth:
+      type: bearer
+      token_env: API_TOKEN
+    response_extract:
+      upload_id: "uploadId"            # extract from response JSON
+  trigger:
+    url: "https://api.example.com/jobs"
+    method: POST
+    body_template: '{"uploadId": "{{ upload_id }}"}'
+    auth:
+      type: bearer
+      token_env: API_TOKEN
+    response_extract:
+      job_id: "jobId"
+  poll:                                # optional — omit for fire-and-forget
+    url: "https://api.example.com/jobs/{{ job_id }}"
+    method: GET
+    auth:
+      type: bearer
+      token_env: API_TOKEN
+    status_field: "status"
+    success_values: ["SUCCEEDED"]
+    failure_values: ["FAILED"]
+    interval_seconds: 30               # default: 30
+    timeout_seconds: 3600              # default: 3600
+```
+
 ---
 
 ## Auth Configs

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -94,6 +94,7 @@ default:
 | Linear | `linear` | Create issues via GraphQL API |
 | SendGrid | `sendgrid` | Transactional emails via v3 Mail Send API |
 | Google Ads | `google_ads` | Offline click conversion upload |
+| Staged Upload | `staged_upload` | Async bulk APIs: file upload → job trigger → poll |
 
 ## CLI Commands
 

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from drt.destinations.rest_api import RestApiDestination
     from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.slack import SlackDestination
+    from drt.destinations.staged_upload import StagedUploadDestination
     from drt.destinations.teams import TeamsDestination
     from drt.sources.bigquery import BigQuerySource
     from drt.sources.clickhouse import ClickHouseSource
@@ -712,6 +713,7 @@ def _get_destination(
     | FileDestination
     | LinearDestination
     | GoogleAdsDestination
+    | StagedUploadDestination
 ):
     from drt.config.models import (
         ClickHouseDestinationConfig,

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -729,6 +729,7 @@ def _get_destination(
         RestApiDestinationConfig,
         SendGridDestinationConfig,
         SlackDestinationConfig,
+        StagedUploadDestinationConfig,
         TeamsDestinationConfig,
     )
     from drt.destinations.clickhouse import ClickHouseDestination
@@ -786,4 +787,8 @@ def _get_destination(
         from drt.destinations.google_ads import GoogleAdsDestination
 
         return GoogleAdsDestination()
+    if isinstance(dest, StagedUploadDestinationConfig):
+        from drt.destinations.staged_upload import StagedUploadDestination
+
+        return StagedUploadDestination()
     raise ValueError(f"Unsupported destination type: {dest.type}")

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -346,6 +346,38 @@ class GoogleAdsDestinationConfig(BaseModel):
         return f"google_ads ({self.customer_id})"
 
 
+class StagedUploadPhaseConfig(BaseModel):
+    url: str
+    method: str = "POST"
+    headers: dict[str, str] | None = None
+    auth: AuthConfig | None = None
+    body_template: str | None = None
+    response_extract: dict[str, str] | None = None
+
+
+class StagedUploadPollConfig(BaseModel):
+    url: str
+    method: str = "GET"
+    headers: dict[str, str] | None = None
+    auth: AuthConfig | None = None
+    status_field: str = "status"
+    success_values: list[str] = ["SUCCEEDED", "COMPLETED"]
+    failure_values: list[str] = ["FAILED", "ERROR"]
+    interval_seconds: int = 30
+    timeout_seconds: int = 3600
+
+
+class StagedUploadDestinationConfig(BaseModel):
+    type: Literal["staged_upload"]
+    stage: StagedUploadPhaseConfig
+    trigger: StagedUploadPhaseConfig
+    poll: StagedUploadPollConfig | None = None
+    format: Literal["csv", "json", "jsonl"] = "csv"
+
+    def describe(self) -> str:
+        return "staged_upload"
+
+
 # Discriminated union — add new destination types here
 DestinationConfig = Annotated[
     RestApiDestinationConfig
@@ -363,7 +395,8 @@ DestinationConfig = Annotated[
     | ClickHouseDestinationConfig
     | ParquetDestinationConfig
     | GoogleAdsDestinationConfig
-    | FileDestinationConfig,
+    | FileDestinationConfig
+    | StagedUploadDestinationConfig,
     Field(discriminator="type"),
 ]
 

--- a/drt/destinations/base.py
+++ b/drt/destinations/base.py
@@ -43,3 +43,31 @@ class Destination(Protocol):
     ) -> SyncResult:
         """Send a batch of records to the destination."""
         ...
+
+
+@runtime_checkable
+class StagedDestination(Protocol):
+    """Destination that accumulates records, then uploads as a batch job.
+
+    Used for APIs that require file upload → job trigger → poll for completion
+    (e.g. Salesforce Bulk API, Amazon Marketing Cloud).
+
+    Engine calls stage() per batch, then finalize() once after all batches.
+    """
+
+    def stage(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> None:
+        """Accumulate records for later upload."""
+        ...
+
+    def finalize(
+        self,
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        """Upload staged file, trigger job, poll for completion."""
+        ...

--- a/drt/destinations/staged_upload.py
+++ b/drt/destinations/staged_upload.py
@@ -99,6 +99,7 @@ class StagedUploadDestination:
         assert isinstance(config, StagedUploadDestinationConfig)
         result = SyncResult()
         context: dict[str, str] = {}
+        record_count = len(self._records)
 
         try:
             # Phase 1: Stage — serialize and upload file
@@ -120,8 +121,9 @@ class StagedUploadDestination:
             if config.poll is not None:
                 self._poll(config.poll, context)
 
+            result.success = record_count
         except Exception as e:
-            result.failed = len(self._records)
+            result.failed = record_count
             result.errors.append(str(e))
         finally:
             self._records.clear()

--- a/drt/destinations/staged_upload.py
+++ b/drt/destinations/staged_upload.py
@@ -1,0 +1,242 @@
+"""Staged Upload destination — async bulk-upload APIs.
+
+Supports APIs that require file upload → job trigger → poll for completion
+(e.g. Amazon Marketing Cloud, Salesforce Bulk API 2.0).
+
+Three declarative phases in YAML:
+  1. Stage: serialize records to file, upload via HTTP
+  2. Trigger: kick off server-side job, extract job ID from response
+  3. Poll: check job status until success/failure/timeout
+
+Example sync YAML:
+
+    destination:
+      type: staged_upload
+      format: csv
+      stage:
+        url: "https://upload.example.com/files"
+        method: POST
+        auth:
+          type: bearer
+          token_env: API_TOKEN
+        response_extract:
+          upload_id: "uploadId"
+      trigger:
+        url: "https://api.example.com/jobs"
+        method: POST
+        body_template: '{"uploadId": "{{ upload_id }}"}'
+        auth:
+          type: bearer
+          token_env: API_TOKEN
+        response_extract:
+          job_id: "jobId"
+      poll:
+        url: "https://api.example.com/jobs/{{ job_id }}"
+        method: GET
+        auth:
+          type: bearer
+          token_env: API_TOKEN
+        status_field: "status"
+        success_values: ["SUCCEEDED"]
+        failure_values: ["FAILED"]
+        interval_seconds: 30
+        timeout_seconds: 3600
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import time
+from typing import Any
+
+import httpx
+from jinja2 import BaseLoader, Environment, StrictUndefined
+from jinja2.exceptions import UndefinedError
+
+from drt.config.models import (
+    DestinationConfig,
+    StagedUploadDestinationConfig,
+    StagedUploadPhaseConfig,
+    StagedUploadPollConfig,
+    SyncOptions,
+)
+from drt.destinations.auth import AuthHandler
+from drt.destinations.base import SyncResult
+
+
+def _render(template_str: str, context: dict[str, str]) -> str:
+    """Render a Jinja2 template with context variables (not row-scoped)."""
+    env = Environment(loader=BaseLoader(), undefined=StrictUndefined)
+    try:
+        return env.from_string(template_str).render(**context)
+    except UndefinedError as e:
+        raise ValueError(f"Template error: {e}") from e
+
+
+class StagedUploadDestination:
+    """Accumulate records, then upload as a file and trigger an async job."""
+
+    def __init__(self) -> None:
+        self._records: list[dict[str, Any]] = []
+
+    def stage(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> None:
+        """Accumulate records for later upload."""
+        self._records.extend(records)
+
+    def finalize(
+        self,
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        """Upload staged file, trigger job, poll for completion."""
+        assert isinstance(config, StagedUploadDestinationConfig)
+        result = SyncResult()
+        context: dict[str, str] = {}
+
+        try:
+            # Phase 1: Stage — serialize and upload file
+            file_bytes = self._serialize(config.format)
+            stage_resp = self._http_phase(
+                config.stage, context, file_bytes=file_bytes
+            )
+            self._extract_values(
+                stage_resp, config.stage.response_extract, context
+            )
+
+            # Phase 2: Trigger — kick off server-side job
+            trigger_resp = self._http_phase(config.trigger, context)
+            self._extract_values(
+                trigger_resp, config.trigger.response_extract, context
+            )
+
+            # Phase 3: Poll — wait for completion (optional)
+            if config.poll is not None:
+                self._poll(config.poll, context)
+
+        except Exception as e:
+            result.failed = len(self._records)
+            result.errors.append(str(e))
+        finally:
+            self._records.clear()
+
+        return result
+
+    def _serialize(self, fmt: str) -> bytes:
+        """Serialize accumulated records to bytes."""
+        if not self._records:
+            return b""
+
+        if fmt == "csv":
+            buf = io.StringIO()
+            writer = csv.DictWriter(buf, fieldnames=self._records[0].keys())
+            writer.writeheader()
+            writer.writerows(self._records)
+            return buf.getvalue().encode("utf-8")
+
+        if fmt == "jsonl":
+            lines = [json.dumps(r, ensure_ascii=False) for r in self._records]
+            return "\n".join(lines).encode("utf-8")
+
+        # json
+        return json.dumps(self._records, ensure_ascii=False).encode("utf-8")
+
+    def _http_phase(
+        self,
+        phase: StagedUploadPhaseConfig,
+        context: dict[str, str],
+        file_bytes: bytes | None = None,
+    ) -> dict[str, Any]:
+        """Execute one HTTP phase (stage or trigger)."""
+        url = _render(phase.url, context) if "{{" in phase.url else phase.url
+        headers = dict(phase.headers or {})
+        if phase.auth:
+            headers.update(AuthHandler(phase.auth).get_headers())
+
+        with httpx.Client(timeout=120.0) as client:
+            if file_bytes is not None:
+                # Stage phase: upload file
+                response = client.request(
+                    phase.method,
+                    url,
+                    content=file_bytes,
+                    headers=headers,
+                )
+            elif phase.body_template:
+                body = _render(phase.body_template, context)
+                response = client.request(
+                    phase.method,
+                    url,
+                    content=body.encode("utf-8"),
+                    headers={**headers, "Content-Type": "application/json"},
+                )
+            else:
+                response = client.request(phase.method, url, headers=headers)
+
+            response.raise_for_status()
+
+        try:
+            return response.json()  # type: ignore[no-any-return]
+        except (json.JSONDecodeError, ValueError):
+            return {}
+
+    @staticmethod
+    def _extract_values(
+        response: dict[str, Any],
+        extract: dict[str, str] | None,
+        context: dict[str, str],
+    ) -> None:
+        """Extract values from HTTP response into context dict."""
+        if not extract:
+            return
+        for var_name, json_key in extract.items():
+            val = response.get(json_key)
+            if val is not None:
+                context[var_name] = str(val)
+
+    def _poll(
+        self,
+        poll_config: StagedUploadPollConfig,
+        context: dict[str, str],
+    ) -> None:
+        """Poll for job completion."""
+        url = (
+            _render(poll_config.url, context)
+            if "{{" in poll_config.url
+            else poll_config.url
+        )
+        headers: dict[str, str] = dict(poll_config.headers or {})
+        if poll_config.auth:
+            headers.update(AuthHandler(poll_config.auth).get_headers())
+
+        deadline = time.monotonic() + poll_config.timeout_seconds
+
+        with httpx.Client(timeout=60.0) as client:
+            while True:
+                response = client.request(
+                    poll_config.method, url, headers=headers
+                )
+                response.raise_for_status()
+                data = response.json()
+
+                status = str(data.get(poll_config.status_field, ""))
+
+                if status in poll_config.success_values:
+                    return
+                if status in poll_config.failure_values:
+                    raise RuntimeError(
+                        f"Job failed with status: {status}"
+                    )
+                if time.monotonic() > deadline:
+                    raise TimeoutError(
+                        f"Poll timed out after {poll_config.timeout_seconds}s"
+                        f" (last status: {status})"
+                    )
+
+                time.sleep(poll_config.interval_seconds)

--- a/drt/engine/sync.py
+++ b/drt/engine/sync.py
@@ -44,7 +44,7 @@ def batch(iterable: Iterator[Any], size: int) -> Iterator[list[Any]]:
 def run_sync(
     sync: SyncConfig,
     source: Source,
-    destination: Destination,
+    destination: Destination | StagedDestination,
     profile: ProfileConfig,
     project_dir: Path,
     dry_run: bool = False,
@@ -99,9 +99,11 @@ def run_sync(
             continue
 
         if is_staged:
+            assert isinstance(destination, StagedDestination)
             destination.stage(record_batch, sync.destination, sync.sync)
             total_result.success += len(record_batch)
         else:
+            assert isinstance(destination, Destination)
             result = destination.load(record_batch, sync.destination, sync.sync)
             total_result.success += result.success
             total_result.failed += result.failed
@@ -114,6 +116,7 @@ def run_sync(
 
     # Finalize staged destinations (upload file, trigger job, poll)
     if is_staged and not dry_run and total_result.success > 0:
+        assert isinstance(destination, StagedDestination)
         finalize_result = destination.finalize(sync.destination, sync.sync)
         total_result.failed += finalize_result.failed
         total_result.errors.extend(finalize_result.errors)

--- a/drt/engine/sync.py
+++ b/drt/engine/sync.py
@@ -83,6 +83,7 @@ def run_sync(
     total_result = SyncResult()
     new_cursor_value: str | None = last_cursor_value
     is_staged = isinstance(destination, StagedDestination)
+    staged_count = 0
 
     for record_batch in batch(records_iter, sync.sync.batch_size):
         # Track max cursor value seen across all batches
@@ -101,7 +102,7 @@ def run_sync(
         if is_staged:
             assert isinstance(destination, StagedDestination)
             destination.stage(record_batch, sync.destination, sync.sync)
-            total_result.success += len(record_batch)
+            staged_count += len(record_batch)
         else:
             assert isinstance(destination, Destination)
             result = destination.load(record_batch, sync.destination, sync.sync)
@@ -114,10 +115,13 @@ def run_sync(
             if sync.sync.on_error == "fail" and result.failed > 0:
                 break
 
-    # Finalize staged destinations (upload file, trigger job, poll)
-    if is_staged and not dry_run and total_result.success > 0:
+    # Finalize staged destinations (upload file, trigger job, poll).
+    # finalize() is authoritative for staged success/failed counts —
+    # stage() only buffers, so records aren't "successful" until finalize.
+    if is_staged and not dry_run and staged_count > 0:
         assert isinstance(destination, StagedDestination)
         finalize_result = destination.finalize(sync.destination, sync.sync)
+        total_result.success += finalize_result.success
         total_result.failed += finalize_result.failed
         total_result.errors.extend(finalize_result.errors)
         total_result.row_errors.extend(

--- a/drt/engine/sync.py
+++ b/drt/engine/sync.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from drt.config.credentials import ProfileConfig
 from drt.config.models import SyncConfig
-from drt.destinations.base import Destination, SyncResult
+from drt.destinations.base import Destination, StagedDestination, SyncResult
 from drt.engine.resolver import resolve_model_ref
 from drt.sources.base import Source
 from drt.state.manager import StateManager, SyncState
@@ -82,6 +82,7 @@ def run_sync(
     records_iter = source.extract(query, profile)
     total_result = SyncResult()
     new_cursor_value: str | None = last_cursor_value
+    is_staged = isinstance(destination, StagedDestination)
 
     for record_batch in batch(records_iter, sync.sync.batch_size):
         # Track max cursor value seen across all batches
@@ -97,15 +98,28 @@ def run_sync(
             total_result.success += len(record_batch)
             continue
 
-        result = destination.load(record_batch, sync.destination, sync.sync)
-        total_result.success += result.success
-        total_result.failed += result.failed
-        total_result.skipped += result.skipped
-        total_result.errors.extend(result.errors)
-        total_result.row_errors.extend(getattr(result, "row_errors", []))
+        if is_staged:
+            destination.stage(record_batch, sync.destination, sync.sync)
+            total_result.success += len(record_batch)
+        else:
+            result = destination.load(record_batch, sync.destination, sync.sync)
+            total_result.success += result.success
+            total_result.failed += result.failed
+            total_result.skipped += result.skipped
+            total_result.errors.extend(result.errors)
+            total_result.row_errors.extend(getattr(result, "row_errors", []))
 
-        if sync.sync.on_error == "fail" and result.failed > 0:
-            break
+            if sync.sync.on_error == "fail" and result.failed > 0:
+                break
+
+    # Finalize staged destinations (upload file, trigger job, poll)
+    if is_staged and not dry_run and total_result.success > 0:
+        finalize_result = destination.finalize(sync.destination, sync.sync)
+        total_result.failed += finalize_result.failed
+        total_result.errors.extend(finalize_result.errors)
+        total_result.row_errors.extend(
+            getattr(finalize_result, "row_errors", [])
+        )
 
     total_result.duration_seconds = round(time.perf_counter() - t0, 3)
 

--- a/skills/drt/skills/drt-create-sync/SKILL.md
+++ b/skills/drt/skills/drt-create-sync/SKILL.md
@@ -12,7 +12,7 @@ Create a drt sync YAML configuration file for the user.
 
 1. Ask the user for the following (or infer from context if already provided):
    - **Source table or SQL**: what data to sync (e.g. `ref('new_users')` or a SQL query)
-   - **Destination**: where to send it (Slack, Discord, Microsoft Teams, REST API, HubSpot, GitHub Actions, Google Sheets, PostgreSQL, MySQL, ClickHouse, Parquet, CSV/JSON/JSONL, Jira, Linear, SendGrid, or other)
+   - **Destination**: where to send it (Slack, Discord, Microsoft Teams, REST API, HubSpot, GitHub Actions, Google Sheets, PostgreSQL, MySQL, ClickHouse, Parquet, CSV/JSON/JSONL, Jira, Linear, SendGrid, Staged Upload (async bulk APIs), or other)
    - **Sync mode**: full (every run) or incremental (watermark-based, needs a cursor column)
    - **Frequency intent**: helps set `batch_size` and `rate_limit`
 

--- a/tests/unit/test_staged_upload.py
+++ b/tests/unit/test_staged_upload.py
@@ -1,0 +1,245 @@
+"""Tests for staged_upload destination."""
+
+from __future__ import annotations
+
+import json
+
+from pytest_httpserver import HTTPServer
+
+from drt.config.models import (
+    StagedUploadDestinationConfig,
+    StagedUploadPhaseConfig,
+    StagedUploadPollConfig,
+    SyncOptions,
+)
+from drt.destinations.base import StagedDestination
+from drt.destinations.staged_upload import StagedUploadDestination
+
+
+def _options() -> SyncOptions:
+    return SyncOptions()
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_implements_staged_destination_protocol() -> None:
+    assert isinstance(StagedUploadDestination(), StagedDestination)
+
+
+# ---------------------------------------------------------------------------
+# Stage — record accumulation
+# ---------------------------------------------------------------------------
+
+
+def test_stage_accumulates_records() -> None:
+    dest = StagedUploadDestination()
+    config = StagedUploadDestinationConfig(
+        type="staged_upload",
+        stage=StagedUploadPhaseConfig(url="http://x"),
+        trigger=StagedUploadPhaseConfig(url="http://x"),
+    )
+    dest.stage([{"a": 1}], config, _options())
+    dest.stage([{"a": 2}, {"a": 3}], config, _options())
+    assert len(dest._records) == 3
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_csv() -> None:
+    dest = StagedUploadDestination()
+    dest._records = [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+    data = dest._serialize("csv").decode()
+    assert "id,name" in data
+    assert "Alice" in data
+    assert "Bob" in data
+
+
+def test_serialize_jsonl() -> None:
+    dest = StagedUploadDestination()
+    dest._records = [{"id": 1}, {"id": 2}]
+    data = dest._serialize("jsonl").decode()
+    lines = data.strip().split("\n")
+    assert len(lines) == 2
+    assert json.loads(lines[0]) == {"id": 1}
+
+
+def test_serialize_json() -> None:
+    dest = StagedUploadDestination()
+    dest._records = [{"id": 1}, {"id": 2}]
+    data = dest._serialize("json").decode()
+    parsed = json.loads(data)
+    assert len(parsed) == 2
+
+
+# ---------------------------------------------------------------------------
+# Full 3-phase flow
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_stage_trigger_poll(httpserver: HTTPServer) -> None:
+    """Full flow: stage upload → trigger job → poll success."""
+    # Stage endpoint: accept file upload, return upload_id
+    httpserver.expect_ordered_request(
+        "/upload", method="POST"
+    ).respond_with_json({"uploadId": "u-123"})
+
+    # Trigger endpoint: start job, return job_id
+    httpserver.expect_ordered_request(
+        "/jobs", method="POST"
+    ).respond_with_json({"jobId": "j-456"})
+
+    # Poll endpoint: return success
+    httpserver.expect_ordered_request(
+        "/jobs/j-456", method="GET"
+    ).respond_with_json({"status": "SUCCEEDED"})
+
+    config = StagedUploadDestinationConfig(
+        type="staged_upload",
+        format="csv",
+        stage=StagedUploadPhaseConfig(
+            url=httpserver.url_for("/upload"),
+            method="POST",
+            response_extract={"upload_id": "uploadId"},
+        ),
+        trigger=StagedUploadPhaseConfig(
+            url=httpserver.url_for("/jobs"),
+            method="POST",
+            body_template='{"uploadId": "{{ upload_id }}"}',
+            response_extract={"job_id": "jobId"},
+        ),
+        poll=StagedUploadPollConfig(
+            url=httpserver.url_for("/jobs/{{ job_id }}"),
+            method="GET",
+            status_field="status",
+            success_values=["SUCCEEDED"],
+            failure_values=["FAILED"],
+            interval_seconds=0,
+            timeout_seconds=5,
+        ),
+    )
+
+    dest = StagedUploadDestination()
+    dest._records = [{"id": 1, "name": "test"}]
+    result = dest.finalize(config, _options())
+
+    assert result.failed == 0
+    assert result.errors == []
+
+
+def test_finalize_without_poll(httpserver: HTTPServer) -> None:
+    """Stage + Trigger only (poll is optional)."""
+    httpserver.expect_ordered_request(
+        "/upload", method="POST"
+    ).respond_with_json({"uploadId": "u-1"})
+
+    httpserver.expect_ordered_request(
+        "/jobs", method="POST"
+    ).respond_with_json({"ok": True})
+
+    config = StagedUploadDestinationConfig(
+        type="staged_upload",
+        format="jsonl",
+        stage=StagedUploadPhaseConfig(
+            url=httpserver.url_for("/upload"),
+            response_extract={"upload_id": "uploadId"},
+        ),
+        trigger=StagedUploadPhaseConfig(
+            url=httpserver.url_for("/jobs"),
+            body_template='{"uploadId": "{{ upload_id }}"}',
+        ),
+        poll=None,
+    )
+
+    dest = StagedUploadDestination()
+    dest._records = [{"x": 1}]
+    result = dest.finalize(config, _options())
+
+    assert result.failed == 0
+
+
+def test_finalize_poll_failure(httpserver: HTTPServer) -> None:
+    """Poll returns failure status."""
+    httpserver.expect_ordered_request(
+        "/upload"
+    ).respond_with_json({"uploadId": "u-1"})
+    httpserver.expect_ordered_request(
+        "/jobs"
+    ).respond_with_json({"jobId": "j-1"})
+    httpserver.expect_ordered_request(
+        "/jobs/j-1"
+    ).respond_with_json({"status": "FAILED"})
+
+    config = StagedUploadDestinationConfig(
+        type="staged_upload",
+        stage=StagedUploadPhaseConfig(
+            url=httpserver.url_for("/upload"),
+            response_extract={"upload_id": "uploadId"},
+        ),
+        trigger=StagedUploadPhaseConfig(
+            url=httpserver.url_for("/jobs"),
+            response_extract={"job_id": "jobId"},
+        ),
+        poll=StagedUploadPollConfig(
+            url=httpserver.url_for("/jobs/{{ job_id }}"),
+            status_field="status",
+            failure_values=["FAILED"],
+            interval_seconds=0,
+            timeout_seconds=5,
+        ),
+    )
+
+    dest = StagedUploadDestination()
+    dest._records = [{"x": 1}]
+    result = dest.finalize(config, _options())
+
+    assert result.failed == 1
+    assert any("failed" in e.lower() for e in result.errors)
+
+
+def test_finalize_stage_error(httpserver: HTTPServer) -> None:
+    """Stage endpoint returns 500."""
+    httpserver.expect_request("/upload").respond_with_data(
+        "error", status=500
+    )
+
+    config = StagedUploadDestinationConfig(
+        type="staged_upload",
+        stage=StagedUploadPhaseConfig(
+            url=httpserver.url_for("/upload"),
+        ),
+        trigger=StagedUploadPhaseConfig(url="http://unused"),
+    )
+
+    dest = StagedUploadDestination()
+    dest._records = [{"x": 1}]
+    result = dest.finalize(config, _options())
+
+    assert result.failed == 1
+    assert len(result.errors) == 1
+
+
+def test_records_cleared_after_finalize(httpserver: HTTPServer) -> None:
+    """Records are cleared even on failure."""
+    httpserver.expect_request("/upload").respond_with_data(
+        "error", status=500
+    )
+
+    config = StagedUploadDestinationConfig(
+        type="staged_upload",
+        stage=StagedUploadPhaseConfig(
+            url=httpserver.url_for("/upload"),
+        ),
+        trigger=StagedUploadPhaseConfig(url="http://unused"),
+    )
+
+    dest = StagedUploadDestination()
+    dest._records = [{"x": 1}]
+    dest.finalize(config, _options())
+
+    assert dest._records == []

--- a/tests/unit/test_staged_upload.py
+++ b/tests/unit/test_staged_upload.py
@@ -128,6 +128,7 @@ def test_finalize_stage_trigger_poll(httpserver: HTTPServer) -> None:
     dest._records = [{"id": 1, "name": "test"}]
     result = dest.finalize(config, _options())
 
+    assert result.success == 1
     assert result.failed == 0
     assert result.errors == []
 
@@ -160,6 +161,7 @@ def test_finalize_without_poll(httpserver: HTTPServer) -> None:
     dest._records = [{"x": 1}]
     result = dest.finalize(config, _options())
 
+    assert result.success == 1
     assert result.failed == 0
 
 
@@ -198,6 +200,7 @@ def test_finalize_poll_failure(httpserver: HTTPServer) -> None:
     dest._records = [{"x": 1}]
     result = dest.finalize(config, _options())
 
+    assert result.success == 0
     assert result.failed == 1
     assert any("failed" in e.lower() for e in result.errors)
 
@@ -220,6 +223,7 @@ def test_finalize_stage_error(httpserver: HTTPServer) -> None:
     dest._records = [{"x": 1}]
     result = dest.finalize(config, _options())
 
+    assert result.success == 0
     assert result.failed == 1
     assert len(result.errors) == 1
 


### PR DESCRIPTION
## Summary

Add `staged_upload` destination type for APIs that require file upload → job trigger → poll for completion (e.g. Amazon Marketing Cloud, Salesforce Bulk API 2.0, HubSpot Imports API).

Closes #258.

### Design

Introduces a new `StagedDestination` Protocol (separate from existing `Destination`):
- `stage(records, config, sync_options)` — accumulate records per batch
- `finalize(config, sync_options)` — serialize to file, upload, trigger job, poll

Inspired by [dlt's LoadJob state machine](https://deepwiki.com/dlt-hub/dlt/5-data-loading) + `complete_load()` finalize pattern. Existing destinations are completely unaffected.

### YAML config

```yaml
destination:
  type: staged_upload
  format: csv
  stage:
    url: "https://upload.example.com/files"
    method: POST
    auth: { type: bearer, token_env: API_TOKEN }
    response_extract: { upload_id: "uploadId" }
  trigger:
    url: "https://api.example.com/jobs"
    method: POST
    body_template: '{"uploadId": "{{ upload_id }}"}'
    response_extract: { job_id: "jobId" }
  poll:
    url: "https://api.example.com/jobs/{{ job_id }}"
    status_field: "status"
    success_values: ["SUCCEEDED"]
    failure_values: ["FAILED"]
    interval_seconds: 30
    timeout_seconds: 3600
```

### Files changed

| File | Change |
|------|--------|
| `drt/destinations/base.py` | New `StagedDestination` Protocol |
| `drt/config/models.py` | `StagedUploadDestinationConfig` + phase configs |
| `drt/engine/sync.py` | Branch: `stage()` per batch → `finalize()` after all |
| `drt/destinations/staged_upload.py` | New — full 3-phase implementation |
| `drt/cli/main.py` | Wire into `_get_destination()` |
| `tests/unit/test_staged_upload.py` | 10 tests |
| `docs/llm/API_REFERENCE.md` | Config example |
| `docs/llm/CONTEXT.md` | Destination table |
| Skills, CHANGELOG | Updated |

## Test plan
- [x] 10 tests for staged_upload (protocol, serialization, 3-phase flow, failure, cleanup)
- [x] 392 total tests passing
- [x] ruff clean

## Reviewer

@yodakanohoshi — you designed this feature spec, would love your review!

🤖 Generated with [Claude Code](https://claude.com/claude-code)