### PR TITLE
fix(mysql): auto json.dumps() for dict/list values in MySQL destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **MCP Server: improved `drt_validate`** (#262): Per-file error reporting via `load_syncs_safe()`.
 - **BigQuery → Discord example** (#266): Alert pipeline that queries BigQuery for recent error rows and posts a Discord notification per row via Incoming Webhook using incremental sync. Includes `examples/bigquery_to_discord/`.
 
+### Fixed
+
+- **MySQL destination**: auto-serialize `dict`/`list` values to JSON strings before passing to pymysql (#311). Also shipped in [0.5.1](#051---2026-04-14).
+
+## [0.5.1] - 2026-04-14
+
+### Fixed
+
+- **MySQL destination**: auto-serialize `dict`/`list` values to JSON strings before passing to pymysql (#311). Fixes BigQuery → MySQL reverse ETL where BigQuery JSON columns come back as Python `dict`/`list`. Backward compatible — strings, ints, and other types pass through unchanged.
+
 ## [0.5.0] - 2026-04-13
 
 ### Added

--- a/drt/destinations/mysql.py
+++ b/drt/destinations/mysql.py
@@ -26,6 +26,18 @@ from drt.destinations.base import SyncResult
 from drt.destinations.row_errors import RowError
 
 
+def _serialize_value(value: Any) -> Any:
+    """Serialize dict/list values to JSON strings for pymysql.
+
+    pymysql does not auto-serialize complex Python types, so values
+    bound for JSON columns (common when sourcing from BigQuery) must
+    be converted to strings before execute().
+    """
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False)
+    return value
+
+
 class MySQLDestination:
     """Upsert records into a MySQL table."""
 
@@ -51,7 +63,7 @@ class MySQLDestination:
 
             for i, record in enumerate(records):
                 try:
-                    values = [record.get(c) for c in columns]
+                    values = [_serialize_value(record.get(c)) for c in columns]
                     cur.execute(sql, values)
                     result.success += 1
                 except Exception as e:

--- a/tests/unit/test_mysql_destination.py
+++ b/tests/unit/test_mysql_destination.py
@@ -179,6 +179,34 @@ class TestMySQLDestinationLoad:
         conn.close.assert_called_once()
 
     @patch("drt.destinations.mysql.MySQLDestination._connect")
+    def test_dict_and_list_values_are_json_serialized(
+        self, mock_connect: MagicMock
+    ) -> None:
+        """dict/list values (e.g. from BigQuery JSON columns) must be
+        serialized to JSON strings before being passed to pymysql."""
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        records = [
+            {
+                "user_id": 1,
+                "company_id": 5,
+                "profile": {"lang": "日本語", "level": "N1"},
+                "tags": ["a", "b"],
+                "score": 0.9,
+            },
+        ]
+        result = MySQLDestination().load(records, _config(), _options())
+
+        assert result.success == 1
+        args, _ = cur.execute.call_args
+        _sql, values = args
+        assert values[2] == '{"lang": "日本語", "level": "N1"}'
+        assert values[3] == '["a", "b"]'
+        assert values[4] == 0.9
+
+    @patch("drt.destinations.mysql.MySQLDestination._connect")
     def test_connection_closed_on_error(self, mock_connect: MagicMock) -> None:
         conn = _fake_connection()
         conn.cursor().execute.side_effect = Exception("fail")


### PR DESCRIPTION
## Summary
- Fixes #311. MySQL destination now auto-serializes `dict`/`list` values to JSON strings before passing them to pymysql.
- Common case: BigQuery JSON columns extracted as Python `dict`/`list`, then synced to a MySQL/CloudSQL JSON column.
- Small, backward-compatible change. Strings, ints, etc. pass through unchanged.

## Test plan
- [x] `make lint` passes
- [x] Full test suite passes (418 passed, 1 skipped)
- [x] New unit test verifies `dict`/`list` values (including non-ASCII) serialize correctly before `cur.execute()`

## Release note
This fix will also ship as **v0.5.1** patch release via cherry-pick from `v0.5.0`, so users on v0.5.x can pick it up without waiting for v0.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)