### PR TITLE
feat: add drt init --from-dbt for sync YAML generation

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -105,8 +105,18 @@ def main(
 
 
 @app.command()
-def init() -> None:
+def init(
+    from_dbt: str = typer.Option(
+        None,
+        "--from-dbt",
+        help="Path to dbt manifest.json — generate sync YAMLs from dbt models.",
+    ),
+) -> None:
     """Initialize a new drt project in the current directory."""
+    if from_dbt:
+        _init_from_dbt(Path(from_dbt))
+        return
+
     from drt.cli.init_wizard import run_wizard, scaffold_project
 
     try:
@@ -119,6 +129,78 @@ def init() -> None:
     except Exception as e:
         print_error(str(e))
         raise typer.Exit(1)
+
+
+def _init_from_dbt(manifest_path: Path) -> None:
+    """Generate sync YAML scaffolds from dbt manifest.json."""
+    import yaml
+
+    from drt.integrations.dbt import list_models_from_manifest
+
+    try:
+        models = list_models_from_manifest(manifest_path)
+    except FileNotFoundError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+    if not models:
+        console.print("[dim]No models found in manifest.[/dim]")
+        return
+
+    console.print(f"\n[bold]Found {len(models)} dbt models:[/bold]\n")
+    for i, m in enumerate(models):
+        desc = f" — {m.description}" if m.description else ""
+        console.print(f"  {i + 1}. {m.name}{desc}")
+
+    console.print("")
+    raw = typer.prompt(
+        "Select models (comma-separated numbers, or 'all')",
+        default="all",
+    )
+
+    if raw.strip().lower() == "all":
+        selected = models
+    else:
+        indices = [int(x.strip()) - 1 for x in raw.split(",") if x.strip().isdigit()]
+        selected = [models[i] for i in indices if 0 <= i < len(models)]
+
+    if not selected:
+        console.print("[dim]No models selected.[/dim]")
+        return
+
+    syncs_dir = Path(".") / "syncs"
+    syncs_dir.mkdir(exist_ok=True)
+    created: list[str] = []
+
+    for model in selected:
+        sync_data = {
+            "name": f"sync_{model.name}",
+            "description": model.description or f"Sync {model.name} to destination",
+            "model": f"ref('{model.name}')",
+            "destination": {
+                "type": "rest_api",
+                "url": "https://example.com/api",
+                "method": "POST",
+            },
+        }
+        path = syncs_dir / f"sync_{model.name}.yml"
+        if path.exists():
+            console.print(f"  [dim]skip[/dim] {path} (already exists)")
+            continue
+        with path.open("w") as f:
+            yaml.dump(sync_data, f, default_flow_style=False, sort_keys=False)
+        created.append(str(path))
+
+    if created:
+        console.print(f"\n[green]Created {len(created)} sync file(s):[/green]")
+        for c in created:
+            console.print(f"  {c}")
+        console.print(
+            "\n[dim]Edit the destination config in each file,"
+            " then run: drt validate && drt run --dry-run[/dim]"
+        )
+    else:
+        console.print("[dim]No new sync files created.[/dim]")
 
 
 # ---------------------------------------------------------------------------

--- a/drt/integrations/dbt.py
+++ b/drt/integrations/dbt.py
@@ -12,7 +12,47 @@ Usage:
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
+
+
+@dataclass
+class DbtModel:
+    """A model extracted from dbt manifest.json."""
+
+    name: str
+    relation_name: str | None
+    description: str
+    resource_type: str
+
+
+def list_models_from_manifest(
+    manifest_path: Path,
+) -> list[DbtModel]:
+    """List all models from a dbt manifest.json.
+
+    Returns a list of DbtModel with name, relation_name, and description.
+    """
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+
+    manifest = json.loads(manifest_path.read_text())
+    nodes = manifest.get("nodes", {})
+
+    models: list[DbtModel] = []
+    for node in nodes.values():
+        if node.get("resource_type") != "model":
+            continue
+        models.append(
+            DbtModel(
+                name=node.get("name", ""),
+                relation_name=node.get("relation_name"),
+                description=node.get("description", ""),
+                resource_type=node.get("resource_type", "model"),
+            )
+        )
+
+    return sorted(models, key=lambda m: m.name)
 
 
 def resolve_ref_from_manifest(

--- a/tests/unit/test_dbt_init.py
+++ b/tests/unit/test_dbt_init.py
@@ -1,4 +1,4 @@
-"""Tests for dbt init integration — list_models_from_manifest."""
+"""Tests for dbt init integration — list_models_from_manifest + CLI."""
 
 from __future__ import annotations
 
@@ -6,8 +6,12 @@ import json
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
+from drt.cli.main import app
 from drt.integrations.dbt import list_models_from_manifest
+
+runner = CliRunner()
 
 
 def _manifest(models: list[dict]) -> dict:
@@ -94,3 +98,55 @@ def test_list_models_with_description(tmp_path: Path) -> None:
 
     models = list_models_from_manifest(path)
     assert models[0].description == "All active users"
+
+
+# ---------------------------------------------------------------------------
+# CLI --from-dbt
+# ---------------------------------------------------------------------------
+
+
+def test_init_from_dbt_generates_syncs(tmp_path: Path) -> None:
+    manifest = _manifest([
+        {"name": "users", "relation_name": '"analytics"."users"'},
+        {"name": "orders", "relation_name": '"analytics"."orders"'},
+    ])
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    mp = pytest.MonkeyPatch()
+    mp.chdir(tmp_path)
+
+    result = runner.invoke(app, ["init", "--from-dbt", str(manifest_path)], input="all\n")
+    assert result.exit_code == 0
+    assert (tmp_path / "syncs" / "sync_users.yml").exists()
+    assert (tmp_path / "syncs" / "sync_orders.yml").exists()
+    mp.undo()
+
+
+def test_init_from_dbt_missing_manifest(tmp_path: Path) -> None:
+    mp = pytest.MonkeyPatch()
+    mp.chdir(tmp_path)
+
+    result = runner.invoke(app, ["init", "--from-dbt", "/nonexistent/manifest.json"])
+    assert result.exit_code == 1
+    mp.undo()
+
+
+def test_init_from_dbt_select_specific(tmp_path: Path) -> None:
+    manifest = _manifest([
+        {"name": "users", "relation_name": '"users"'},
+        {"name": "orders", "relation_name": '"orders"'},
+        {"name": "products", "relation_name": '"products"'},
+    ])
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    mp = pytest.MonkeyPatch()
+    mp.chdir(tmp_path)
+
+    # Select only model 1 (orders, sorted alphabetically)
+    result = runner.invoke(app, ["init", "--from-dbt", str(manifest_path)], input="1\n")
+    assert result.exit_code == 0
+    assert (tmp_path / "syncs" / "sync_orders.yml").exists()
+    assert not (tmp_path / "syncs" / "sync_users.yml").exists()
+    mp.undo()

--- a/tests/unit/test_dbt_init.py
+++ b/tests/unit/test_dbt_init.py
@@ -1,0 +1,96 @@
+"""Tests for dbt init integration — list_models_from_manifest."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from drt.integrations.dbt import list_models_from_manifest
+
+
+def _manifest(models: list[dict]) -> dict:
+    """Build a minimal dbt manifest.json."""
+    nodes = {}
+    for m in models:
+        key = f"model.project.{m['name']}"
+        nodes[key] = {
+            "resource_type": "model",
+            "name": m["name"],
+            "relation_name": m.get("relation_name"),
+            "description": m.get("description", ""),
+        }
+    return {"nodes": nodes}
+
+
+def test_list_models(tmp_path: Path) -> None:
+    manifest = _manifest([
+        {"name": "users", "relation_name": '"analytics"."users"'},
+        {"name": "orders", "relation_name": '"analytics"."orders"'},
+    ])
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    models = list_models_from_manifest(path)
+    assert len(models) == 2
+    assert models[0].name == "orders"  # sorted
+    assert models[1].name == "users"
+    assert models[1].relation_name == '"analytics"."users"'
+
+
+def test_list_models_skips_non_models(tmp_path: Path) -> None:
+    manifest = {
+        "nodes": {
+            "model.p.users": {
+                "resource_type": "model",
+                "name": "users",
+                "relation_name": '"users"',
+                "description": "",
+            },
+            "test.p.test_users": {
+                "resource_type": "test",
+                "name": "test_users",
+                "description": "",
+            },
+            "seed.p.seed_data": {
+                "resource_type": "seed",
+                "name": "seed_data",
+                "description": "",
+            },
+        }
+    }
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    models = list_models_from_manifest(path)
+    assert len(models) == 1
+    assert models[0].name == "users"
+
+
+def test_list_models_empty_manifest(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps({"nodes": {}}))
+
+    models = list_models_from_manifest(path)
+    assert models == []
+
+
+def test_list_models_file_not_found(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        list_models_from_manifest(tmp_path / "nonexistent.json")
+
+
+def test_list_models_with_description(tmp_path: Path) -> None:
+    manifest = _manifest([
+        {
+            "name": "users",
+            "relation_name": '"users"',
+            "description": "All active users",
+        },
+    ])
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    models = list_models_from_manifest(path)
+    assert models[0].description == "All active users"


### PR DESCRIPTION
## Summary

Generate sync YAML scaffolds from dbt `manifest.json`, reducing friction from "I have dbt models" to "I have drt syncs."

```bash
drt init --from-dbt ./dbt/target/manifest.json
```

### Flow
1. Reads manifest.json, lists models with descriptions
2. User selects models (comma-separated numbers or `all`)
3. Generates `syncs/sync_<model>.yml` with `ref('<model>')` and placeholder destination
4. User edits destination config, runs `drt validate && drt run --dry-run`

Closes #215.

### Example output
```
Found 3 dbt models:

  1. orders — Customer orders
  2. products
  3. users — All active users

Select models (comma-separated numbers, or 'all'): 1,3

Created 2 sync file(s):
  syncs/sync_orders.yml
  syncs/sync_users.yml

Edit the destination config in each file, then run: drt validate && drt run --dry-run
```

## Test plan
- [x] 8 tests (model listing, filtering, CLI generate, missing manifest, selection)
- [x] 393 total tests passing
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)