### PR TITLE
fix(postgres): crash on dict values bound for JSONB columns (#315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **MySQL destination**: auto-serialize `dict`/`list` values to JSON strings before passing to pymysql (#311). Also shipped in [0.5.1](#051---2026-04-14).
+- **PostgreSQL destination**: wrap `dict` values with `psycopg2.extras.Json` before `cur.execute()` to fix crash on JSONB columns (#315). Same pattern as MySQL fix in #311. Backward compatible — non-dict values pass through unchanged.
 
 ## [0.5.1] - 2026-04-14
 

--- a/drt/destinations/postgres.py
+++ b/drt/destinations/postgres.py
@@ -26,6 +26,20 @@ from drt.destinations.base import SyncResult
 from drt.destinations.row_errors import RowError
 
 
+def _serialize_value(value: Any) -> Any:
+    """Wrap dict values with psycopg2.extras.Json for JSONB columns.
+
+    psycopg2 has no default adapter for dict, so values bound for JSONB
+    columns (common when sourcing from BigQuery) must be wrapped before
+    execute(). Follows the same pattern as MySQL's _serialize_value (#311).
+    """
+    if isinstance(value, dict):
+        from psycopg2.extras import Json
+
+        return Json(value)
+    return value
+
+
 class PostgresDestination:
     """Upsert records into a PostgreSQL table."""
 
@@ -51,7 +65,7 @@ class PostgresDestination:
 
             for i, record in enumerate(records):
                 try:
-                    values = [record.get(c) for c in columns]
+                    values = [_serialize_value(record.get(c)) for c in columns]
                     cur.execute(sql, values)
                     result.success += 1
                 except Exception as e:

--- a/tests/unit/test_postgres_destination.py
+++ b/tests/unit/test_postgres_destination.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from drt.config.models import PostgresDestinationConfig, SyncOptions
-from drt.destinations.postgres import PostgresDestination
+from drt.destinations.postgres import PostgresDestination, _serialize_value
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -188,3 +188,62 @@ class TestPostgresDestinationLoad:
 
         PostgresDestination().load([{"id": 1, "score": 0.5}], _config(), _options(on_error="fail"))
         conn.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Value serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeValue:
+    def test_dict_wrapped_with_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Mock psycopg2.extras.Json
+        mock_json_cls = MagicMock()
+        mock_json_cls.side_effect = lambda v: MagicMock(adapted=v, __class__=type("Json", (), {}))
+        mock_extras = MagicMock()
+        mock_extras.Json = mock_json_cls
+        monkeypatch.setitem(__import__("sys").modules, "psycopg2.extras", mock_extras)
+
+        result = _serialize_value({"lang": "ja"})
+        mock_json_cls.assert_called_once_with({"lang": "ja"})
+
+    def test_nested_dict_wrapped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_json_cls = MagicMock()
+        mock_json_cls.side_effect = lambda v: MagicMock(adapted=v)
+        mock_extras = MagicMock()
+        mock_extras.Json = mock_json_cls
+        monkeypatch.setitem(__import__("sys").modules, "psycopg2.extras", mock_extras)
+
+        data = {"user": {"name": "test", "prefs": [1, 2]}}
+        _serialize_value(data)
+        mock_json_cls.assert_called_once_with(data)
+
+    def test_non_dict_passthrough(self) -> None:
+        assert _serialize_value("hello") == "hello"
+        assert _serialize_value(42) == 42
+        assert _serialize_value(3.14) == 3.14
+        assert _serialize_value(None) is None
+        assert _serialize_value([1, 2, 3]) == [1, 2, 3]
+        assert _serialize_value(True) is True
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_dict_value_in_load(self, mock_connect: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify that dict values are serialized when loading records."""
+        # Mock psycopg2.extras.Json
+        mock_json_cls = MagicMock()
+        mock_json_cls.side_effect = lambda v: MagicMock(adapted=v)
+        mock_extras = MagicMock()
+        mock_extras.Json = mock_json_cls
+        monkeypatch.setitem(__import__("sys").modules, "psycopg2.extras", mock_extras)
+
+        conn = _fake_connection()
+        mock_connect.return_value = conn
+
+        records = [
+            {"id": 1, "profile": {"lang": "ja", "theme": "dark"}},
+        ]
+        result = PostgresDestination().load(records, _config(), _options())
+
+        assert result.success == 1
+        # Verify Json was called with the dict value
+        mock_json_cls.assert_called_once_with({"lang": "ja", "theme": "dark"})


### PR DESCRIPTION
## Summary

Fixes #315. `psycopg2` has no default adapter for `dict`, so any dict value bound via `cur.execute()` triggers `ProgrammingError: can't adapt type 'dict'`.

This wraps `dict` values with `psycopg2.extras.Json` before binding — the idiomatic psycopg2 pattern for JSONB columns. Same shape as the MySQL fix in #311.

## Changes

- **`drt/destinations/postgres.py`**: Added `_serialize_value()` helper that wraps `dict` with `psycopg2.extras.Json`. Called in `load()` when building the values list.
- **`tests/unit/test_postgres_destination.py`**: Added `TestSerializeValue` class with 4 tests (dict wrapping, nested dict, non-dict passthrough, integration with load).
- **`CHANGELOG.md`**: Entry under `[Unreleased] ### Fixed`.

## Backward compatibility

- `str`, `int`, `float`, `bool`, `None`, `list` — all pass through unchanged
- Only `dict` gets wrapped (with `psycopg2.extras.Json`, which psycopg2 handles natively for JSONB)

## Test results

17/17 tests pass.
