### PR TITLE
feat: add Notion destination

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.slack import SlackDestination
     from drt.destinations.teams import TeamsDestination
+    from drt.destinations.notion import NotionDestination
     from drt.sources.bigquery import BigQuerySource
     from drt.sources.clickhouse import ClickHouseSource
     from drt.sources.duckdb import DuckDBSource
@@ -665,6 +666,7 @@ def _get_destination(
     | FileDestination
     | LinearDestination
     | GoogleAdsDestination
+    | NotionDestination
 ):
     from drt.config.models import (
         ClickHouseDestinationConfig,
@@ -695,6 +697,7 @@ def _get_destination(
     from drt.destinations.rest_api import RestApiDestination
     from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.slack import SlackDestination
+    from drt.destinations.notion import NotionDestination
 
     dest = sync.destination
     if isinstance(dest, RestApiDestinationConfig):
@@ -707,6 +710,8 @@ def _get_destination(
         return GitHubActionsDestination()
     if isinstance(dest, HubSpotDestinationConfig):
         return HubSpotDestination()
+    if isinstance(dest, NotionDestinationConfig):
+        return NotionDestination()
     if isinstance(dest, JiraDestinationConfig):
         return JiraDestination()
     if isinstance(dest, SendGridDestinationConfig):

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -154,6 +154,28 @@ class HubSpotDestinationConfig(BaseModel):
         return f"{self.type} ({self.object_type})"
 
 
+class NotionDestinationConfig(BaseModel):
+    type: Literal["notion"]
+
+    database_id: str | None = None
+    database_id_env: str | None = None
+
+    properties_template: str | None = None
+
+    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
+
+    def describe(self) -> str:
+        return "notion (database)"
+
+    @model_validator(mode="after")
+    def _check_database(self) -> "NotionDestinationConfig":
+        if not self.database_id and not self.database_id_env:
+            raise ValueError(
+                "Either database_id or database_id_env is required."
+            )
+        return self
+    
+    
 class SendGridDestinationConfig(BaseModel):
     type: Literal["sendgrid"]
     from_email: str
@@ -363,7 +385,8 @@ DestinationConfig = Annotated[
     | ClickHouseDestinationConfig
     | ParquetDestinationConfig
     | GoogleAdsDestinationConfig
-    | FileDestinationConfig,
+    | FileDestinationConfig
+    | NotionDestinationConfig,
     Field(discriminator="type"),
 ]
 

--- a/drt/destinations/notion.py
+++ b/drt/destinations/notion.py
@@ -1,0 +1,164 @@
+"""Notion destination — append rows to a Notion database.
+
+Creates pages in a Notion database using the Notion API.
+
+Requires: NOTION_TOKEN (integration token with write access).
+
+Example sync YAML:
+
+    destination:
+      type: notion
+      database_id_env: NOTION_DATABASE_ID
+      properties_template: |
+        {
+          "Name": {"title": [{"text": {"content": "{{ row.name }}"}}]},
+          "Email": {"email": "{{ row.email }}"},
+          "Revenue": {"number": {{ row.revenue }}},
+          "Status": {"select": {"name": "{{ row.status }}"}}
+        }
+      auth:
+        type: bearer
+        token_env: NOTION_TOKEN
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+from drt.config.credentials import resolve_env
+from drt.config.models import (
+    NotionDestinationConfig,
+    RetryConfig,
+    SyncOptions,
+)
+from drt.destinations.base import SyncResult
+from drt.destinations.rate_limiter import RateLimiter
+from drt.destinations.retry import with_retry
+from drt.destinations.row_errors import RowError
+from drt.templates.renderer import render_template
+
+
+_NOTION_API = "https://api.notion.com/v1/pages"
+_NOTION_VERSION = "2022-06-28"
+
+_DEFAULT_RETRY = RetryConfig(
+    max_attempts=3,
+    initial_backoff=1.0,
+    retryable_status_codes=(429, 500, 502, 503, 504),
+)
+
+
+class NotionDestination:
+    """Append records into a Notion database via the Pages API."""
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, NotionDestinationConfig)
+
+        token = resolve_env(config.auth.token, config.auth.token_env)
+        if not token:
+            raise ValueError(
+                "Notion destination: set NOTION_TOKEN env var "
+                "or provide auth.token_env in the sync config."
+            )
+
+        database_id = resolve_env(
+            config.database_id, config.database_id_env
+        )
+        if not database_id:
+            raise ValueError(
+                "Notion destination: set NOTION_DATABASE_ID env var "
+                "or provide database_id/database_id_env in config."
+            )
+
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Notion-Version": _NOTION_VERSION,
+            "Content-Type": "application/json",
+        }
+
+        create_url = _NOTION_API
+        result = SyncResult()
+
+        # Notion rate limit: ~3 req/sec per integration
+        rate_limiter = RateLimiter(
+            min(sync_options.rate_limit.requests_per_second, 3)
+        )
+
+        with httpx.Client(timeout=30.0) as client:
+            for i, record in enumerate(records):
+                rate_limiter.acquire()
+
+                # Build properties dict (same pattern as HubSpot)
+                if config.properties_template:
+                    try:
+                        rendered = render_template(
+                            config.properties_template, record
+                        )
+                        properties = json.loads(rendered)
+                    except (ValueError, json.JSONDecodeError) as e:
+                        result.failed += 1
+                        result.row_errors.append(
+                            RowError(
+                                batch_index=i,
+                                record_preview=json.dumps(record)[:200],
+                                http_status=None,
+                                error_message=f"properties_template error: {e}",
+                            )
+                        )
+                        continue
+                else:
+                    properties = record
+
+                payload = {
+                    "parent": {"database_id": database_id},
+                    "properties": properties,
+                }
+
+                def do_create(
+                    _url: str = create_url,
+                    _headers: dict[str, Any] = headers,
+                    _payload: dict[str, Any] = payload,
+                ) -> httpx.Response:
+                    response = client.post(
+                        _url,
+                        json=_payload,
+                        headers=_headers,
+                    )
+                    response.raise_for_status()
+                    return response
+
+                try:
+                    with_retry(do_create, _DEFAULT_RETRY)
+                    result.success += 1
+
+                except httpx.HTTPStatusError as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=e.response.status_code,
+                            error_message=e.response.text[:500],
+                        )
+                    )
+
+                except Exception as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=None,
+                            error_message=str(e),
+                        )
+                    )
+
+        return result

--- a/tests/unit/test_notion.py
+++ b/tests/unit/test_notion.py
@@ -1,0 +1,115 @@
+import json
+import pytest
+import httpx
+from unittest.mock import patch, MagicMock
+
+from drt.destinations.notion import NotionDestination
+from drt.config.models import (
+    NotionDestinationConfig,
+    SyncOptions,
+    RetryConfig,
+    RateLimitConfig,
+    BearerAuth,
+)
+
+
+@pytest.fixture
+def config():
+    return NotionDestinationConfig(
+        type="notion",
+        database_id="db123",
+        properties_template='{"Name": {"title": [{"text": {"content": "{{ row.name }}"}}]}}',
+        auth=BearerAuth(type="bearer", token="test-token"),
+    )
+
+
+@pytest.fixture
+def sync_options():
+    return SyncOptions(
+        retry=RetryConfig(max_attempts=2),
+        rate_limit=RateLimitConfig(requests_per_second=100),
+    )
+
+
+def make_response(status=200):
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status
+    response.text = "error"
+    response.raise_for_status.side_effect = (
+        None if status < 400 else httpx.HTTPStatusError("err", request=None, response=response)
+    )
+    return response
+
+
+# ---------------------------------------------------------
+# Tests
+# ---------------------------------------------------------
+
+
+@patch("httpx.Client.post")
+def test_successful_insert(mock_post, config, sync_options):
+    mock_post.return_value = make_response(200)
+
+    dest = NotionDestination()
+    result = dest.load([{"name": "Alice"}], config, sync_options)
+
+    assert result.success == 1
+    assert result.failed == 0
+
+
+@patch("httpx.Client.post")
+def test_retry_then_success(mock_post, config, sync_options):
+    mock_post.side_effect = [
+        make_response(500),
+        make_response(200),
+    ]
+
+    dest = NotionDestination()
+    result = dest.load([{"name": "Retry"}], config, sync_options)
+
+    assert result.success == 1
+    assert mock_post.call_count >= 2
+
+
+@patch("httpx.Client.post")
+def test_max_retries_failure(mock_post, config, sync_options):
+    mock_post.return_value = make_response(500)
+
+    dest = NotionDestination()
+    result = dest.load([{"name": "Fail"}], config, sync_options)
+
+    assert result.failed == 1
+    assert result.success == 0
+
+
+def test_invalid_template(config, sync_options):
+    config.properties_template = "{ invalid json }"
+
+    dest = NotionDestination()
+    result = dest.load([{"name": "Bad"}], config, sync_options)
+
+    assert result.failed == 1
+    assert "properties_template error" in result.row_errors[0].error_message
+
+
+def test_missing_token(sync_options):
+    config = NotionDestinationConfig(
+        type="notion",
+        database_id="db123",
+        properties_template="{}",
+        auth=BearerAuth(type="bearer"),
+    )
+
+    dest = NotionDestination()
+
+    with pytest.raises(ValueError):
+        dest.load([{}], config, sync_options)
+
+
+def test_missing_database_id(sync_options):
+    with pytest.raises(ValueError):
+        NotionDestinationConfig(
+            type="notion",
+            properties_template="{}",
+            auth=BearerAuth(type="bearer", token="x"),
+        )


### PR DESCRIPTION
## What does this PR do?

1. Add NotionDestinationConfig to drt/config/models.py
2. Create drt/destinations/notion.py and implement with retry and rate limiting
3. Register in DestinationConfig union and _get_destination() in CLI
4. At least 5 unit tests

## Related Issue

Closes #38

## Checklist

- [ ] Tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Updated `CHANGELOG.md` (if user-facing change)
