### PR TITLE
feat: add drt cloud push command stub

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -547,6 +547,23 @@ def _test_display_name(test_def: object) -> str:
 
 
 # ---------------------------------------------------------------------------
+# cloud
+# ---------------------------------------------------------------------------
+
+cloud_app = typer.Typer(name="cloud", help="drt Cloud commands (stub).", no_args_is_help=True)
+app.add_typer(cloud_app)
+
+
+@cloud_app.command(name="push")
+def cloud_push() -> None:
+    """Push local project configuration to drt Cloud (stub)."""
+    console.print("\n[bold blue]🚀 drt Cloud[/bold blue]")
+    console.print("This is a stub for the future drt Cloud service.")
+    console.print("Project state would be pushed to your cloud dashboard here.")
+    console.print("\n[dim]Coming soon...[/dim]\n")
+
+
+# ---------------------------------------------------------------------------
 # mcp
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR adds a stub for the `drt cloud push` command as a placeholder for the future Cloud service.

Changes:
- Added `cloud` command group to the CLI.
- Added `push` command to the `cloud` group with a placeholder message.

Fixes #302