### PR TITLE
feat: add Google Ads offline conversion destination

### DIFF
--- a/docs/llm/API_REFERENCE.md
+++ b/docs/llm/API_REFERENCE.md
@@ -445,6 +445,31 @@ auth:
 
 → Sends `Authorization: Basic <base64(username:password)>` header.
 
+### `type: google_ads`
+
+```yaml
+destination:
+  type: google_ads
+  customer_id: "1234567890"            # required: Google Ads customer ID (no hyphens)
+  conversion_action: "customers/1234567890/conversionActions/987"  # required
+  gclid_field: gclid                   # row field for click ID (default: "gclid")
+  conversion_time_field: conversion_time  # row field for timestamp
+  conversion_value_field: revenue      # optional: row field for conversion value
+  currency_code: JPY                   # default: USD
+  developer_token_env: GOOGLE_ADS_DEVELOPER_TOKEN
+  auth:
+    type: oauth2_client_credentials
+    token_url: "https://oauth2.googleapis.com/token"
+    client_id_env: GOOGLE_ADS_CLIENT_ID
+    client_secret_env: GOOGLE_ADS_CLIENT_SECRET
+```
+
+---
+
+## Auth Configs
+
+Auth configs are used inside destination configs under the `auth:` key.
+
 ### OAuth2 Client Credentials
 
 ```yaml

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from drt.destinations.discord import DiscordDestination
     from drt.destinations.file import FileDestination
     from drt.destinations.github_actions import GitHubActionsDestination
+    from drt.destinations.google_ads import GoogleAdsDestination
     from drt.destinations.google_sheets import GoogleSheetsDestination
     from drt.destinations.hubspot import HubSpotDestination
     from drt.destinations.jira import JiraDestination
@@ -663,12 +664,14 @@ def _get_destination(
     | ParquetDestination
     | FileDestination
     | LinearDestination
+    | GoogleAdsDestination
 ):
     from drt.config.models import (
         ClickHouseDestinationConfig,
         DiscordDestinationConfig,
         FileDestinationConfig,
         GitHubActionsDestinationConfig,
+        GoogleAdsDestinationConfig,
         GoogleSheetsDestinationConfig,
         HubSpotDestinationConfig,
         JiraDestinationConfig,
@@ -732,4 +735,8 @@ def _get_destination(
         return FileDestination()
     if isinstance(dest, LinearDestinationConfig):
         return LinearDestination()
+    if isinstance(dest, GoogleAdsDestinationConfig):
+        from drt.destinations.google_ads import GoogleAdsDestination
+
+        return GoogleAdsDestination()
     raise ValueError(f"Unsupported destination type: {dest.type}")

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -331,6 +331,21 @@ class FileDestinationConfig(BaseModel):
         return f"{self.type} ({self.path})"
 
 
+class GoogleAdsDestinationConfig(BaseModel):
+    type: Literal["google_ads"]
+    customer_id: str  # Google Ads customer ID (without hyphens)
+    conversion_action: str  # e.g. "customers/123/conversionActions/456"
+    gclid_field: str = "gclid"  # row field containing the click ID
+    conversion_time_field: str = "conversion_time"  # row field for timestamp
+    conversion_value_field: str | None = None  # optional: row field for value
+    currency_code: str = "USD"
+    developer_token_env: str = "GOOGLE_ADS_DEVELOPER_TOKEN"
+    auth: AuthConfig | None = None  # typically oauth2_client_credentials
+
+    def describe(self) -> str:
+        return f"google_ads ({self.customer_id})"
+
+
 # Discriminated union — add new destination types here
 DestinationConfig = Annotated[
     RestApiDestinationConfig
@@ -347,6 +362,7 @@ DestinationConfig = Annotated[
     | JiraDestinationConfig
     | ClickHouseDestinationConfig
     | ParquetDestinationConfig
+    | GoogleAdsDestinationConfig
     | FileDestinationConfig,
     Field(discriminator="type"),
 ]

--- a/drt/destinations/google_ads.py
+++ b/drt/destinations/google_ads.py
@@ -1,0 +1,147 @@
+"""Google Ads destination — upload offline click conversions.
+
+Sends conversion data to Google Ads via the Conversions Upload API.
+Each record should contain a gclid, conversion timestamp, and optionally
+a conversion value.
+
+Requires OAuth2 authentication (service account or client credentials)
+and a developer token.
+
+Example sync YAML:
+
+    destination:
+      type: google_ads
+      customer_id: "1234567890"
+      conversion_action: "customers/1234567890/conversionActions/987"
+      gclid_field: gclid
+      conversion_time_field: conversion_time
+      conversion_value_field: revenue
+      currency_code: USD
+      developer_token_env: GOOGLE_ADS_DEVELOPER_TOKEN
+      auth:
+        type: oauth2_client_credentials
+        token_url: "https://oauth2.googleapis.com/token"
+        client_id_env: GOOGLE_ADS_CLIENT_ID
+        client_secret_env: GOOGLE_ADS_CLIENT_SECRET
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import httpx
+
+from drt.config.models import DestinationConfig, GoogleAdsDestinationConfig, SyncOptions
+from drt.destinations.auth import AuthHandler
+from drt.destinations.base import SyncResult
+from drt.destinations.rate_limiter import RateLimiter
+from drt.destinations.row_errors import RowError
+
+_API_VERSION = "v17"
+_BASE_URL = "https://googleads.googleapis.com"
+
+
+class GoogleAdsDestination:
+    """Upload offline click conversions to Google Ads."""
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, GoogleAdsDestinationConfig)
+        result = SyncResult()
+        rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
+
+        developer_token = os.environ.get(config.developer_token_env, "")
+        if not developer_token:
+            raise ValueError(
+                f"Google Ads: env var '{config.developer_token_env}' is not set."
+            )
+
+        auth_headers = AuthHandler(config.auth).get_headers()
+        headers = {
+            **auth_headers,
+            "developer-token": developer_token,
+            "Content-Type": "application/json",
+        }
+
+        # Build conversions payload
+        conversions = []
+        for i, record in enumerate(records):
+            gclid = record.get(config.gclid_field)
+            conv_time = record.get(config.conversion_time_field)
+            if not gclid or not conv_time:
+                result.failed += 1
+                result.row_errors.append(
+                    RowError(
+                        batch_index=i,
+                        record_preview=json.dumps(record)[:200],
+                        http_status=None,
+                        error_message=(
+                            f"Missing required field: "
+                            f"{config.gclid_field} or "
+                            f"{config.conversion_time_field}"
+                        ),
+                    )
+                )
+                continue
+
+            conversion: dict[str, Any] = {
+                "gclid": str(gclid),
+                "conversionAction": config.conversion_action,
+                "conversionDateTime": str(conv_time),
+            }
+            if config.conversion_value_field:
+                val = record.get(config.conversion_value_field)
+                if val is not None:
+                    conversion["conversionValue"] = float(val)
+                    conversion["currencyCode"] = config.currency_code
+
+            conversions.append(conversion)
+
+        if not conversions:
+            return result
+
+        url = (
+            f"{_BASE_URL}/{_API_VERSION}"
+            f"/customers/{config.customer_id}"
+            f":uploadClickConversions"
+        )
+        payload = {
+            "conversions": conversions,
+            "partialFailure": True,
+        }
+
+        rate_limiter.acquire()
+        try:
+            with httpx.Client(timeout=60.0) as client:
+                response = client.post(url, json=payload, headers=headers)
+                response.raise_for_status()
+
+            resp_data = response.json()
+            # Count partial failures
+            partial_errors = resp_data.get("partialFailureError")
+            if partial_errors:
+                error_details = partial_errors.get("details", [])
+                result.failed += len(error_details)
+                result.success += len(conversions) - len(error_details)
+                for detail in error_details[:10]:
+                    result.errors.append(str(detail.get("message", "")))
+            else:
+                result.success += len(conversions)
+
+        except httpx.HTTPStatusError as e:
+            result.failed += len(conversions)
+            result.errors.append(
+                f"Google Ads API error: {e.response.status_code} "
+                f"{e.response.text[:500]}"
+            )
+        except Exception as e:
+            result.failed += len(conversions)
+            result.errors.append(f"Google Ads error: {e}")
+
+        return result

--- a/tests/unit/test_google_ads.py
+++ b/tests/unit/test_google_ads.py
@@ -1,0 +1,132 @@
+"""Tests for Google Ads offline conversion destination."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from drt.config.models import GoogleAdsDestinationConfig, SyncOptions
+from drt.destinations.google_ads import GoogleAdsDestination
+
+
+def _options() -> SyncOptions:
+    return SyncOptions()
+
+
+def _config(httpserver: HTTPServer, **overrides: str) -> GoogleAdsDestinationConfig:
+    defaults = {
+        "type": "google_ads",
+        "customer_id": "1234567890",
+        "conversion_action": "customers/1234567890/conversionActions/987",
+    }
+    return GoogleAdsDestinationConfig(**{**defaults, **overrides})
+
+
+class TestGoogleAdsDestination:
+    def test_success(
+        self, httpserver: HTTPServer, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "dev-tok")
+
+        httpserver.expect_request(
+            "/v17/customers/1234567890:uploadClickConversions",
+            method="POST",
+        ).respond_with_json({"results": [{}]})
+
+        from drt.destinations import google_ads
+
+        monkeypatch.setattr(google_ads, "_BASE_URL", httpserver.url_for(""))
+
+        config = _config(httpserver)
+        records = [
+            {"gclid": "abc123", "conversion_time": "2024-01-01 12:00:00"},
+        ]
+        result = GoogleAdsDestination().load(records, config, _options())
+        assert result.success == 1
+        assert result.failed == 0
+
+    def test_missing_gclid(
+        self, httpserver: HTTPServer, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "dev-tok")
+        config = _config(httpserver)
+        records = [{"conversion_time": "2024-01-01 12:00:00"}]
+        result = GoogleAdsDestination().load(records, config, _options())
+        assert result.failed == 1
+        assert any("Missing" in e.error_message for e in result.row_errors)
+
+    def test_missing_developer_token(
+        self, monkeypatch: pytest.MonkeyPatch, httpserver: HTTPServer
+    ) -> None:
+        monkeypatch.delenv("GOOGLE_ADS_DEVELOPER_TOKEN", raising=False)
+        config = _config(httpserver)
+        with pytest.raises(ValueError, match="GOOGLE_ADS_DEVELOPER_TOKEN"):
+            GoogleAdsDestination().load(
+                [{"gclid": "x", "conversion_time": "t"}],
+                config,
+                _options(),
+            )
+
+    def test_partial_failure(
+        self, httpserver: HTTPServer, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "dev-tok")
+
+        httpserver.expect_request(
+            "/v17/customers/1234567890:uploadClickConversions",
+        ).respond_with_json({
+            "partialFailureError": {
+                "details": [{"message": "Invalid gclid"}],
+            },
+        })
+
+        from drt.destinations import google_ads
+
+        monkeypatch.setattr(google_ads, "_BASE_URL", httpserver.url_for(""))
+
+        config = _config(httpserver)
+        records = [
+            {"gclid": "good", "conversion_time": "2024-01-01 12:00:00"},
+            {"gclid": "bad", "conversion_time": "2024-01-01 12:00:00"},
+        ]
+        result = GoogleAdsDestination().load(records, config, _options())
+        assert result.failed == 1
+        assert result.success == 1
+
+    def test_with_conversion_value(
+        self, httpserver: HTTPServer, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "dev-tok")
+
+        httpserver.expect_request(
+            "/v17/customers/1234567890:uploadClickConversions",
+        ).respond_with_json({"results": [{}]})
+
+        from drt.destinations import google_ads
+
+        monkeypatch.setattr(google_ads, "_BASE_URL", httpserver.url_for(""))
+
+        config = GoogleAdsDestinationConfig(
+            type="google_ads",
+            customer_id="1234567890",
+            conversion_action="customers/1234567890/conversionActions/987",
+            conversion_value_field="revenue",
+            currency_code="JPY",
+        )
+        records = [
+            {
+                "gclid": "abc",
+                "conversion_time": "2024-01-01",
+                "revenue": 9800,
+            },
+        ]
+        result = GoogleAdsDestination().load(records, config, _options())
+        assert result.success == 1
+
+        req = httpserver.log[0][0]
+        body = json.loads(req.data)
+        conv = body["conversions"][0]
+        assert conv["conversionValue"] == 9800.0
+        assert conv["currencyCode"] == "JPY"


### PR DESCRIPTION
## Summary

Add Google Ads destination for uploading offline click conversions — one of the most common Reverse ETL use cases in marketing.

```yaml
destination:
  type: google_ads
  customer_id: "1234567890"
  conversion_action: "customers/1234567890/conversionActions/987"
  gclid_field: gclid
  conversion_time_field: conversion_time
  conversion_value_field: revenue
  currency_code: JPY
  developer_token_env: GOOGLE_ADS_DEVELOPER_TOKEN
  auth:
    type: oauth2_client_credentials
    token_url: "https://oauth2.googleapis.com/token"
    client_id_env: GOOGLE_ADS_CLIENT_ID
    client_secret_env: GOOGLE_ADS_CLIENT_SECRET
```

- Partial failure handling (Google Ads returns per-conversion errors)
- Missing gclid/conversion_time → row-level error, not batch failure
- Uses OAuth2 auth from #259

Closes #217.

## Test plan
- [x] 5 tests (success, missing fields, missing token, partial failure, conversion value)
- [x] 403 total tests passing
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)