### PR TITLE
feat: add Notion destination (Issue #38)

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from drt.destinations.jira import JiraDestination
     from drt.destinations.linear import LinearDestination
     from drt.destinations.mysql import MySQLDestination
+    from drt.destinations.notion import NotionDestination
     from drt.destinations.parquet import ParquetDestination
     from drt.destinations.postgres import PostgresDestination
     from drt.destinations.rest_api import RestApiDestination
@@ -339,9 +340,7 @@ def run(
 
 @app.command(name="list")
 def list_syncs(
-    output: str = typer.Option(
-        "text", "--output", "-o", help="Output format: text or json."
-    ),
+    output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
 ) -> None:
     """List all sync definitions in the project."""
     import json as json_mod
@@ -351,17 +350,22 @@ def list_syncs(
     syncs = load_syncs(Path("."))
 
     if output == "json":
-        print(json_mod.dumps({
-            "syncs": [
+        print(
+            json_mod.dumps(
                 {
-                    "name": s.name,
-                    "destination_type": s.destination.type,
-                    "mode": s.sync.mode,
-                    "description": s.description,
-                }
-                for s in syncs
-            ],
-        }, indent=2))
+                    "syncs": [
+                        {
+                            "name": s.name,
+                            "destination_type": s.destination.type,
+                            "mode": s.sync.mode,
+                            "description": s.description,
+                        }
+                        for s in syncs
+                    ],
+                },
+                indent=2,
+            )
+        )
         return
 
     print_sync_table(syncs)
@@ -377,9 +381,7 @@ def validate(
     emit_schema: bool = typer.Option(  # noqa: E501
         False, "--emit-schema", help="Write JSON Schemas to .drt/schemas/."
     ),
-    output: str = typer.Option(
-        "text", "--output", "-o", help="Output format: text or json."
-    ),
+    output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
 ) -> None:
     """Validate sync definitions against the JSON Schema."""
     import json as json_mod
@@ -390,15 +392,18 @@ def validate(
     result = load_syncs_safe(Path("."))
 
     if output == "json":
-        print(json_mod.dumps({
-            "results": [
-                {"name": s.name, "valid": True}
-                for s in result.syncs
-            ] + [
-                {"name": name, "valid": False, "errors": errs}
-                for name, errs in result.errors.items()
-            ],
-        }, indent=2))
+        print(
+            json_mod.dumps(
+                {
+                    "results": [{"name": s.name, "valid": True} for s in result.syncs]
+                    + [
+                        {"name": name, "valid": False, "errors": errs}
+                        for name, errs in result.errors.items()
+                    ],
+                },
+                indent=2,
+            )
+        )
         if result.errors:
             raise typer.Exit(code=1)
         return
@@ -672,6 +677,7 @@ def _get_destination(
     | DiscordDestination
     | GitHubActionsDestination
     | HubSpotDestination
+    | NotionDestination
     | JiraDestination
     | SendGridDestination
     | GoogleSheetsDestination
@@ -695,6 +701,7 @@ def _get_destination(
         JiraDestinationConfig,
         LinearDestinationConfig,
         MySQLDestinationConfig,
+        NotionDestinationConfig,
         ParquetDestinationConfig,
         PostgresDestinationConfig,
         RestApiDestinationConfig,
@@ -709,6 +716,7 @@ def _get_destination(
     from drt.destinations.jira import JiraDestination
     from drt.destinations.linear import LinearDestination
     from drt.destinations.mysql import MySQLDestination
+    from drt.destinations.notion import NotionDestination
     from drt.destinations.postgres import PostgresDestination
     from drt.destinations.rest_api import RestApiDestination
     from drt.destinations.sendgrid import SendGridDestination
@@ -725,6 +733,10 @@ def _get_destination(
         return GitHubActionsDestination()
     if isinstance(dest, HubSpotDestinationConfig):
         return HubSpotDestination()
+    if isinstance(dest, NotionDestinationConfig):
+        from drt.destinations.notion import NotionDestination
+
+        return NotionDestination()
     if isinstance(dest, JiraDestinationConfig):
         return JiraDestination()
     if isinstance(dest, SendGridDestinationConfig):

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -154,6 +154,17 @@ class HubSpotDestinationConfig(BaseModel):
         return f"{self.type} ({self.object_type})"
 
 
+class NotionDestinationConfig(BaseModel):
+    type: Literal["notion"]
+    database_id: str | None = None
+    database_id_env: str | None = None
+    properties_template: str
+    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
+
+    def describe(self) -> str:
+        return f"notion (db:{self.database_id})"
+
+
 class SendGridDestinationConfig(BaseModel):
     type: Literal["sendgrid"]
     from_email: str
@@ -353,6 +364,7 @@ DestinationConfig = Annotated[
     | DiscordDestinationConfig
     | GitHubActionsDestinationConfig
     | HubSpotDestinationConfig
+    | NotionDestinationConfig
     | SendGridDestinationConfig
     | LinearDestinationConfig
     | GoogleSheetsDestinationConfig

--- a/drt/destinations/notion.py
+++ b/drt/destinations/notion.py
@@ -1,0 +1,144 @@
+"""Notion destination — Append rows to a Notion database.
+
+Appends records as new pages in a Notion database.
+Uses the Notion API to create pages with properties populated from a Jinja2 template.
+
+Requires: NOTION_TOKEN (Integration token with read/write access).
+
+Example sync YAML:
+
+    destination:
+      type: notion
+      database_id_env: NOTION_DATABASE_ID
+      properties_template: |
+        {
+          "Name": {"title": [{"text": {"content": "{{ row.name }}"}}]},
+          "Email": {"email": "{{ row.email }}"},
+          "Revenue": {"number": {{ row.revenue }}},
+          "Status": {"select": {"name": "{{ row.status }}"}}
+        }
+      auth:
+        type: bearer
+        token_env: NOTION_TOKEN
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+from drt.config.credentials import resolve_env
+from drt.config.models import DestinationConfig, NotionDestinationConfig, RetryConfig, SyncOptions
+from drt.destinations.base import SyncResult
+from drt.destinations.rate_limiter import RateLimiter
+from drt.destinations.retry import with_retry
+from drt.destinations.row_errors import RowError
+from drt.templates.renderer import render_template
+
+_NOTION_API = "https://api.notion.com/v1/pages"
+_DEFAULT_RETRY = RetryConfig(
+    max_attempts=3,
+    initial_backoff=1.0,
+    retryable_status_codes=(429, 500, 502, 503, 504),
+)
+
+
+class NotionDestination:
+    """Append records as pages to a Notion database."""
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, NotionDestinationConfig)
+
+        database_id = resolve_env(config.database_id, config.database_id_env)
+        if not database_id:
+            raise ValueError(
+                "Notion destination: set database_id or database_id_env in the sync config."
+            )
+
+        token = resolve_env(config.auth.token, config.auth.token_env)
+        if not token:
+            raise ValueError(
+                "Notion destination: set auth.token or auth.token_env in the sync config."
+            )
+
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Notion-Version": "2022-06-28",
+        }
+
+        result = SyncResult()
+        rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
+
+        with httpx.Client(timeout=30.0) as client:
+            for i, record in enumerate(records):
+                rate_limiter.acquire()
+
+                # Build properties dict via Jinja2 template
+                if config.properties_template:
+                    try:
+                        rendered = render_template(config.properties_template, record)
+                        properties = json.loads(rendered)
+                    except (ValueError, json.JSONDecodeError) as e:
+                        result.failed += 1
+                        result.row_errors.append(
+                            RowError(
+                                batch_index=i,
+                                record_preview=json.dumps(record)[:200],
+                                http_status=None,
+                                error_message=f"properties_template error: {e}",
+                            )
+                        )
+                        continue
+                else:
+                    # Fallback: treat row values as properties (requires matching keys)
+                    properties = {
+                        k: {"rich_text": [{"text": {"content": str(v)}}]} for k, v in record.items()
+                    }
+
+                payload = {
+                    "parent": {"database_id": database_id},
+                    "properties": properties,
+                }
+
+                def create_page(
+                    _url: str = _NOTION_API,
+                    _headers: dict[str, Any] = headers,
+                    _payload: dict[str, Any] = payload,
+                ) -> httpx.Response:
+                    response = client.post(_url, json=_payload, headers=_headers)
+                    response.raise_for_status()
+                    return response
+
+                try:
+                    with_retry(create_page, _DEFAULT_RETRY)
+                    result.success += 1
+                except httpx.HTTPStatusError as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=e.response.status_code,
+                            error_message=e.response.text[:500],
+                        )
+                    )
+                except Exception as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=json.dumps(record)[:200],
+                            http_status=None,
+                            error_message=str(e),
+                        )
+                    )
+
+        return result

--- a/tests/unit/test_notion_destination.py
+++ b/tests/unit/test_notion_destination.py
@@ -1,0 +1,109 @@
+"""Unit tests for the Notion destination."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from drt.config.models import BearerAuth, NotionDestinationConfig, RateLimitConfig, SyncOptions
+from drt.destinations.notion import NotionDestination
+
+
+@pytest.fixture
+def config():
+    return NotionDestinationConfig(
+        type="notion",
+        database_id="test_db_123",
+        properties_template='{"Name": {"title": [{"text": {"content": "{{ row.name }}"}}]}}',
+        auth=BearerAuth(type="bearer", token="secret_token"),
+    )
+
+
+@pytest.fixture
+def sync_options():
+    return SyncOptions(rate_limit=RateLimitConfig(requests_per_second=100))
+
+
+@pytest.fixture
+def destination():
+    return NotionDestination()
+
+
+def test_missing_database_id():
+    """Should raise error if no database_id is provided."""
+    with pytest.raises(ValueError, match="database_id"):
+        dest = NotionDestination()
+        dest.load(
+            [{"name": "Alice"}],
+            NotionDestinationConfig(
+                type="notion",
+                properties_template="{}",
+                auth=BearerAuth(type="bearer", token="secret"),
+            ),
+            SyncOptions(),
+        )
+
+
+def test_missing_token():
+    """Should raise error if no auth token is provided."""
+    with pytest.raises(ValueError, match="token"):
+        dest = NotionDestination()
+        dest.load(
+            [{"name": "Alice"}],
+            NotionDestinationConfig(
+                type="notion",
+                database_id="test_db",
+                properties_template="{}",
+                auth=BearerAuth(type="bearer"),
+            ),
+            SyncOptions(),
+        )
+
+
+@patch("drt.destinations.notion.httpx.Client")
+def test_successful_sync(MockClient, config, sync_options, destination):
+    """Should sync records successfully."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    MockClient.return_value.__enter__.return_value.post.return_value = mock_response
+
+    records = [{"name": "Alice"}, {"name": "Bob"}]
+    result = destination.load(records, config, sync_options)
+
+    assert result.success == 2
+    assert result.failed == 0
+    assert MockClient.return_value.__enter__.return_value.post.call_count == 2
+
+
+@patch("drt.destinations.notion.httpx.Client")
+def test_sync_failure(MockClient, config, sync_options, destination):
+    """Should handle HTTP errors gracefully."""
+    error_response = MagicMock()
+    error_response.status_code = 400
+    error_response.text = '{"message": "Invalid property"}'
+    http_error = httpx.HTTPStatusError("Bad Request", request=MagicMock(), response=error_response)
+
+    MockClient.return_value.__enter__.return_value.post.side_effect = http_error
+
+    records = [{"name": "Alice"}]
+    result = destination.load(records, config, sync_options)
+
+    assert result.success == 0
+    assert result.failed == 1
+    assert len(result.row_errors) == 1
+
+
+@patch("drt.destinations.notion.httpx.Client")
+def test_template_rendering_error(MockClient, config, sync_options, destination):
+    """Should handle Jinja2 template errors gracefully."""
+    config_bad_template = config.model_copy()
+    config_bad_template.properties_template = "NOT JSON"
+
+    records = [{"name": "Alice"}]
+    result = destination.load(records, config_bad_template, sync_options)
+
+    assert result.failed == 1
+    assert len(result.row_errors) == 1
+    assert "Expecting" in result.row_errors[0].error_message


### PR DESCRIPTION
## Summary
Implements **Issue #38**: Adds a `notion` destination to append rows to a Notion database.

## Implementation Details
1. **`NotionDestinationConfig`**: Added to `drt/config/models.py` with support for `database_id`, `properties_template` (Jinja2), and `BearerAuth`.
2. **`NotionDestination`**: Implemented in `drt/destinations/notion.py` following the existing destination protocol.
   - Uses Notion API (`POST /v1/pages`) with `Notion-Version: 2022-06-28` header.
   - Handles rate limiting and retries via existing `RateLimiter` and `with_retry` utilities.
   - Provides detailed `RowError` on template or HTTP failures.
3. **Unit Tests**: Added 5 comprehensive tests in `tests/unit/test_notion_destination.py` covering:
   - Missing configuration validation.
   - Successful sync mock.
   - HTTP error handling.
   - Template rendering failures.

## Acceptance Criteria
- [x] `NotionDestinationConfig` added to `config/models.py`
- [x] `drt/destinations/notion.py` implemented with retry + rate limiting
- [x] 5 unit tests added
- [x] `make lint` and `make test` pass locally

## Example Usage
```yaml
destination:
  type: notion
  database_id_env: NOTION_DATABASE_ID
  properties_template: |
    {
      "Name": {"title": [{"text": {"content": "{{ row.name }}"}}]},
      "Email": {"email": "{{ row.email }}"},
      "Revenue": {"number": {{ row.revenue }}}
    }
  auth:
    type: bearer
    token_env: NOTION_TOKEN
```