### PR TITLE
feat: add OAuth2 Client Credentials auth for REST API destination

### DIFF
--- a/docs/llm/API_REFERENCE.md
+++ b/docs/llm/API_REFERENCE.md
@@ -445,6 +445,19 @@ auth:
 
 → Sends `Authorization: Basic <base64(username:password)>` header.
 
+### OAuth2 Client Credentials
+
+```yaml
+auth:
+  type: oauth2_client_credentials
+  token_url: "https://auth.example.com/oauth/token"  # required
+  client_id_env: OAUTH_CLIENT_ID       # required: env var name
+  client_secret_env: OAUTH_CLIENT_SECRET  # required: env var name
+  scope: "contacts.write"             # optional
+```
+
+→ Exchanges client credentials for an access token, caches until expiry. Sends `Authorization: Bearer <access_token>` header.
+
 ---
 
 ## Complete Examples

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -28,8 +28,16 @@ class BasicAuth(BaseModel):
     password_env: str
 
 
+class OAuth2ClientCredentialsAuth(BaseModel):
+    type: Literal["oauth2_client_credentials"]
+    token_url: str
+    client_id_env: str
+    client_secret_env: str
+    scope: str | None = None
+
+
 AuthConfig = Annotated[
-    BearerAuth | ApiKeyAuth | BasicAuth,
+    BearerAuth | ApiKeyAuth | BasicAuth | OAuth2ClientCredentialsAuth,
     Field(discriminator="type"),
 ]
 

--- a/drt/destinations/auth.py
+++ b/drt/destinations/auth.py
@@ -17,6 +17,7 @@ from drt.config.models import (
     AuthConfig,  # noqa: F401
     BasicAuth,
     BearerAuth,
+    OAuth2ClientCredentialsAuth,
 )
 
 
@@ -63,4 +64,62 @@ class AuthHandler:
             encoded = base64.b64encode(f"{username}:{password}".encode()).decode()
             return {"Authorization": f"Basic {encoded}"}
 
+        if isinstance(auth, OAuth2ClientCredentialsAuth):
+            return _get_oauth2_token(auth)
+
         return {}
+
+
+# Cache: token_url → (access_token, expires_at)
+_oauth2_cache: dict[str, tuple[str, float]] = {}
+
+
+def _get_oauth2_token(auth: OAuth2ClientCredentialsAuth) -> dict[str, str]:
+    """Exchange client credentials for an access token (with caching)."""
+    import time
+
+    import httpx
+
+    from drt.config.credentials import resolve_env
+
+    # Check cache
+    cached = _oauth2_cache.get(auth.token_url)
+    if cached:
+        token, expires_at = cached
+        if time.monotonic() < expires_at:
+            return {"Authorization": f"Bearer {token}"}
+
+    client_id = resolve_env(None, auth.client_id_env)
+    client_secret = resolve_env(None, auth.client_secret_env)
+    if not client_id:
+        raise ValueError(
+            f"OAuth2: env var '{auth.client_id_env}' is not set."
+        )
+    if not client_secret:
+        raise ValueError(
+            f"OAuth2: env var '{auth.client_secret_env}' is not set."
+        )
+
+    data: dict[str, str] = {
+        "grant_type": "client_credentials",
+        "client_id": client_id,
+        "client_secret": client_secret,
+    }
+    if auth.scope:
+        data["scope"] = auth.scope
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.post(auth.token_url, data=data)
+        response.raise_for_status()
+
+    token_data = response.json()
+    access_token: str = token_data["access_token"]
+    expires_in: int = token_data.get("expires_in", 3600)
+
+    # Cache with 60s safety margin
+    _oauth2_cache[auth.token_url] = (
+        access_token,
+        time.monotonic() + expires_in - 60,
+    )
+
+    return {"Authorization": f"Bearer {access_token}"}

