### PR TITLE
feat: add --output json to drt validate and drt list

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -251,11 +251,32 @@ def run(
 
 
 @app.command(name="list")
-def list_syncs() -> None:
+def list_syncs(
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text or json."
+    ),
+) -> None:
     """List all sync definitions in the project."""
+    import json as json_mod
+
     from drt.config.parser import load_syncs
 
     syncs = load_syncs(Path("."))
+
+    if output == "json":
+        print(json_mod.dumps({
+            "syncs": [
+                {
+                    "name": s.name,
+                    "destination_type": s.destination.type,
+                    "mode": s.sync.mode,
+                    "description": s.description,
+                }
+                for s in syncs
+            ],
+        }, indent=2))
+        return
+
     print_sync_table(syncs)
 
 
@@ -269,12 +290,32 @@ def validate(
     emit_schema: bool = typer.Option(  # noqa: E501
         False, "--emit-schema", help="Write JSON Schemas to .drt/schemas/."
     ),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text or json."
+    ),
 ) -> None:
     """Validate sync definitions against the JSON Schema."""
+    import json as json_mod
+
     from drt.config.parser import load_syncs_safe
     from drt.config.schema import write_schemas
 
     result = load_syncs_safe(Path("."))
+
+    if output == "json":
+        print(json_mod.dumps({
+            "results": [
+                {"name": s.name, "valid": True}
+                for s in result.syncs
+            ] + [
+                {"name": name, "valid": False, "errors": errs}
+                for name, errs in result.errors.items()
+            ],
+        }, indent=2))
+        if result.errors:
+            raise typer.Exit(code=1)
+        return
+
     if not result.syncs and not result.errors:
         console.print("[dim]No syncs found.[/dim]")
         return

--- a/tests/unit/test_cli_output_json.py
+++ b/tests/unit/test_cli_output_json.py
@@ -135,3 +135,98 @@ def test_status_json_no_rich_markup(
     json.loads(result.output)
 
     mp.undo()
+
+
+# ---------------------------------------------------------------------------
+# drt list --output json
+# ---------------------------------------------------------------------------
+
+
+def test_list_json(
+    tmp_path: Path, monkeypatch: object
+) -> None:
+    import pytest
+    import yaml
+
+    mp = pytest.MonkeyPatch()
+    mp.chdir(tmp_path)
+
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    with (syncs_dir / "test.yml").open("w") as f:
+        yaml.dump({
+            "name": "my-sync",
+            "model": "SELECT 1",
+            "destination": {
+                "type": "rest_api",
+                "url": "http://example.com",
+                "method": "POST",
+            },
+        }, f)
+
+    result = runner.invoke(app, ["list", "--output", "json"])
+    data = json.loads(result.output)
+    assert len(data["syncs"]) == 1
+    assert data["syncs"][0]["name"] == "my-sync"
+    assert data["syncs"][0]["destination_type"] == "rest_api"
+    assert data["syncs"][0]["mode"] == "full"
+
+    mp.undo()
+
+
+# ---------------------------------------------------------------------------
+# drt validate --output json
+# ---------------------------------------------------------------------------
+
+
+def test_validate_json_valid(
+    tmp_path: Path, monkeypatch: object
+) -> None:
+    import pytest
+    import yaml
+
+    mp = pytest.MonkeyPatch()
+    mp.chdir(tmp_path)
+
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    with (syncs_dir / "ok.yml").open("w") as f:
+        yaml.dump({
+            "name": "good",
+            "model": "SELECT 1",
+            "destination": {
+                "type": "rest_api",
+                "url": "http://example.com",
+                "method": "POST",
+            },
+        }, f)
+
+    result = runner.invoke(app, ["validate", "--output", "json"])
+    data = json.loads(result.output)
+    assert len(data["results"]) == 1
+    assert data["results"][0]["valid"] is True
+    assert result.exit_code == 0
+
+    mp.undo()
+
+
+def test_validate_json_invalid(
+    tmp_path: Path, monkeypatch: object
+) -> None:
+    import pytest
+    import yaml
+
+    mp = pytest.MonkeyPatch()
+    mp.chdir(tmp_path)
+
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    with (syncs_dir / "bad.yml").open("w") as f:
+        yaml.dump({"name": "broken"}, f)
+
+    result = runner.invoke(app, ["validate", "--output", "json"])
+    data = json.loads(result.output)
+    assert any(r["valid"] is False for r in data["results"])
+    assert result.exit_code == 1
+
+    mp.undo()


### PR DESCRIPTION
## Summary
- `drt list --output json` — syncs with name, destination_type, mode, description
- `drt validate --output json` — results with valid/invalid status and error details

Follows the same pattern as `drt run --output json` and `drt status --output json` from #142.

Closes #230.

## Test plan
- [x] 3 new tests (list json, validate valid, validate invalid)
- [x] 8 total output json tests passing
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)