### PR TITLE
feat: add SQL Server source connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **SQL Server source connector** (#91): Extract data from Microsoft SQL Server using pure-Python `pymssql`. Supports host, port, database, user, password_env, schema. Install: `pip install drt-core[sqlserver]`.
 - **Databricks source connector** (#88): Extract data from Databricks SQL Warehouse using `databricks-sql-connector`. Supports Unity Catalog, access token auth. Install: `pip install drt-core[databricks]`.
 - **Prefect integration** (#213): Built-in `run_drt_sync()` helper and `drt_sync_task` for Prefect 2.x/3.x. No extra package needed — included in drt-core. Shares the runner with Airflow integration via `drt.integrations._runner`.
 - **Airflow integration** (#70): Built-in `run_drt_sync()` helper and `DrtRunOperator` for Apache Airflow. No extra package needed — included in drt-core.

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 | ClickHouse | ✅ v0.4.3 | `pip install drt-core[clickhouse]` | Password (env var) |
 | MySQL | ✅ v0.5 | `pip install drt-core[mysql]` | Password (env var) |
 | Databricks | ✅ v0.6 | `pip install drt-core[databricks]` | Access Token (env var) |
+| SQL Server | ✅ v0.6 | `pip install drt-core[sqlserver]` | Password (env var) |
 
 ### Destinations
 

--- a/docs/llm/API_REFERENCE.md
+++ b/docs/llm/API_REFERENCE.md
@@ -19,7 +19,7 @@ profile: default          # optional, default: "default" — maps to ~/.drt/prof
 
 ```yaml
 default:
-  type: bigquery            # "bigquery" | "duckdb" | "sqlite" | "postgres" | "redshift" | "clickhouse" | "snowflake" | "mysql" | "databricks"
+  type: bigquery            # "bigquery" | "duckdb" | "sqlite" | "postgres" | "redshift" | "clickhouse" | "snowflake" | "mysql" | "databricks" | "sqlserver"
   project: my-gcp-project   # BigQuery: GCP project ID
   dataset: analytics        # BigQuery: dataset name
   location: US              # optional: "US" (default), "EU", "asia-northeast1", etc.

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -62,6 +62,7 @@ my-project/
 | Snowflake | `drt-core[snowflake]` | Supports account, user, password_env, database, schema, warehouse, role |
 | MySQL | `drt-core[mysql]` | Uses pymysql. Supports host, port, dbname, user, password_env |
 | Databricks | `drt-core[databricks]` | SQL Warehouse via databricks-sql-connector. Supports Unity Catalog, access_token_env |
+| SQL Server | `drt-core[sqlserver]` | Microsoft SQL Server via pure-Python pymssql. Supports host, port, database, user, password_env |
 
 Source is configured in `~/.drt/profiles.yml` (dbt-style):
 

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
         RedshiftProfile,
         SnowflakeProfile,
         SQLiteProfile,
+        SQLServerProfile,
     )
     from drt.config.models import SyncConfig
     from drt.destinations.clickhouse import ClickHouseDestination
@@ -47,6 +48,7 @@ if TYPE_CHECKING:
     from drt.sources.redshift import RedshiftSource
     from drt.sources.snowflake import SnowflakeSource
     from drt.sources.sqlite import SQLiteSource
+    from drt.sources.sqlserver import SQLServerSource
 
 from drt import __version__
 from drt.cli.output import (
@@ -597,6 +599,7 @@ def _get_source(
         | MySQLProfile
         | SnowflakeProfile
         | DatabricksProfile
+        | SQLServerProfile
     ),
 ) -> (
     BigQuerySource
@@ -608,6 +611,7 @@ def _get_source(
     | MySQLSource
     | SnowflakeSource
     | DatabricksSource
+    | SQLServerSource
 ):
     from drt.config.credentials import (
         BigQueryProfile,
@@ -619,6 +623,7 @@ def _get_source(
         RedshiftProfile,
         SnowflakeProfile,
         SQLiteProfile,
+        SQLServerProfile,
     )
     from drt.sources.bigquery import BigQuerySource
     from drt.sources.duckdb import DuckDBSource
@@ -652,6 +657,10 @@ def _get_source(
         from drt.sources.databricks import DatabricksSource
 
         return DatabricksSource()
+    if isinstance(profile, SQLServerProfile):
+        from drt.sources.sqlserver import SQLServerSource
+
+        return SQLServerSource()
     raise ValueError(f"Unsupported source type: {type(profile)}")
 
 

--- a/drt/config/credentials.py
+++ b/drt/config/credentials.py
@@ -172,6 +172,23 @@ class SnowflakeProfile:
 
 
 @dataclass
+class SQLServerProfile:
+    """SQL Server profile using pymssql."""
+
+    type: Literal["sqlserver"]
+    host: str = ""
+    port: int = 1433
+    database: str = ""
+    user: str = ""
+    password_env: str | None = None
+    password: str | None = None
+    schema: str = "dbo"
+
+    def describe(self) -> str:
+        return f"{self.type} ({self.host}/{self.database}.{self.schema})"
+
+
+@dataclass
 class DatabricksProfile:
     """Databricks SQL Warehouse profile using databricks-sql-connector."""
 
@@ -199,6 +216,7 @@ ProfileConfig = (
     | MySQLProfile
     | SnowflakeProfile
     | DatabricksProfile
+    | SQLServerProfile
 )
 
 
@@ -383,6 +401,23 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             role=raw.get("role"),
         )
 
+    if source_type == "sqlserver":
+        _db = raw.get("database", "")
+        if not _db:
+            raise ValueError(
+                "SQL Server profile requires 'database'."
+            )
+        return SQLServerProfile(
+            type="sqlserver",
+            host=raw.get("host", ""),
+            port=int(raw.get("port", 1433)),
+            database=_db,
+            user=raw.get("user", ""),
+            password_env=raw.get("password_env"),
+            password=raw.get("password"),
+            schema=raw.get("schema") or "dbo",
+        )
+
     if source_type == "databricks":
         _host = raw.get("server_hostname", "")
         _path = raw.get("http_path", "")
@@ -403,7 +438,7 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
     raise ValueError(
         f"Unsupported source type '{source_type}'. "
         "Supported: bigquery, duckdb, sqlite, postgres, redshift, clickhouse, "
-        "mysql, snowflake, databricks"
+        "mysql, snowflake, databricks, sqlserver"
     )
 
 
@@ -489,6 +524,17 @@ def save_profile(
             entry["password_env"] = profile.password_env
         if profile.role:
             entry["role"] = profile.role
+    elif isinstance(profile, SQLServerProfile):
+        entry = {
+            "type": "sqlserver",
+            "host": profile.host,
+            "port": profile.port,
+            "database": profile.database,
+            "user": profile.user,
+            "schema": profile.schema,
+        }
+        if profile.password_env:
+            entry["password_env"] = profile.password_env
     elif isinstance(profile, DatabricksProfile):
         entry = {
             "type": "databricks",

--- a/drt/engine/resolver.py
+++ b/drt/engine/resolver.py
@@ -22,6 +22,7 @@ from drt.config.credentials import (
     PostgresProfile,
     ProfileConfig,
     SnowflakeProfile,
+    SQLServerProfile,
 )
 
 # Matches: ref('table') or ref("table")
@@ -95,6 +96,8 @@ def resolve_model_ref(
                 base_sql = f"SELECT * FROM {profile.catalog}.{profile.schema}.{table_name}"
             else:
                 base_sql = f"SELECT * FROM {profile.schema}.{table_name}"
+        elif isinstance(profile, SQLServerProfile):
+            base_sql = f"SELECT * FROM [{profile.schema}].[{table_name}]"
         else:
             base_sql = f"SELECT * FROM {table_name}"
     else:

--- a/drt/sources/sqlserver.py
+++ b/drt/sources/sqlserver.py
@@ -1,0 +1,74 @@
+"""SQL Server source using pymssql.
+
+Requires: pip install drt-core[sqlserver]
+
+Example ~/.drt/profiles.yml:
+    sqlserver_prod:
+      type: sqlserver
+      host: db.example.com
+      port: 1433
+      database: analytics
+      user: drt_reader
+      password_env: SQLSERVER_PASSWORD
+      schema: dbo
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from drt.config.credentials import ProfileConfig, SQLServerProfile, resolve_env
+
+
+class SQLServerSource:
+    """Extract records from a SQL Server database."""
+
+    def extract(self, query: str, config: ProfileConfig) -> Iterator[dict[str, Any]]:
+        assert isinstance(config, SQLServerProfile)
+        conn = self._connect(config)
+        try:
+            cur = conn.cursor(as_dict=True)
+            try:
+                cur.execute(query)
+                for row in cur.fetchall():
+                    yield dict(row)
+            finally:
+                cur.close()
+        finally:
+            conn.close()
+
+    def test_connection(self, config: ProfileConfig) -> bool:
+        assert isinstance(config, SQLServerProfile)
+        conn = None
+        try:
+            conn = self._connect(config)
+            cur = conn.cursor()
+            try:
+                cur.execute("SELECT 1")
+                return True
+            finally:
+                cur.close()
+        except Exception:
+            return False
+        finally:
+            if conn:
+                conn.close()
+
+    def _connect(self, config: SQLServerProfile) -> Any:
+        password = resolve_env(config.password, config.password_env) or ""
+
+        try:
+            import pymssql
+        except ImportError as e:
+            raise ImportError(
+                "SQL Server support requires: pip install drt-core[sqlserver]"
+            ) from e
+
+        return pymssql.connect(
+            server=config.host,
+            port=config.port,
+            user=config.user,
+            password=password,
+            database=config.database,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ redshift = ["psycopg2-binary>=2.9"]  # Redshift uses PostgreSQL wire protocol
 clickhouse = ["clickhouse-connect>=0.7.0"]
 snowflake = ["snowflake-connector-python>=3.0"]
 databricks = ["databricks-sql-connector>=3.0"]
+sqlserver = ["pymssql>=2.3"]
 sheets = ["google-api-python-client>=2.0", "google-auth>=2.0"]
 mysql = ["pymysql>=1.1"]
 parquet = ["pandas>=2.0", "pyarrow>=12.0"]

--- a/tests/unit/test_source_contract.py
+++ b/tests/unit/test_source_contract.py
@@ -16,6 +16,7 @@ from drt.sources.postgres import PostgresSource
 from drt.sources.redshift import RedshiftSource
 from drt.sources.snowflake import SnowflakeSource
 from drt.sources.sqlite import SQLiteSource
+from drt.sources.sqlserver import SQLServerSource
 
 ALL_SOURCES = [
     BigQuerySource,
@@ -27,6 +28,7 @@ ALL_SOURCES = [
     RedshiftSource,
     SnowflakeSource,
     SQLiteSource,
+    SQLServerSource,
 ]
 
 

--- a/tests/unit/test_sqlserver_source.py
+++ b/tests/unit/test_sqlserver_source.py
@@ -1,0 +1,67 @@
+"""Tests for SQL Server source."""
+
+from __future__ import annotations
+
+import pytest
+
+from drt.config.credentials import SQLServerProfile
+from drt.sources.base import Source
+from drt.sources.sqlserver import SQLServerSource
+
+
+def _profile(**overrides: object) -> SQLServerProfile:
+    defaults: dict = {
+        "type": "sqlserver",
+        "host": "db.example.com",
+        "port": 1433,
+        "database": "analytics",
+        "user": "drt_reader",
+        "password_env": "SQLSERVER_PASSWORD",
+        "schema": "dbo",
+    }
+    return SQLServerProfile(**{**defaults, **overrides})
+
+
+def test_implements_source_protocol() -> None:
+    assert isinstance(SQLServerSource(), Source)
+
+
+def test_profile_describe() -> None:
+    p = _profile()
+    d = p.describe()
+    assert d.startswith("sqlserver")
+    assert "db.example.com" in d
+    assert "analytics.dbo" in d
+
+
+def test_profile_custom_schema() -> None:
+    p = _profile(schema="sales")
+    assert "analytics.sales" in p.describe()
+
+
+def test_connection_import_error_handled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ImportError propagates when pymssql is not installed."""
+    import sys
+
+    try:
+        import pymssql  # noqa: F401
+
+        pytest.skip("pymssql is installed locally")
+    except ImportError:
+        monkeypatch.setitem(sys.modules, "pymssql", None)
+        src = SQLServerSource()
+        monkeypatch.setenv("SQLSERVER_PASSWORD", "fake")
+        with pytest.raises(ImportError, match="drt-core\\[sqlserver\\]"):
+            src._connect(_profile())
+
+
+def test_resolver_ref_sqlserver(tmp_path: object) -> None:
+    """ref() generates [schema].[table] for SQL Server."""
+    from pathlib import Path
+
+    from drt.engine.resolver import resolve_model_ref
+
+    sql = resolve_model_ref("ref('users')", Path(tmp_path), _profile())
+    assert sql == "SELECT * FROM [dbo].[users]"


### PR DESCRIPTION
## Summary

Add Microsoft SQL Server source connector using pure-Python \`pymssql\` (no ODBC driver required — easier for OSS users).

\`\`\`yaml
# ~/.drt/profiles.yml
sqlserver_prod:
  type: sqlserver
  host: db.example.com
  port: 1433
  database: analytics
  user: drt_reader
  password_env: SQLSERVER_PASSWORD
  schema: dbo
\`\`\`

### Features
- Pure Python \`pymssql\` (vs \`pyodbc\` which needs system driver)
- \`ref('users')\` → \`SELECT * FROM [dbo].[users]\` (T-SQL quoting)
- Follows existing SQL source pattern

Closes #91.

## Files changed
- \`drt/sources/sqlserver.py\` — new
- \`drt/config/credentials.py\` — SQLServerProfile + load/save
- \`drt/engine/resolver.py\` — ref() → [schema].[table]
- \`drt/cli/main.py\` — _get_source dispatch
- \`pyproject.toml\` — \`sqlserver = [\"pymssql>=2.3\"]\` extra
- \`tests/unit/test_sqlserver_source.py\` — 5 tests
- \`tests/unit/test_source_contract.py\` — protocol conformance

## Test plan
- [x] 5 new tests + contract test
- [x] 428 total tests passing
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)