--- a/tests/unit/test_oauth2_auth.py
+++ b/tests/unit/test_oauth2_auth.py
@@ -1,0 +1,118 @@
+"""Tests for OAuth2 Client Credentials auth."""
+
+from __future__ import annotations
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from drt.config.models import OAuth2ClientCredentialsAuth
+from drt.destinations.auth import AuthHandler, _oauth2_cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    """Clear OAuth2 token cache between tests."""
+    _oauth2_cache.clear()
+
+
+def test_oauth2_token_exchange(
+    httpserver: HTTPServer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MY_CLIENT_ID", "test-id")
+    monkeypatch.setenv("MY_CLIENT_SECRET", "test-secret")
+
+    httpserver.expect_request("/oauth/token", method="POST").respond_with_json(
+        {"access_token": "tok_abc123", "token_type": "Bearer", "expires_in": 3600}
+    )
+
+    auth = OAuth2ClientCredentialsAuth(
+        type="oauth2_client_credentials",
+        token_url=httpserver.url_for("/oauth/token"),
+        client_id_env="MY_CLIENT_ID",
+        client_secret_env="MY_CLIENT_SECRET",
+    )
+    headers = AuthHandler(auth).get_headers()
+    assert headers == {"Authorization": "Bearer tok_abc123"}
+
+
+def test_oauth2_with_scope(
+    httpserver: HTTPServer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CID", "id")
+    monkeypatch.setenv("CSEC", "secret")
+
+    httpserver.expect_request("/token", method="POST").respond_with_json(
+        {"access_token": "scoped_tok", "expires_in": 3600}
+    )
+
+    auth = OAuth2ClientCredentialsAuth(
+        type="oauth2_client_credentials",
+        token_url=httpserver.url_for("/token"),
+        client_id_env="CID",
+        client_secret_env="CSEC",
+        scope="contacts.write",
+    )
+    headers = AuthHandler(auth).get_headers()
+    assert headers["Authorization"] == "Bearer scoped_tok"
+
+    # Verify scope was sent
+    req = httpserver.log[0][0]
+    assert b"scope=contacts.write" in req.data
+
+
+def test_oauth2_caches_token(
+    httpserver: HTTPServer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CID", "id")
+    monkeypatch.setenv("CSEC", "secret")
+
+    httpserver.expect_request("/token").respond_with_json(
+        {"access_token": "cached_tok", "expires_in": 3600}
+    )
+
+    auth = OAuth2ClientCredentialsAuth(
+        type="oauth2_client_credentials",
+        token_url=httpserver.url_for("/token"),
+        client_id_env="CID",
+        client_secret_env="CSEC",
+    )
+
+    # First call — hits server
+    h1 = AuthHandler(auth).get_headers()
+    # Second call — should use cache (server only expects 1 request)
+    h2 = AuthHandler(auth).get_headers()
+
+    assert h1 == h2 == {"Authorization": "Bearer cached_tok"}
+    assert len(httpserver.log) == 1
+
+
+def test_oauth2_missing_client_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MISSING_ID", raising=False)
+    monkeypatch.setenv("CSEC", "secret")
+
+    auth = OAuth2ClientCredentialsAuth(
+        type="oauth2_client_credentials",
+        token_url="http://unused",
+        client_id_env="MISSING_ID",
+        client_secret_env="CSEC",
+    )
+    with pytest.raises(ValueError, match="MISSING_ID"):
+        AuthHandler(auth).get_headers()
+
+
+def test_oauth2_missing_client_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CID", "id")
+    monkeypatch.delenv("MISSING_SEC", raising=False)
+
+    auth = OAuth2ClientCredentialsAuth(
+        type="oauth2_client_credentials",
+        token_url="http://unused",
+        client_id_env="CID",
+        client_secret_env="MISSING_SEC",
+    )
+    with pytest.raises(ValueError, match="MISSING_SEC"):
+        AuthHandler(auth).get_headers()


### PR DESCRIPTION
## Summary

Add OAuth2 Client Credentials flow to the REST API destination, enabling drt to authenticate with any OAuth2-protected API (Salesforce, Google APIs, Microsoft Graph, etc.).

```yaml
auth:
  type: oauth2_client_credentials
  token_url: "https://auth.example.com/oauth/token"
  client_id_env: OAUTH_CLIENT_ID
  client_secret_env: OAUTH_CLIENT_SECRET
  scope: "contacts.write"
```

- Token exchange via POST to token_url
- Caching with 60s safety margin before expiry
- Existing auth types (bearer, api_key, basic) unchanged

Closes #259.

## Test plan
- [x] 5 tests: token exchange, scope, caching, missing client_id, missing client_secret
- [x] 390+ total tests passing
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)