### PR TITLE
feat: add --log-format json flag to drt run

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -88,9 +88,7 @@ class _JsonFormatter(logging.Formatter):
     """Emit each log record as a single JSON object (JSON Lines format)."""
 
     def format(self, record: logging.LogRecord) -> str:
-        ts = datetime.fromtimestamp(record.created, tz=timezone.utc).strftime(
-            "%Y-%m-%dT%H:%M:%SZ"
-        )
+        ts = datetime.fromtimestamp(record.created, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         payload: dict[str, object] = {
             "ts": ts,
             "level": record.levelname,
@@ -108,7 +106,7 @@ def _configure_json_logging() -> None:
     handler = logging.StreamHandler()
     handler.setFormatter(_JsonFormatter())
     logging.root.handlers = [handler]
-    logging.root.setLevel(logging.DEBUG)
+    logging.root.setLevel(logging.INFO)
 
 
 def _resolve_profile_name(cli_flag: str | None, project_profile: str) -> str:
@@ -258,8 +256,13 @@ def run(
         None, "--profile", "-p", help="Override profile (default: drt_project.yml or DRT_PROFILE)."
     ),
     log_format: str = typer.Option(
-        "text", "--log-format", help="Log format: text or json (structured JSON lines)."
+    "text",
+    "--log-format",
+    help=(
+        "Log format: text or json (structured JSON lines for each sync event"
+        " — separate from --output json which controls the final result)."
     ),
+),
 ) -> None:
     """Run sync(s) defined in the project."""
     import json as json_mod
@@ -345,11 +348,7 @@ def run(
         elapsed = round(time.monotonic() - t0, 2)
         if log_format == "json":
             status_str = (
-                "success"
-                if result.failed == 0
-                else "partial"
-                if result.success > 0
-                else "failed"
+                "success" if result.failed == 0 else "partial" if result.success > 0 else "failed"
             )
             logging.info(
                 "sync_complete",
@@ -409,9 +408,7 @@ def run(
 
 @app.command(name="list")
 def list_syncs(
-    output: str = typer.Option(
-        "text", "--output", "-o", help="Output format: text or json."
-    ),
+    output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
 ) -> None:
     """List all sync definitions in the project."""
     import json as json_mod
@@ -421,17 +418,22 @@ def list_syncs(
     syncs = load_syncs(Path("."))
 
     if output == "json":
-        print(json_mod.dumps({
-            "syncs": [
+        print(
+            json_mod.dumps(
                 {
-                    "name": s.name,
-                    "destination_type": s.destination.type,
-                    "mode": s.sync.mode,
-                    "description": s.description,
-                }
-                for s in syncs
-            ],
-        }, indent=2))
+                    "syncs": [
+                        {
+                            "name": s.name,
+                            "destination_type": s.destination.type,
+                            "mode": s.sync.mode,
+                            "description": s.description,
+                        }
+                        for s in syncs
+                    ],
+                },
+                indent=2,
+            )
+        )
         return
 
     print_sync_table(syncs)
@@ -447,9 +449,7 @@ def validate(
     emit_schema: bool = typer.Option(  # noqa: E501
         False, "--emit-schema", help="Write JSON Schemas to .drt/schemas/."
     ),
-    output: str = typer.Option(
-        "text", "--output", "-o", help="Output format: text or json."
-    ),
+    output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
 ) -> None:
     """Validate sync definitions against the JSON Schema."""
     import json as json_mod
@@ -460,15 +460,18 @@ def validate(
     result = load_syncs_safe(Path("."))
 
     if output == "json":
-        print(json_mod.dumps({
-            "results": [
-                {"name": s.name, "valid": True}
-                for s in result.syncs
-            ] + [
-                {"name": name, "valid": False, "errors": errs}
-                for name, errs in result.errors.items()
-            ],
-        }, indent=2))
+        print(
+            json_mod.dumps(
+                {
+                    "results": [{"name": s.name, "valid": True} for s in result.syncs]
+                    + [
+                        {"name": name, "valid": False, "errors": errs}
+                        for name, errs in result.errors.items()
+                    ],
+                },
+                indent=2,
+            )
+        )
         if result.errors:
             raise typer.Exit(code=1)
         return

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
+import logging
 import os
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -74,6 +77,38 @@ app = typer.Typer(
     help="Reverse ETL for the code-first data stack.",
     no_args_is_help=True,
 )
+
+
+# ---------------------------------------------------------------------------
+# JSON logging
+# ---------------------------------------------------------------------------
+
+
+class _JsonFormatter(logging.Formatter):
+    """Emit each log record as a single JSON object (JSON Lines format)."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        ts = datetime.fromtimestamp(record.created, tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        payload: dict[str, object] = {
+            "ts": ts,
+            "level": record.levelname,
+            "msg": record.getMessage(),
+        }
+        # Merge any extra fields passed via the `extra` kwarg
+        for key, value in record.__dict__.items():
+            if key not in logging.LogRecord.__dict__ and not key.startswith("_"):
+                payload[key] = value
+        return json.dumps(payload)
+
+
+def _configure_json_logging() -> None:
+    """Replace root logger handlers with a stderr JSON handler."""
+    handler = logging.StreamHandler()
+    handler.setFormatter(_JsonFormatter())
+    logging.root.handlers = [handler]
+    logging.root.setLevel(logging.DEBUG)
 
 
 def _resolve_profile_name(cli_flag: str | None, project_profile: str) -> str:
@@ -222,6 +257,9 @@ def run(
     profile_name: str = typer.Option(
         None, "--profile", "-p", help="Override profile (default: drt_project.yml or DRT_PROFILE)."
     ),
+    log_format: str = typer.Option(
+        "text", "--log-format", help="Log format: text or json (structured JSON lines)."
+    ),
 ) -> None:
     """Run sync(s) defined in the project."""
     import json as json_mod
@@ -230,6 +268,9 @@ def run(
     from drt.config.parser import load_project, load_syncs
     from drt.engine.sync import run_sync
     from drt.state.manager import StateManager
+
+    if log_format == "json":
+        _configure_json_logging()
 
     json_mode = output == "json"
 
@@ -269,10 +310,22 @@ def run(
         if not json_mode and not dry_run:
             print_sync_start(sync.name, dry_run)
         t0 = time.monotonic()
+        if log_format == "json":
+            logging.info("sync_started", extra={"sync": sync.name})
         try:
             result = run_sync(sync, source, dest, profile, Path("."), dry_run, state_mgr)
         except Exception as e:
             elapsed = round(time.monotonic() - t0, 2)
+            if log_format == "json":
+                logging.error(
+                    "sync_complete",
+                    extra={
+                        "sync": sync.name,
+                        "rows": 0,
+                        "duration_ms": round(elapsed * 1000),
+                        "status": "failed",
+                    },
+                )
             if json_mode:
                 json_results.append(
                     {
@@ -290,6 +343,23 @@ def run(
             had_errors = True
             continue
         elapsed = round(time.monotonic() - t0, 2)
+        if log_format == "json":
+            status_str = (
+                "success"
+                if result.failed == 0
+                else "partial"
+                if result.success > 0
+                else "failed"
+            )
+            logging.info(
+                "sync_complete",
+                extra={
+                    "sync": sync.name,
+                    "rows": result.success,
+                    "duration_ms": round(elapsed * 1000),
+                    "status": status_str,
+                },
+            )
         if json_mode:
             json_results.append(
                 {

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import click
 import typer
 
 if TYPE_CHECKING:
@@ -83,6 +84,8 @@ app = typer.Typer(
 # JSON logging
 # ---------------------------------------------------------------------------
 
+_STANDARD_LOG_FIELDS = frozenset(vars(logging.LogRecord("", 0, "", 0, "", (), None)))
+
 
 class _JsonFormatter(logging.Formatter):
     """Emit each log record as a single JSON object (JSON Lines format)."""
@@ -96,7 +99,7 @@ class _JsonFormatter(logging.Formatter):
         }
         # Merge any extra fields passed via the `extra` kwarg
         for key, value in record.__dict__.items():
-            if key not in logging.LogRecord.__dict__ and not key.startswith("_"):
+            if key not in _STANDARD_LOG_FIELDS and not key.startswith("_"):
                 payload[key] = value
         return json.dumps(payload)
 
@@ -256,13 +259,14 @@ def run(
         None, "--profile", "-p", help="Override profile (default: drt_project.yml or DRT_PROFILE)."
     ),
     log_format: str = typer.Option(
-    "text",
-    "--log-format",
-    help=(
-        "Log format: text or json (structured JSON lines for each sync event"
-        " — separate from --output json which controls the final result)."
+        "text",
+        "--log-format",
+        help=(
+            "Log format: 'text' (default) or 'json' (structured JSON Lines,"
+            " separate from --output json)."
+        ),
+        click_type=click.Choice(["text", "json"]),
     ),
-),
 ) -> None:
     """Run sync(s) defined in the project."""
     import json as json_mod

--- a/tests/unit/test_json_logging.py
+++ b/tests/unit/test_json_logging.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
+import io
 import json
 import logging
-import io
 
-import pytest
-
-from drt.cli.main import _JsonFormatter, _configure_json_logging
-
+from drt.cli.main import _configure_json_logging, _JsonFormatter
 
 # ---------------------------------------------------------------------------
 # Test 1: _configure_json_logging() produces valid JSON with required fields
@@ -96,7 +93,10 @@ def test_json_formatter_each_line_is_valid_json() -> None:
     logger.setLevel(logging.DEBUG)
 
     logger.info("sync_started", extra={"sync": "s1"})
-    logger.info("sync_complete", extra={"sync": "s1", "rows": 10, "duration_ms": 200, "status": "success"})
+    logger.info(
+    "sync_complete",
+    extra={"sync": "s1", "rows": 10, "duration_ms": 200, "status": "success"},
+    )
 
     lines = [line for line in stream.getvalue().splitlines() if line.strip()]
     assert len(lines) == 2, f"Expected 2 log lines, got {len(lines)}"
@@ -114,14 +114,16 @@ def test_json_formatter_each_line_is_valid_json() -> None:
 
 def test_configure_json_logging_replaces_handlers() -> None:
     """_configure_json_logging() sets exactly one handler on the root logger."""
+    old_handlers = logging.root.handlers[:]
+    old_level = logging.root.level
     # Add a dummy handler first to verify replacement
     dummy = logging.StreamHandler(io.StringIO())
     logging.root.addHandler(dummy)
+    try:
+        _configure_json_logging()
 
-    _configure_json_logging()
-
-    assert len(logging.root.handlers) == 1
-    assert isinstance(logging.root.handlers[0].formatter, _JsonFormatter)
-
-    # Cleanup: restore a sane state
-    logging.root.handlers = []
+        assert len(logging.root.handlers) == 1
+        assert isinstance(logging.root.handlers[0].formatter, _JsonFormatter)
+    finally:
+        logging.root.handlers = old_handlers
+        logging.root.setLevel(old_level)

--- a/tests/unit/test_json_logging.py
+++ b/tests/unit/test_json_logging.py
@@ -1,0 +1,127 @@
+"""Tests for --log-format json structured logging (GitHub Issue #275)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import io
+
+import pytest
+
+from drt.cli.main import _JsonFormatter, _configure_json_logging
+
+
+# ---------------------------------------------------------------------------
+# Test 1: _configure_json_logging() produces valid JSON with required fields
+# ---------------------------------------------------------------------------
+
+
+def test_json_formatter_basic_fields() -> None:
+    """_JsonFormatter emits valid JSON with ts, level, and msg fields."""
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(_JsonFormatter())
+
+    logger = logging.getLogger("test_json_logging.basic")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    logger.info("hello world")
+
+    output = stream.getvalue().strip()
+    assert output, "Expected log output but got nothing"
+
+    data = json.loads(output)
+    assert "ts" in data, "Missing 'ts' field"
+    assert "level" in data, "Missing 'level' field"
+    assert "msg" in data, "Missing 'msg' field"
+    assert data["level"] == "INFO"
+    assert data["msg"] == "hello world"
+    # ts must be ISO 8601 ending in Z
+    assert data["ts"].endswith("Z"), f"Expected ISO 8601 UTC timestamp, got: {data['ts']}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: sync_complete log line includes rows, duration_ms, and status
+# ---------------------------------------------------------------------------
+
+
+def test_json_formatter_sync_complete_fields() -> None:
+    """sync_complete log line includes rows, duration_ms, and status fields."""
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(_JsonFormatter())
+
+    logger = logging.getLogger("test_json_logging.sync_complete")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    logger.info(
+        "sync_complete",
+        extra={
+            "sync": "my_sync",
+            "rows": 42,
+            "duration_ms": 1500,
+            "status": "success",
+        },
+    )
+
+    output = stream.getvalue().strip()
+    data = json.loads(output)
+
+    assert data["msg"] == "sync_complete"
+    assert data["sync"] == "my_sync"
+    assert data["rows"] == 42
+    assert data["duration_ms"] == 1500
+    assert data["status"] == "success"
+    assert data["level"] == "INFO"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: each log line is a single valid JSON object (JSON Lines format)
+# ---------------------------------------------------------------------------
+
+
+def test_json_formatter_each_line_is_valid_json() -> None:
+    """Multiple log calls each produce a separate valid JSON line."""
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(_JsonFormatter())
+
+    logger = logging.getLogger("test_json_logging.multiline")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    logger.info("sync_started", extra={"sync": "s1"})
+    logger.info("sync_complete", extra={"sync": "s1", "rows": 10, "duration_ms": 200, "status": "success"})
+
+    lines = [l for l in stream.getvalue().splitlines() if l.strip()]
+    assert len(lines) == 2, f"Expected 2 log lines, got {len(lines)}"
+    for line in lines:
+        obj = json.loads(line)  # must not raise
+        assert "ts" in obj
+        assert "level" in obj
+        assert "msg" in obj
+
+
+# ---------------------------------------------------------------------------
+# Test 4: _configure_json_logging replaces root handlers cleanly
+# ---------------------------------------------------------------------------
+
+
+def test_configure_json_logging_replaces_handlers() -> None:
+    """_configure_json_logging() sets exactly one handler on the root logger."""
+    # Add a dummy handler first to verify replacement
+    dummy = logging.StreamHandler(io.StringIO())
+    logging.root.addHandler(dummy)
+
+    _configure_json_logging()
+
+    assert len(logging.root.handlers) == 1
+    assert isinstance(logging.root.handlers[0].formatter, _JsonFormatter)
+
+    # Cleanup: restore a sane state
+    logging.root.handlers = []

--- a/tests/unit/test_json_logging.py
+++ b/tests/unit/test_json_logging.py
@@ -15,28 +15,34 @@ from drt.cli.main import _configure_json_logging, _JsonFormatter
 
 def test_json_formatter_basic_fields() -> None:
     """_JsonFormatter emits valid JSON with ts, level, and msg fields."""
-    stream = io.StringIO()
-    handler = logging.StreamHandler(stream)
-    handler.setFormatter(_JsonFormatter())
+    original_handlers = logging.root.handlers[:]
+    original_level = logging.root.level
+    try:
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(_JsonFormatter())
 
-    logger = logging.getLogger("test_json_logging.basic")
-    logger.handlers = [handler]
-    logger.propagate = False
-    logger.setLevel(logging.DEBUG)
+        logger = logging.getLogger("test_json_logging.basic")
+        logger.handlers = [handler]
+        logger.propagate = False
+        logger.setLevel(logging.DEBUG)
 
-    logger.info("hello world")
+        logger.info("hello world")
 
-    output = stream.getvalue().strip()
-    assert output, "Expected log output but got nothing"
+        output = stream.getvalue().strip()
+        assert output, "Expected log output but got nothing"
 
-    data = json.loads(output)
-    assert "ts" in data, "Missing 'ts' field"
-    assert "level" in data, "Missing 'level' field"
-    assert "msg" in data, "Missing 'msg' field"
-    assert data["level"] == "INFO"
-    assert data["msg"] == "hello world"
-    # ts must be ISO 8601 ending in Z
-    assert data["ts"].endswith("Z"), f"Expected ISO 8601 UTC timestamp, got: {data['ts']}"
+        data = json.loads(output)
+        assert "ts" in data, "Missing 'ts' field"
+        assert "level" in data, "Missing 'level' field"
+        assert "msg" in data, "Missing 'msg' field"
+        assert data["level"] == "INFO"
+        assert data["msg"] == "hello world"
+        # ts must be ISO 8601 ending in Z
+        assert data["ts"].endswith("Z"), f"Expected ISO 8601 UTC timestamp, got: {data['ts']}"
+    finally:
+        logging.root.handlers = original_handlers
+        logging.root.level = original_level
 
 
 # ---------------------------------------------------------------------------
@@ -46,34 +52,40 @@ def test_json_formatter_basic_fields() -> None:
 
 def test_json_formatter_sync_complete_fields() -> None:
     """sync_complete log line includes rows, duration_ms, and status fields."""
-    stream = io.StringIO()
-    handler = logging.StreamHandler(stream)
-    handler.setFormatter(_JsonFormatter())
+    original_handlers = logging.root.handlers[:]
+    original_level = logging.root.level
+    try:
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(_JsonFormatter())
 
-    logger = logging.getLogger("test_json_logging.sync_complete")
-    logger.handlers = [handler]
-    logger.propagate = False
-    logger.setLevel(logging.DEBUG)
+        logger = logging.getLogger("test_json_logging.sync_complete")
+        logger.handlers = [handler]
+        logger.propagate = False
+        logger.setLevel(logging.DEBUG)
 
-    logger.info(
-        "sync_complete",
-        extra={
-            "sync": "my_sync",
-            "rows": 42,
-            "duration_ms": 1500,
-            "status": "success",
-        },
-    )
+        logger.info(
+            "sync_complete",
+            extra={
+                "sync": "my_sync",
+                "rows": 42,
+                "duration_ms": 1500,
+                "status": "success",
+            },
+        )
 
-    output = stream.getvalue().strip()
-    data = json.loads(output)
+        output = stream.getvalue().strip()
+        data = json.loads(output)
 
-    assert data["msg"] == "sync_complete"
-    assert data["sync"] == "my_sync"
-    assert data["rows"] == 42
-    assert data["duration_ms"] == 1500
-    assert data["status"] == "success"
-    assert data["level"] == "INFO"
+        assert data["msg"] == "sync_complete"
+        assert data["sync"] == "my_sync"
+        assert data["rows"] == 42
+        assert data["duration_ms"] == 1500
+        assert data["status"] == "success"
+        assert data["level"] == "INFO"
+    finally:
+        logging.root.handlers = original_handlers
+        logging.root.level = original_level
 
 
 # ---------------------------------------------------------------------------
@@ -83,28 +95,34 @@ def test_json_formatter_sync_complete_fields() -> None:
 
 def test_json_formatter_each_line_is_valid_json() -> None:
     """Multiple log calls each produce a separate valid JSON line."""
-    stream = io.StringIO()
-    handler = logging.StreamHandler(stream)
-    handler.setFormatter(_JsonFormatter())
+    original_handlers = logging.root.handlers[:]
+    original_level = logging.root.level
+    try:
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(_JsonFormatter())
 
-    logger = logging.getLogger("test_json_logging.multiline")
-    logger.handlers = [handler]
-    logger.propagate = False
-    logger.setLevel(logging.DEBUG)
+        logger = logging.getLogger("test_json_logging.multiline")
+        logger.handlers = [handler]
+        logger.propagate = False
+        logger.setLevel(logging.DEBUG)
 
-    logger.info("sync_started", extra={"sync": "s1"})
-    logger.info(
-    "sync_complete",
-    extra={"sync": "s1", "rows": 10, "duration_ms": 200, "status": "success"},
-    )
+        logger.info("sync_started", extra={"sync": "s1"})
+        logger.info(
+            "sync_complete",
+            extra={"sync": "s1", "rows": 10, "duration_ms": 200, "status": "success"},
+        )
 
-    lines = [line for line in stream.getvalue().splitlines() if line.strip()]
-    assert len(lines) == 2, f"Expected 2 log lines, got {len(lines)}"
-    for line in lines:
-        obj = json.loads(line)  # must not raise
-        assert "ts" in obj
-        assert "level" in obj
-        assert "msg" in obj
+        lines = [line for line in stream.getvalue().splitlines() if line.strip()]
+        assert len(lines) == 2, f"Expected 2 log lines, got {len(lines)}"
+        for line in lines:
+            obj = json.loads(line)  # must not raise
+            assert "ts" in obj
+            assert "level" in obj
+            assert "msg" in obj
+    finally:
+        logging.root.handlers = original_handlers
+        logging.root.level = original_level
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_json_logging.py
+++ b/tests/unit/test_json_logging.py
@@ -98,7 +98,7 @@ def test_json_formatter_each_line_is_valid_json() -> None:
     logger.info("sync_started", extra={"sync": "s1"})
     logger.info("sync_complete", extra={"sync": "s1", "rows": 10, "duration_ms": 200, "status": "success"})
 
-    lines = [l for l in stream.getvalue().splitlines() if l.strip()]
+    lines = [line for line in stream.getvalue().splitlines() if line.strip()]
     assert len(lines) == 2, f"Expected 2 log lines, got {len(lines)}"
     for line in lines:
         obj = json.loads(line)  # must not raise


### PR DESCRIPTION
## Summary
Implements #275 — adds `--log-format json` flag to `drt run` for structured 
JSON logging, enabling integration with log aggregators like Datadog and CloudWatch.

## Changes
- `drt/cli/main.py` — added `--log-format` flag and `_configure_json_logging()` 
  using stdlib `logging` only (no new dependencies)
- `tests/unit/test_json_logging.py` — 4 unit tests covering JSON output format

## Acceptance Criteria
- [x] `drt run my_sync.yaml --log-format json` outputs JSON lines
- [x] `drt run my_sync.yaml` (default) outputs text as before  
- [x] Unit tests covering JSON log output (4/4 passing)

## Testing
uv run pytest tests/unit/test_json_logging.py -v
# 4 passed