### PR TITLE
fix(ci): re-run CLA workflow on sign-phrase comments

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,7 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'pull_request_target') ||
-      (github.event_name == 'issue_comment' && github.event.comment.body == 'recheck')
+      (github.event_name == 'issue_comment' && (
+        github.event.comment.body == 'recheck' ||
+        contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')
+      ))
     steps:
       - name: CLA Assistant
         uses: contributor-assistant/github-action@v2.6.1


### PR DESCRIPTION
## Summary

Fix the CLA workflow so signature comments automatically re-trigger the check. Contributors no longer need to type \`recheck\`.

## Problem

Three PRs (#307, #308, #313) are stuck with \`cla: fail\` despite the contributors signing via the standard phrase \"I have read the CLA Document and I hereby sign the CLA.\"

Root cause: \`.github/workflows/cla.yml\` previously gated re-runs on \`comment.body == 'recheck'\` (exact match only), so the sign phrase posted by the CLA Assistant bot never re-triggered the workflow.

## Fix

Extend the \`if\` condition to also match the sign phrase via \`contains()\`:

\`\`\`yaml
if: |
  (github.event_name == 'pull_request_target') ||
  (github.event_name == 'issue_comment' && (
    github.event.comment.body == 'recheck' ||
    contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')
  ))
\`\`\`

## Follow-up (after merge)

Unstick existing PRs by commenting \`recheck\` on them:
- #307, #308, #313

Future PRs will pick up signatures automatically.

## Test plan
- [ ] Merge this PR
- [ ] Comment \`recheck\` on #313 → CLA check passes
- [ ] Verify a future PR with the sign phrase re-triggers the workflow automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)