### PR TITLE
feat: add Airflow integration — run_drt_sync() and DrtRunOperator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## drt-core
 
+## [Unreleased]
+
+### Added
+
+- **Airflow integration** (#70): Built-in `run_drt_sync()` helper and `DrtRunOperator` for Apache Airflow. No extra package needed — included in drt-core.
+- **Google Ads destination** (#217): Upload offline click conversions. Supports partial failure handling and OAuth2 auth.
+- **OAuth2 Client Credentials auth** (#259): Token exchange with caching for REST API destination.
+- **`drt init --from-dbt`** (#215): Generate sync YAML scaffolds from dbt `manifest.json`.
+- **`--output json` for validate/list** (#230): Structured JSON output for `drt validate` and `drt list`.
+- **MCP Server: `drt_list_connectors`** (#262): New tool listing all available sources and destinations.
+- **MCP Server: improved `drt_validate`** (#262): Per-file error reporting via `load_syncs_safe()`.
+
 ## [0.5.0] - 2026-04-13
 
 ### Added

--- a/docs/guides/using-with-airflow.md
+++ b/docs/guides/using-with-airflow.md
@@ -1,0 +1,105 @@
+# Using drt with Apache Airflow
+
+Run drt syncs as Airflow tasks. No extra package needed — drt's Airflow integration is built into `drt-core`.
+
+## Option 1: PythonOperator (recommended)
+
+Use `run_drt_sync()` with Airflow's built-in `PythonOperator`:
+
+```python
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from datetime import datetime
+
+from drt.integrations.airflow import run_drt_sync
+
+with DAG(
+    "drt_syncs",
+    schedule="@hourly",
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+) as dag:
+
+    sync_users = PythonOperator(
+        task_id="sync_users",
+        python_callable=run_drt_sync,
+        op_kwargs={
+            "sync_name": "sync_users",
+            "project_dir": "/path/to/drt-project",
+        },
+    )
+
+    sync_orders = PythonOperator(
+        task_id="sync_orders",
+        python_callable=run_drt_sync,
+        op_kwargs={
+            "sync_name": "sync_orders",
+            "project_dir": "/path/to/drt-project",
+            "dry_run": False,
+        },
+    )
+
+    sync_users >> sync_orders
+```
+
+### Return value (XCom)
+
+`run_drt_sync()` returns a dict that is automatically pushed to XCom:
+
+```json
+{
+  "sync_name": "sync_users",
+  "status": "success",
+  "rows_synced": 42,
+  "rows_failed": 0,
+  "duration_seconds": 1.5,
+  "dry_run": false,
+  "errors": []
+}
+```
+
+### Multi-environment with `--profile`
+
+```python
+PythonOperator(
+    task_id="sync_users_prd",
+    python_callable=run_drt_sync,
+    op_kwargs={
+        "sync_name": "sync_users",
+        "project_dir": "/path/to/drt-project",
+        "profile": "prd",  # overrides drt_project.yml
+    },
+)
+```
+
+## Option 2: DrtRunOperator
+
+If you prefer a dedicated operator (requires Airflow at runtime):
+
+```python
+from drt.integrations.airflow import DrtRunOperator
+
+with DAG(...) as dag:
+    sync_task = DrtRunOperator(
+        task_id="sync_users",
+        sync_name="sync_users",
+        project_dir="/path/to/drt-project",
+    )
+```
+
+`DrtRunOperator` supports Airflow's `template_fields` for `sync_name`, `project_dir`, and `profile`.
+
+## Google Cloud Composer
+
+For Cloud Composer, install `drt-core` in your Composer environment:
+
+```bash
+# Via requirements.txt
+drt-core[bigquery]>=0.5.0
+
+# Or via gcloud
+gcloud composer environments update MY_ENV \
+  --update-pypi-package drt-core[bigquery]>=0.5.0
+```
+
+Then use `PythonOperator` as shown above.

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -91,6 +91,7 @@ default:
 | Jira | `jira` | Create/update issues via REST API v3 |
 | Linear | `linear` | Create issues via GraphQL API |
 | SendGrid | `sendgrid` | Transactional emails via v3 Mail Send API |
+| Google Ads | `google_ads` | Offline click conversion upload |
 
 ## CLI Commands
 

--- a/drt/integrations/airflow.py
+++ b/drt/integrations/airflow.py
@@ -95,6 +95,9 @@ def run_drt_sync(
     }
 
 
+_airflow_operator_cls: type | None = None
+
+
 class DrtRunOperator:
     """Airflow Operator that runs a drt sync.
 
@@ -114,6 +117,8 @@ class DrtRunOperator:
     """
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Any:
+        global _airflow_operator_cls  # noqa: PLW0603
+
         try:
             from airflow.models import BaseOperator
         except ImportError as e:
@@ -123,8 +128,7 @@ class DrtRunOperator:
                 "or install Airflow: pip install apache-airflow"
             ) from e
 
-        # Dynamically create a class that inherits from BaseOperator
-        if not hasattr(cls, "_airflow_cls"):
+        if _airflow_operator_cls is None:
 
             class _DrtRunOperator(BaseOperator):  # type: ignore[misc]
                 """Airflow operator that runs a drt sync."""
@@ -153,6 +157,6 @@ class DrtRunOperator:
                         profile=self.profile,
                     )
 
-            cls._airflow_cls = _DrtRunOperator
+            _airflow_operator_cls = _DrtRunOperator
 
-        return cls._airflow_cls(*args, **kwargs)
+        return _airflow_operator_cls(*args, **kwargs)

--- a/drt/integrations/airflow.py
+++ b/drt/integrations/airflow.py
@@ -1,0 +1,158 @@
+"""Airflow integration — run drt syncs as Airflow tasks.
+
+Two usage patterns:
+
+1. Standalone helper (no Airflow dependency in drt-core):
+
+    from drt.integrations.airflow import run_drt_sync
+
+    with DAG(...) as dag:
+        PythonOperator(
+            task_id="sync_users",
+            python_callable=run_drt_sync,
+            op_kwargs={"sync_name": "sync_users", "project_dir": "/path/to/project"},
+        )
+
+2. DrtRunOperator (requires Airflow at runtime):
+
+    from drt.integrations.airflow import DrtRunOperator
+
+    with DAG(...) as dag:
+        DrtRunOperator(
+            task_id="sync_users",
+            sync_name="sync_users",
+            project_dir="/path/to/project",
+        )
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def run_drt_sync(
+    sync_name: str,
+    project_dir: str = ".",
+    dry_run: bool = False,
+    profile: str | None = None,
+) -> dict[str, Any]:
+    """Run a drt sync and return the result as a dict.
+
+    Designed to be called from Airflow's PythonOperator.
+    Returns a dict suitable for XCom push.
+
+    Args:
+        sync_name: Name of the sync to run.
+        project_dir: Path to the drt project directory.
+        dry_run: If True, extract but don't write to destination.
+        profile: Override profile name (default: from drt_project.yml).
+
+    Returns:
+        Dict with sync_name, status, rows_synced, rows_failed, duration_seconds.
+
+    Raises:
+        ValueError: If sync_name is not found.
+        RuntimeError: If sync fails completely.
+    """
+    from drt.cli.main import _get_destination, _get_source, _resolve_profile_name
+    from drt.config.credentials import load_profile
+    from drt.config.parser import load_project, load_syncs
+    from drt.engine.sync import run_sync
+    from drt.state.manager import StateManager
+
+    pdir = Path(project_dir)
+    project = load_project(pdir)
+    resolved_profile = _resolve_profile_name(profile, project.profile)
+    prof = load_profile(resolved_profile)
+    syncs = load_syncs(pdir)
+
+    matched = [s for s in syncs if s.name == sync_name]
+    if not matched:
+        raise ValueError(f"No sync named '{sync_name}' found in {pdir}")
+
+    sync = matched[0]
+    source = _get_source(prof)
+    dest = _get_destination(sync)
+    state_mgr = StateManager(pdir)
+
+    result = run_sync(sync, source, dest, prof, pdir, dry_run, state_mgr)
+
+    status = (
+        "success" if result.failed == 0
+        else "partial" if result.success > 0
+        else "failed"
+    )
+
+    return {
+        "sync_name": sync_name,
+        "status": status,
+        "rows_synced": result.success,
+        "rows_failed": result.failed,
+        "duration_seconds": result.duration_seconds,
+        "dry_run": dry_run,
+        "errors": result.errors[:10],
+    }
+
+
+class DrtRunOperator:
+    """Airflow Operator that runs a drt sync.
+
+    Inherits from ``airflow.models.BaseOperator`` at runtime.
+    If Airflow is not installed, this class is still importable
+    but cannot be used as an operator.
+
+    Example::
+
+        from drt.integrations.airflow import DrtRunOperator
+
+        sync_task = DrtRunOperator(
+            task_id="sync_users",
+            sync_name="sync_users",
+            project_dir="/path/to/drt-project",
+        )
+    """
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> Any:
+        try:
+            from airflow.models import BaseOperator
+        except ImportError as e:
+            raise ImportError(
+                "DrtRunOperator requires Apache Airflow. "
+                "Use run_drt_sync() with PythonOperator instead, "
+                "or install Airflow: pip install apache-airflow"
+            ) from e
+
+        # Dynamically create a class that inherits from BaseOperator
+        if not hasattr(cls, "_airflow_cls"):
+
+            class _DrtRunOperator(BaseOperator):  # type: ignore[misc]
+                """Airflow operator that runs a drt sync."""
+
+                template_fields = ("sync_name", "project_dir", "profile")
+
+                def __init__(
+                    self,
+                    sync_name: str,
+                    project_dir: str = ".",
+                    dry_run: bool = False,
+                    profile: str | None = None,
+                    **kwargs: Any,
+                ) -> None:
+                    super().__init__(**kwargs)
+                    self.sync_name = sync_name
+                    self.project_dir = project_dir
+                    self.dry_run = dry_run
+                    self.profile = profile
+
+                def execute(self, context: Any) -> dict[str, Any]:
+                    return run_drt_sync(
+                        sync_name=self.sync_name,
+                        project_dir=self.project_dir,
+                        dry_run=self.dry_run,
+                        profile=self.profile,
+                    )
+
+            cls._airflow_cls = _DrtRunOperator
+
+        return cls._airflow_cls(*args, **kwargs)

--- a/tests/unit/test_airflow_integration.py
+++ b/tests/unit/test_airflow_integration.py
@@ -1,0 +1,56 @@
+"""Tests for Airflow integration helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from drt.integrations.airflow import DrtRunOperator, run_drt_sync
+
+
+def test_run_drt_sync_not_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run_drt_sync raises ValueError for unknown sync."""
+    # Create minimal project
+    (tmp_path / "drt_project.yml").write_text(
+        yaml.dump({"name": "test", "version": "0.1", "profile": "default"})
+    )
+    # Create credentials in home-like dir
+    creds = tmp_path / "drt_home"
+    creds.mkdir()
+    (creds / "profiles.yml").write_text(
+        yaml.dump({"default": {"type": "duckdb", "database": ":memory:"}})
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Patch config dir to use our temp dir
+    monkeypatch.setattr(
+        "drt.config.credentials._config_dir",
+        lambda override=None: override or creds,
+    )
+    (tmp_path / "syncs").mkdir()
+
+    with pytest.raises(ValueError, match="No sync named"):
+        run_drt_sync("nonexistent", project_dir=str(tmp_path))
+
+
+def test_run_drt_sync_missing_project(tmp_path: Path) -> None:
+    """run_drt_sync raises FileNotFoundError without drt_project.yml."""
+    with pytest.raises(FileNotFoundError):
+        run_drt_sync("any", project_dir=str(tmp_path))
+
+
+def test_drt_run_operator_requires_airflow() -> None:
+    """DrtRunOperator raises ImportError without Airflow installed."""
+    with pytest.raises(ImportError, match="Airflow"):
+        DrtRunOperator(task_id="test", sync_name="test")
+
+
+def test_run_drt_sync_return_type() -> None:
+    """Verify return type annotation is dict."""
+    import inspect
+
+    sig = inspect.signature(run_drt_sync)
+    assert "dict" in str(sig.return_annotation)


### PR DESCRIPTION
## Summary

Built-in Airflow integration (dlt-style, no separate package needed).

### Two usage patterns

**1. PythonOperator (recommended):**
```python
from drt.integrations.airflow import run_drt_sync

PythonOperator(
    task_id="sync_users",
    python_callable=run_drt_sync,
    op_kwargs={"sync_name": "sync_users", "project_dir": "/path/to/project"},
)
```

**2. DrtRunOperator:**
```python
from drt.integrations.airflow import DrtRunOperator

DrtRunOperator(task_id="sync_users", sync_name="sync_users", project_dir="/path")
```

### Features
- Returns XCom-ready dict (sync_name, status, rows_synced, rows_failed, duration_seconds)
- `profile` param for multi-environment DAGs (dev/stg/prd)
- `DrtRunOperator` supports Airflow `template_fields`
- No Airflow dependency in drt-core — operator auto-detects at runtime

### Design decision
Chose built-in (dlt pattern) over separate package (dagster-drt pattern) because Airflow integration is thin (`PythonOperator` + helper), unlike Dagster which needs deep `@multi_asset` integration.

Closes #70.

## Test plan
- [x] 4 tests (sync not found, missing project, operator requires airflow, return type)
- [x] 407 total tests passing
- [x] Guide: `docs/guides/using-with-airflow.md`
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)