### PR TITLE
feat: add Prefect integration — drt_sync_task and run_drt_sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Prefect integration** (#213): Built-in `run_drt_sync()` helper and `drt_sync_task` for Prefect 2.x/3.x. No extra package needed — included in drt-core. Shares the runner with Airflow integration via `drt.integrations._runner`.
 - **Airflow integration** (#70): Built-in `run_drt_sync()` helper and `DrtRunOperator` for Apache Airflow. No extra package needed — included in drt-core.
 - **Google Ads destination** (#217): Upload offline click conversions. Supports partial failure handling and OAuth2 auth.
 - **OAuth2 Client Credentials auth** (#259): Token exchange with caching for REST API destination.

--- a/docs/guides/using-with-prefect.md
+++ b/docs/guides/using-with-prefect.md
@@ -1,0 +1,78 @@
+# Using drt with Prefect
+
+Run drt syncs as Prefect tasks. No extra package needed — drt's Prefect integration is built into `drt-core`. Works with Prefect 2.x and 3.x.
+
+## Option 1: Pre-decorated task (recommended)
+
+```python
+from prefect import flow
+from drt.integrations.prefect import drt_sync_task
+
+@flow
+def reverse_etl_flow():
+    drt_sync_task(
+        sync_name="sync_users",
+        project_dir="/path/to/drt-project",
+    )
+
+    drt_sync_task(
+        sync_name="sync_orders",
+        project_dir="/path/to/drt-project",
+    )
+```
+
+## Option 2: Decorate the helper yourself
+
+For more control over task name, retries, tags, etc.:
+
+```python
+from prefect import flow, task
+from drt.integrations.prefect import run_drt_sync
+
+sync_users = task(run_drt_sync, name="sync-users", retries=3)
+
+@flow(name="reverse-etl")
+def my_flow():
+    sync_users(
+        sync_name="sync_users",
+        project_dir="/path/to/drt-project",
+    )
+```
+
+## Return value
+
+Both forms return a dict ready for result passing:
+
+```json
+{
+  "sync_name": "sync_users",
+  "status": "success",
+  "rows_synced": 42,
+  "rows_failed": 0,
+  "duration_seconds": 1.5,
+  "dry_run": false,
+  "errors": []
+}
+```
+
+## Multi-environment with `--profile`
+
+```python
+@flow
+def prd_flow():
+    drt_sync_task(
+        sync_name="sync_users",
+        project_dir="/path/to/drt-project",
+        profile="prd",  # overrides drt_project.yml
+    )
+```
+
+## Installation
+
+Install Prefect alongside drt-core in your environment:
+
+```bash
+pip install drt-core prefect
+```
+
+No extra `drt-core[prefect]` extra is needed — the integration is pure Python and only imports Prefect at runtime.

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -133,6 +133,14 @@ drt mcp run   # starts stdio MCP server
 
 The MCP server reads from the current working directory (the drt project root).
 
+## Orchestration
+
+drt provides built-in helpers for Airflow and Prefect (no separate package needed), plus a first-class Dagster integration (`dagster-drt` on PyPI).
+
+- **Airflow**: `drt.integrations.airflow` — `run_drt_sync()` + `DrtRunOperator`. See `docs/guides/using-with-airflow.md`.
+- **Prefect**: `drt.integrations.prefect` — `run_drt_sync()` + `drt_sync_task`. See `docs/guides/using-with-prefect.md`.
+- **Dagster**: `pip install dagster-drt`. See below.
+
 ## Orchestration: dagster-drt
 
 Community-maintained Dagster integration. Install: `pip install dagster-drt`

--- a/drt/integrations/_runner.py
+++ b/drt/integrations/_runner.py
@@ -1,0 +1,74 @@
+"""Shared sync runner for orchestrator integrations (Airflow, Prefect, etc.).
+
+Provides the pure `run_drt_sync()` helper used by framework-specific wrappers.
+Keep this free of any orchestrator dependency.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def run_drt_sync(
+    sync_name: str,
+    project_dir: str = ".",
+    dry_run: bool = False,
+    profile: str | None = None,
+) -> dict[str, Any]:
+    """Run a drt sync and return the result as a dict.
+
+    Designed to be called from orchestrator tasks (Airflow PythonOperator,
+    Prefect @task, etc.). Returns a dict suitable for result passing.
+
+    Args:
+        sync_name: Name of the sync to run.
+        project_dir: Path to the drt project directory.
+        dry_run: If True, extract but don't write to destination.
+        profile: Override profile name (default: from drt_project.yml).
+
+    Returns:
+        Dict with sync_name, status, rows_synced, rows_failed,
+        duration_seconds, dry_run, errors.
+
+    Raises:
+        ValueError: If sync_name is not found.
+    """
+    from drt.cli.main import _get_destination, _get_source, _resolve_profile_name
+    from drt.config.credentials import load_profile
+    from drt.config.parser import load_project, load_syncs
+    from drt.engine.sync import run_sync
+    from drt.state.manager import StateManager
+
+    pdir = Path(project_dir)
+    project = load_project(pdir)
+    resolved_profile = _resolve_profile_name(profile, project.profile)
+    prof = load_profile(resolved_profile)
+    syncs = load_syncs(pdir)
+
+    matched = [s for s in syncs if s.name == sync_name]
+    if not matched:
+        raise ValueError(f"No sync named '{sync_name}' found in {pdir}")
+
+    sync = matched[0]
+    source = _get_source(prof)
+    dest = _get_destination(sync)
+    state_mgr = StateManager(pdir)
+
+    result = run_sync(sync, source, dest, prof, pdir, dry_run, state_mgr)
+
+    status = (
+        "success" if result.failed == 0
+        else "partial" if result.success > 0
+        else "failed"
+    )
+
+    return {
+        "sync_name": sync_name,
+        "status": status,
+        "rows_synced": result.success,
+        "rows_failed": result.failed,
+        "duration_seconds": result.duration_seconds,
+        "dry_run": dry_run,
+        "errors": result.errors[:10],
+    }

--- a/drt/integrations/airflow.py
+++ b/drt/integrations/airflow.py
@@ -27,73 +27,11 @@ Two usage patterns:
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
+from drt.integrations._runner import run_drt_sync  # re-export for backward compat
 
-def run_drt_sync(
-    sync_name: str,
-    project_dir: str = ".",
-    dry_run: bool = False,
-    profile: str | None = None,
-) -> dict[str, Any]:
-    """Run a drt sync and return the result as a dict.
-
-    Designed to be called from Airflow's PythonOperator.
-    Returns a dict suitable for XCom push.
-
-    Args:
-        sync_name: Name of the sync to run.
-        project_dir: Path to the drt project directory.
-        dry_run: If True, extract but don't write to destination.
-        profile: Override profile name (default: from drt_project.yml).
-
-    Returns:
-        Dict with sync_name, status, rows_synced, rows_failed, duration_seconds.
-
-    Raises:
-        ValueError: If sync_name is not found.
-        RuntimeError: If sync fails completely.
-    """
-    from drt.cli.main import _get_destination, _get_source, _resolve_profile_name
-    from drt.config.credentials import load_profile
-    from drt.config.parser import load_project, load_syncs
-    from drt.engine.sync import run_sync
-    from drt.state.manager import StateManager
-
-    pdir = Path(project_dir)
-    project = load_project(pdir)
-    resolved_profile = _resolve_profile_name(profile, project.profile)
-    prof = load_profile(resolved_profile)
-    syncs = load_syncs(pdir)
-
-    matched = [s for s in syncs if s.name == sync_name]
-    if not matched:
-        raise ValueError(f"No sync named '{sync_name}' found in {pdir}")
-
-    sync = matched[0]
-    source = _get_source(prof)
-    dest = _get_destination(sync)
-    state_mgr = StateManager(pdir)
-
-    result = run_sync(sync, source, dest, prof, pdir, dry_run, state_mgr)
-
-    status = (
-        "success" if result.failed == 0
-        else "partial" if result.success > 0
-        else "failed"
-    )
-
-    return {
-        "sync_name": sync_name,
-        "status": status,
-        "rows_synced": result.success,
-        "rows_failed": result.failed,
-        "duration_seconds": result.duration_seconds,
-        "dry_run": dry_run,
-        "errors": result.errors[:10],
-    }
-
+__all__ = ["run_drt_sync", "DrtRunOperator"]
 
 _airflow_operator_cls: type | None = None
 

--- a/drt/integrations/prefect.py
+++ b/drt/integrations/prefect.py
@@ -1,0 +1,73 @@
+"""Prefect integration — run drt syncs as Prefect tasks.
+
+Built-in integration (no separate package). Works with Prefect 2.x and 3.x.
+
+Two usage patterns:
+
+1. Use the pre-decorated task directly:
+
+    from prefect import flow
+    from drt.integrations.prefect import drt_sync_task
+
+    @flow
+    def my_flow():
+        drt_sync_task(sync_name="sync_users", project_dir="/path/to/project")
+
+2. Decorate the plain helper yourself (more control over task name, retries, etc.):
+
+    from prefect import flow, task
+    from drt.integrations.prefect import run_drt_sync
+
+    my_sync = task(run_drt_sync, name="sync-users", retries=3)
+
+    @flow
+    def my_flow():
+        my_sync(sync_name="sync_users", project_dir="/path/to/project")
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from drt.integrations._runner import run_drt_sync  # re-export
+
+__all__ = ["run_drt_sync", "drt_sync_task"]
+
+
+def drt_sync_task(
+    sync_name: str,
+    project_dir: str = ".",
+    dry_run: bool = False,
+    profile: str | None = None,
+) -> dict[str, Any]:
+    """Run a drt sync as a Prefect task.
+
+    Applies ``@prefect.task`` to :func:`run_drt_sync` lazily so that drt-core
+    doesn't require Prefect as a dependency.
+
+    Raises:
+        ImportError: If Prefect is not installed.
+    """
+    try:
+        from prefect import task
+    except ImportError as e:
+        raise ImportError(
+            "drt_sync_task requires Prefect. "
+            "Use run_drt_sync() with your own @task decorator, "
+            "or install Prefect: pip install prefect"
+        ) from e
+
+    global _decorated_task
+    if _decorated_task is None:
+        _decorated_task = task(name="drt_sync")(run_drt_sync)
+
+    result: dict[str, Any] = _decorated_task(
+        sync_name=sync_name,
+        project_dir=project_dir,
+        dry_run=dry_run,
+        profile=profile,
+    )
+    return result
+
+
+_decorated_task: Any = None

--- a/tests/unit/test_prefect_integration.py
+++ b/tests/unit/test_prefect_integration.py
@@ -1,0 +1,52 @@
+"""Tests for Prefect integration helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from drt.integrations.prefect import drt_sync_task, run_drt_sync
+
+
+def test_run_drt_sync_not_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run_drt_sync raises ValueError for unknown sync."""
+    (tmp_path / "drt_project.yml").write_text(
+        yaml.dump({"name": "test", "version": "0.1", "profile": "default"})
+    )
+    creds = tmp_path / "drt_home"
+    creds.mkdir()
+    (creds / "profiles.yml").write_text(
+        yaml.dump({"default": {"type": "duckdb", "database": ":memory:"}})
+    )
+    monkeypatch.setattr(
+        "drt.config.credentials._config_dir",
+        lambda override=None: override or creds,
+    )
+    (tmp_path / "syncs").mkdir()
+
+    with pytest.raises(ValueError, match="No sync named"):
+        run_drt_sync("nonexistent", project_dir=str(tmp_path))
+
+
+def test_run_drt_sync_missing_project(tmp_path: Path) -> None:
+    """run_drt_sync raises FileNotFoundError without drt_project.yml."""
+    with pytest.raises(FileNotFoundError):
+        run_drt_sync("any", project_dir=str(tmp_path))
+
+
+def test_drt_sync_task_requires_prefect() -> None:
+    """drt_sync_task raises ImportError when Prefect is not installed."""
+    with pytest.raises(ImportError, match="Prefect"):
+        drt_sync_task(sync_name="x", project_dir=".")
+
+
+def test_run_drt_sync_return_type() -> None:
+    """Verify return type annotation is dict."""
+    import inspect
+
+    sig = inspect.signature(run_drt_sync)
+    assert "dict" in str(sig.return_annotation)


### PR DESCRIPTION
## Summary

Built-in Prefect 2.x/3.x integration. Same pattern as Airflow (#70) — no separate package, lazy Prefect import.

### Two usage patterns

**1. Pre-decorated task (recommended):**
```python
from prefect import flow
from drt.integrations.prefect import drt_sync_task

@flow
def reverse_etl_flow():
    drt_sync_task(sync_name="sync_users", project_dir="/path/to/project")
```

**2. Decorate yourself (custom name, retries, tags):**
```python
from prefect import flow, task
from drt.integrations.prefect import run_drt_sync

sync_users = task(run_drt_sync, name="sync-users", retries=3)

@flow
def my_flow():
    sync_users(sync_name="sync_users", project_dir="/path/to/project")
```

### Architecture

Extracted shared sync runner into `drt.integrations._runner` so Airflow and Prefect wrappers reuse the same logic. `airflow.run_drt_sync` and `prefect.run_drt_sync` are re-exports for backward compat.

Closes #213.

## Test plan
- [x] 4 new tests mirroring test_airflow_integration.py
- [x] 412 total tests passing (8 integration tests)
- [x] ruff + mypy clean
- [x] Guide: docs/guides/using-with-prefect.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)