### PR TITLE
feat: add Databricks SQL Warehouse source connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Databricks source connector** (#88): Extract data from Databricks SQL Warehouse using `databricks-sql-connector`. Supports Unity Catalog, access token auth. Install: `pip install drt-core[databricks]`.
 - **Prefect integration** (#213): Built-in `run_drt_sync()` helper and `drt_sync_task` for Prefect 2.x/3.x. No extra package needed — included in drt-core. Shares the runner with Airflow integration via `drt.integrations._runner`.
 - **Airflow integration** (#70): Built-in `run_drt_sync()` helper and `DrtRunOperator` for Apache Airflow. No extra package needed — included in drt-core.
 - **Google Ads destination** (#217): Upload offline click conversions. Supports partial failure handling and OAuth2 auth.

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 | Redshift | ✅ v0.3.4 | `pip install drt-core[redshift]` | Password (env var) |
 | ClickHouse | ✅ v0.4.3 | `pip install drt-core[clickhouse]` | Password (env var) |
 | MySQL | ✅ v0.5 | `pip install drt-core[mysql]` | Password (env var) |
+| Databricks | ✅ v0.6 | `pip install drt-core[databricks]` | Access Token (env var) |
 
 ### Destinations
 

--- a/docs/llm/API_REFERENCE.md
+++ b/docs/llm/API_REFERENCE.md
@@ -19,7 +19,7 @@ profile: default          # optional, default: "default" — maps to ~/.drt/prof
 
 ```yaml
 default:
-  type: bigquery            # "bigquery" | "duckdb" | "sqlite" | "postgres" | "redshift" | "clickhouse" | "snowflake" | "mysql"
+  type: bigquery            # "bigquery" | "duckdb" | "sqlite" | "postgres" | "redshift" | "clickhouse" | "snowflake" | "mysql" | "databricks"
   project: my-gcp-project   # BigQuery: GCP project ID
   dataset: analytics        # BigQuery: dataset name
   location: US              # optional: "US" (default), "EU", "asia-northeast1", etc.

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -61,6 +61,7 @@ my-project/
 | ClickHouse | `drt-core[clickhouse]` | HTTP interface via `clickhouse-connect`. Supports host, port, database, user, password_env. |
 | Snowflake | `drt-core[snowflake]` | Supports account, user, password_env, database, schema, warehouse, role |
 | MySQL | `drt-core[mysql]` | Uses pymysql. Supports host, port, dbname, user, password_env |
+| Databricks | `drt-core[databricks]` | SQL Warehouse via databricks-sql-connector. Supports Unity Catalog, access_token_env |
 
 Source is configured in `~/.drt/profiles.yml` (dbt-style):
 

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from drt.config.credentials import (
         BigQueryProfile,
         ClickHouseProfile,
+        DatabricksProfile,
         DuckDBProfile,
         MySQLProfile,
         PostgresProfile,
@@ -39,6 +40,7 @@ if TYPE_CHECKING:
     from drt.destinations.teams import TeamsDestination
     from drt.sources.bigquery import BigQuerySource
     from drt.sources.clickhouse import ClickHouseSource
+    from drt.sources.databricks import DatabricksSource
     from drt.sources.duckdb import DuckDBSource
     from drt.sources.mysql import MySQLSource
     from drt.sources.postgres import PostgresSource
@@ -594,6 +596,7 @@ def _get_source(
         | ClickHouseProfile
         | MySQLProfile
         | SnowflakeProfile
+        | DatabricksProfile
     ),
 ) -> (
     BigQuerySource
@@ -604,10 +607,12 @@ def _get_source(
     | ClickHouseSource
     | MySQLSource
     | SnowflakeSource
+    | DatabricksSource
 ):
     from drt.config.credentials import (
         BigQueryProfile,
         ClickHouseProfile,
+        DatabricksProfile,
         DuckDBProfile,
         MySQLProfile,
         PostgresProfile,
@@ -643,6 +648,10 @@ def _get_source(
         from drt.sources.snowflake import SnowflakeSource
 
         return SnowflakeSource()
+    if isinstance(profile, DatabricksProfile):
+        from drt.sources.databricks import DatabricksSource
+
+        return DatabricksSource()
     raise ValueError(f"Unsupported source type: {type(profile)}")
 
 

--- a/drt/config/credentials.py
+++ b/drt/config/credentials.py
@@ -171,6 +171,23 @@ class SnowflakeProfile:
         return f"{self.type} ({self.account}/{self.database}.{self.schema})"
 
 
+@dataclass
+class DatabricksProfile:
+    """Databricks SQL Warehouse profile using databricks-sql-connector."""
+
+    type: Literal["databricks"]
+    server_hostname: str = ""  # e.g. "dbc-abc.cloud.databricks.com"
+    http_path: str = ""  # e.g. "/sql/1.0/warehouses/xxxxxx"
+    access_token_env: str | None = None
+    access_token: str | None = None
+    catalog: str | None = None  # Unity Catalog (optional)
+    schema: str = "default"
+
+    def describe(self) -> str:
+        path = f"{self.catalog}.{self.schema}" if self.catalog else self.schema
+        return f"{self.type} ({self.server_hostname}/{path})"
+
+
 # Union type — used throughout the codebase
 ProfileConfig = (
     BigQueryProfile
@@ -181,6 +198,7 @@ ProfileConfig = (
     | ClickHouseProfile
     | MySQLProfile
     | SnowflakeProfile
+    | DatabricksProfile
 )
 
 
@@ -365,9 +383,27 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             role=raw.get("role"),
         )
 
+    if source_type == "databricks":
+        _host = raw.get("server_hostname", "")
+        _path = raw.get("http_path", "")
+        if not _host or not _path:
+            raise ValueError(
+                "Databricks profile requires 'server_hostname' and 'http_path'."
+            )
+        return DatabricksProfile(
+            type="databricks",
+            server_hostname=_host,
+            http_path=_path,
+            access_token_env=raw.get("access_token_env"),
+            access_token=raw.get("access_token"),
+            catalog=raw.get("catalog"),
+            schema=raw.get("schema") or "default",
+        )
+
     raise ValueError(
         f"Unsupported source type '{source_type}'. "
-        "Supported: bigquery, duckdb, sqlite, postgres, redshift, clickhouse, mysql, snowflake"
+        "Supported: bigquery, duckdb, sqlite, postgres, redshift, clickhouse, "
+        "mysql, snowflake, databricks"
     )
 
 
@@ -453,6 +489,17 @@ def save_profile(
             entry["password_env"] = profile.password_env
         if profile.role:
             entry["role"] = profile.role
+    elif isinstance(profile, DatabricksProfile):
+        entry = {
+            "type": "databricks",
+            "server_hostname": profile.server_hostname,
+            "http_path": profile.http_path,
+            "schema": profile.schema,
+        }
+        if profile.access_token_env:
+            entry["access_token_env"] = profile.access_token_env
+        if profile.catalog:
+            entry["catalog"] = profile.catalog
     else:
         raise ValueError(f"Unknown profile type: {type(profile)}")
 

--- a/drt/engine/resolver.py
+++ b/drt/engine/resolver.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from drt.config.credentials import (
     BigQueryProfile,
+    DatabricksProfile,
     DuckDBProfile,
     MySQLProfile,
     PostgresProfile,
@@ -88,6 +89,12 @@ def resolve_model_ref(
                 base_sql = f'SELECT * FROM "{profile.database}"."{profile.schema}"."{table_name}"'
             else:
                 base_sql = f'SELECT * FROM "{table_name}"'
+        elif isinstance(profile, DatabricksProfile):
+            # Unity Catalog: catalog.schema.table, else schema.table
+            if profile.catalog:
+                base_sql = f"SELECT * FROM {profile.catalog}.{profile.schema}.{table_name}"
+            else:
+                base_sql = f"SELECT * FROM {profile.schema}.{table_name}"
         else:
             base_sql = f"SELECT * FROM {table_name}"
     else:

--- a/drt/sources/databricks.py
+++ b/drt/sources/databricks.py
@@ -1,0 +1,83 @@
+"""Databricks SQL Warehouse source.
+
+Requires: pip install drt-core[databricks]
+
+Example ~/.drt/profiles.yml:
+    databricks_prod:
+      type: databricks
+      server_hostname: dbc-abc123.cloud.databricks.com
+      http_path: /sql/1.0/warehouses/abc123xyz
+      access_token_env: DATABRICKS_TOKEN
+      catalog: main           # optional (Unity Catalog)
+      schema: analytics
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from drt.config.credentials import DatabricksProfile, ProfileConfig, resolve_env
+
+
+class DatabricksSource:
+    """Extract records from a Databricks SQL Warehouse."""
+
+    def extract(self, query: str, config: ProfileConfig) -> Iterator[dict[str, Any]]:
+        assert isinstance(config, DatabricksProfile)
+        conn = self._connect(config)
+        try:
+            cur = conn.cursor()
+            try:
+                cur.execute(query)
+                columns = [desc[0] for desc in cur.description]
+                for row in cur.fetchall():
+                    yield dict(zip(columns, row))
+            finally:
+                cur.close()
+        finally:
+            conn.close()
+
+    def test_connection(self, config: ProfileConfig) -> bool:
+        assert isinstance(config, DatabricksProfile)
+        conn = None
+        try:
+            conn = self._connect(config)
+            cur = conn.cursor()
+            try:
+                cur.execute("SELECT 1")
+                return True
+            finally:
+                cur.close()
+        except Exception:
+            return False
+        finally:
+            if conn:
+                conn.close()
+
+    def _connect(self, config: DatabricksProfile) -> Any:
+        token = resolve_env(config.access_token, config.access_token_env) or ""
+        if not token:
+            raise ValueError(
+                "Databricks profile: provide 'access_token' or set "
+                "the env var named in 'access_token_env'."
+            )
+
+        try:
+            from databricks import sql
+        except ImportError as e:
+            raise ImportError(
+                "Databricks support requires: pip install drt-core[databricks]"
+            ) from e
+
+        connect_args: dict[str, Any] = {
+            "server_hostname": config.server_hostname,
+            "http_path": config.http_path,
+            "access_token": token,
+        }
+        if config.catalog:
+            connect_args["catalog"] = config.catalog
+        if config.schema:
+            connect_args["schema"] = config.schema
+
+        return sql.connect(**connect_args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ postgres = ["psycopg2-binary>=2.9"]
 redshift = ["psycopg2-binary>=2.9"]  # Redshift uses PostgreSQL wire protocol
 clickhouse = ["clickhouse-connect>=0.7.0"]
 snowflake = ["snowflake-connector-python>=3.0"]
+databricks = ["databricks-sql-connector>=3.0"]
 sheets = ["google-api-python-client>=2.0", "google-auth>=2.0"]
 mysql = ["pymysql>=1.1"]
 parquet = ["pandas>=2.0", "pyarrow>=12.0"]

--- a/tests/unit/test_databricks_source.py
+++ b/tests/unit/test_databricks_source.py
@@ -1,0 +1,66 @@
+"""Tests for Databricks SQL Warehouse source."""
+
+from __future__ import annotations
+
+import pytest
+
+from drt.config.credentials import DatabricksProfile
+from drt.sources.base import Source
+from drt.sources.databricks import DatabricksSource
+
+
+def _profile(**overrides: object) -> DatabricksProfile:
+    defaults: dict = {
+        "type": "databricks",
+        "server_hostname": "dbc-xxx.cloud.databricks.com",
+        "http_path": "/sql/1.0/warehouses/abc",
+        "access_token_env": "DATABRICKS_TOKEN",
+        "schema": "default",
+    }
+    return DatabricksProfile(**{**defaults, **overrides})
+
+
+def test_implements_source_protocol() -> None:
+    assert isinstance(DatabricksSource(), Source)
+
+
+def test_profile_describe_without_catalog() -> None:
+    p = _profile()
+    assert "default" in p.describe()
+    assert p.describe().startswith("databricks")
+
+
+def test_profile_describe_with_catalog() -> None:
+    p = _profile(catalog="main", schema="analytics")
+    assert "main.analytics" in p.describe()
+
+
+def test_missing_token_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+    src = DatabricksSource()
+    with pytest.raises(ValueError, match="access_token"):
+        # Force connection attempt by iterating (connection is lazy)
+        # We need to actually call _connect to hit the token check
+        src._connect(_profile())
+
+
+def test_connection_import_error_handled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Confirm ImportError propagates when databricks-sql is not installed."""
+    import sys
+
+    # Simulate missing databricks module
+    monkeypatch.setitem(sys.modules, "databricks", None)
+    src = DatabricksSource()
+    # _connect should raise ImportError when it tries to import
+    # Note: this only hits if databricks-sql-connector isn't installed
+    # Skip if it IS installed
+    try:
+        from databricks import sql  # noqa: F401
+
+        pytest.skip("databricks-sql-connector is installed locally")
+    except ImportError:
+        monkeypatch.setenv("DATABRICKS_TOKEN", "fake-token")
+        with pytest.raises(ImportError, match="drt-core\\[databricks\\]"):
+            src._connect(_profile())

--- a/tests/unit/test_source_contract.py
+++ b/tests/unit/test_source_contract.py
@@ -9,6 +9,7 @@ import pytest
 from drt.sources.base import Source
 from drt.sources.bigquery import BigQuerySource
 from drt.sources.clickhouse import ClickHouseSource
+from drt.sources.databricks import DatabricksSource
 from drt.sources.duckdb import DuckDBSource
 from drt.sources.mysql import MySQLSource
 from drt.sources.postgres import PostgresSource
@@ -19,6 +20,7 @@ from drt.sources.sqlite import SQLiteSource
 ALL_SOURCES = [
     BigQuerySource,
     ClickHouseSource,
+    DatabricksSource,
     DuckDBSource,
     MySQLSource,
     PostgresSource,


### PR DESCRIPTION
## Summary

Add Databricks source connector using \`databricks-sql-connector\`. Natural fit for dbt-supported warehouses.

\`\`\`yaml
# ~/.drt/profiles.yml
databricks_prod:
  type: databricks
  server_hostname: dbc-abc123.cloud.databricks.com
  http_path: /sql/1.0/warehouses/abc123xyz
  access_token_env: DATABRICKS_TOKEN
  catalog: main           # optional (Unity Catalog)
  schema: analytics
\`\`\`

### Features
- Unity Catalog support (\`catalog.schema.table\` in \`ref()\`)
- Access token auth via env var
- Token check before lazy import (fails fast without misleading ImportError)
- Follows existing SQL source pattern (Snowflake-style)

Closes #88.

## Files changed
- \`drt/sources/databricks.py\` — new
- \`drt/config/credentials.py\` — DatabricksProfile + load/save
- \`drt/engine/resolver.py\` — ref() → catalog.schema.table
- \`drt/cli/main.py\` — _get_source dispatch
- \`pyproject.toml\` — \`databricks = [\"databricks-sql-connector>=3.0\"]\` extra
- \`tests/unit/test_databricks_source.py\` — 5 tests
- \`tests/unit/test_source_contract.py\` — protocol conformance

## Test plan
- [x] 5 new tests + contract test
- [x] 420 total tests passing
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)