### PR TITLE
feat: add drt serve — HTTP webhook trigger endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **SQL Server source connector** (#91): Extract data from Microsoft SQL Server using pure-Python `pymssql`. Supports host, port, database, user, password_env, schema. Install: `pip install drt-core[sqlserver]`.
 - **Databricks source connector** (#88): Extract data from Databricks SQL Warehouse using `databricks-sql-connector`. Supports Unity Catalog, access token auth. Install: `pip install drt-core[databricks]`.
+- **Webhook trigger endpoint** (#218): New `drt serve` command starts a lightweight HTTP server (stdlib `http.server`) so you can trigger syncs via `POST /sync/<name>`. Includes health check, bearer token auth, and single-sync concurrency control (423 on parallel requests). Guide: `docs/guides/using-webhook-trigger.md`.
 - **Prefect integration** (#213): Built-in `run_drt_sync()` helper and `drt_sync_task` for Prefect 2.x/3.x. No extra package needed — included in drt-core. Shares the runner with Airflow integration via `drt.integrations._runner`.
 - **Airflow integration** (#70): Built-in `run_drt_sync()` helper and `DrtRunOperator` for Apache Airflow. No extra package needed — included in drt-core.
 - **Google Ads destination** (#217): Upload offline click conversions. Supports partial failure handling and OAuth2 auth.

--- a/docs/guides/using-webhook-trigger.md
+++ b/docs/guides/using-webhook-trigger.md
@@ -1,0 +1,94 @@
+# Triggering drt syncs via HTTP
+
+`drt serve` starts a lightweight HTTP endpoint so you can trigger syncs from webhooks, CI systems, or other orchestrators.
+
+No extra dependencies — stdlib only.
+
+## Start the server
+
+```bash
+drt serve --port 8080 --token-env DRT_WEBHOOK_TOKEN
+```
+
+- `--host` (default `127.0.0.1`)
+- `--port` (default `8080`)
+- `--token-env` (default `DRT_WEBHOOK_TOKEN`) — env var holding the bearer token. Empty or unset means no auth (local dev only).
+
+```bash
+export DRT_WEBHOOK_TOKEN="$(openssl rand -hex 32)"
+drt serve --port 8080
+```
+
+## Endpoints
+
+### `GET /health`
+
+```bash
+curl http://localhost:8080/health
+# {"status": "ok", "version": "0.6.0-dev"}
+```
+
+### `POST /sync/<name>`
+
+Trigger a sync by name. Optional `?dry_run=true` for preview.
+
+```bash
+curl -X POST http://localhost:8080/sync/sync_users \
+  -H "Authorization: Bearer $DRT_WEBHOOK_TOKEN"
+```
+
+Response (success):
+```json
+{
+  "sync_name": "sync_users",
+  "status": "success",
+  "rows_synced": 42,
+  "rows_failed": 0,
+  "duration_seconds": 1.5,
+  "dry_run": false,
+  "errors": []
+}
+```
+
+### Status codes
+
+| Code | Meaning |
+|------|---------|
+| 200  | sync succeeded |
+| 207  | sync partial or failed (result body has details) |
+| 400  | sync name missing from URL |
+| 401  | bearer token missing or wrong (when auth enabled) |
+| 404  | sync name not found in project |
+| 423  | another sync is already running (one at a time) |
+| 500  | unexpected error |
+
+## Use cases
+
+### GitHub webhook → run sync on push
+
+```yaml
+# .github/workflows/trigger-drt.yml
+on:
+  push:
+    branches: [main]
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -X POST $DRT_HOST/sync/sync_users \
+            -H "Authorization: Bearer ${{ secrets.DRT_WEBHOOK_TOKEN }}"
+```
+
+### dbt Cloud job completion → sync downstream
+
+Add a post-job webhook in dbt Cloud pointing to `https://your-drt-host/sync/sync_users` with the bearer token.
+
+## Design notes
+
+- **One sync at a time** — concurrent requests return 423 Locked. This keeps state consistent without needing a queue or DB.
+- **No persistent state** beyond what `StateManager` already does (`.drt/state.json`).
+- **Stdlib only** — `http.server.ThreadingHTTPServer`, no FastAPI/uvicorn. Keeps drt-core dependency-free.
+
+For production, run behind a reverse proxy (nginx, Caddy) for TLS and rate limiting.

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -112,6 +112,7 @@ drt test --select <sync-name>     # test a specific sync
 drt status                        # show recent sync results
 drt status --output json          # JSON output for status
 drt mcp run                       # start MCP server (requires drt-core[mcp])
+drt serve --port 8080             # start HTTP webhook endpoint (POST /sync/<name>)
 ```
 
 ## MCP Server

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -551,6 +551,35 @@ def _test_display_name(test_def: object) -> str:
 
 
 # ---------------------------------------------------------------------------
+# serve (webhook trigger)
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def serve(
+    host: str = typer.Option("127.0.0.1", "--host", help="Host to bind."),
+    port: int = typer.Option(8080, "--port", "-p", help="Port to bind."),
+    token_env: str = typer.Option(
+        "DRT_WEBHOOK_TOKEN",
+        "--token-env",
+        help="Env var holding bearer token for auth. Empty/unset = no auth.",
+    ),
+) -> None:
+    """Start an HTTP endpoint that triggers drt syncs on demand.
+
+    Example:
+        drt serve --port 8080 --token-env DRT_WEBHOOK_TOKEN
+
+        curl -X POST http://localhost:8080/sync/my_sync \\
+          -H "Authorization: Bearer $DRT_WEBHOOK_TOKEN"
+    """
+    from drt.cli.server import serve as serve_impl
+
+    token = os.environ.get(token_env) or None
+    serve_impl(host=host, port=port, token=token, project_dir=".")
+
+
+# ---------------------------------------------------------------------------
 # mcp
 # ---------------------------------------------------------------------------
 

--- a/drt/cli/server.py
+++ b/drt/cli/server.py
@@ -1,0 +1,147 @@
+"""drt webhook server — lightweight HTTP endpoint to trigger syncs.
+
+Enables event-driven sync patterns (GitHub webhooks, dbt job completion, etc.).
+No external dependencies — uses stdlib ``http.server``.
+
+Routes:
+    GET  /health           → {"status": "ok", "version": "..."}
+    POST /sync/<name>      → run sync, return SyncResult as JSON
+    POST /sync/<name>?dry_run=true  → dry run
+
+Auth:
+    Optional Bearer token via ``token`` argument (from ``DRT_WEBHOOK_TOKEN``
+    env var by default). If not set, endpoint is unauthenticated (local dev).
+
+One sync at a time — concurrent requests get 423 Locked.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+from drt import __version__
+
+
+class _SyncLock:
+    """Serialize sync executions — one at a time."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+
+    def try_acquire(self) -> bool:
+        return self._lock.acquire(blocking=False)
+
+    def release(self) -> None:
+        self._lock.release()
+
+
+def make_handler(
+    token: str | None,
+    sync_lock: _SyncLock,
+    project_dir: str = ".",
+) -> type[BaseHTTPRequestHandler]:
+    """Build a request handler bound to the given token and project dir."""
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: Any) -> None:
+            # Quiet the default stderr access log
+            return
+
+        def _json(self, status: int, payload: dict[str, Any]) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _check_auth(self) -> bool:
+            if token is None:
+                return True
+            header = self.headers.get("Authorization", "")
+            return header == f"Bearer {token}"
+
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path == "/health":
+                self._json(200, {"status": "ok", "version": __version__})
+                return
+            self._json(404, {"error": "not found"})
+
+        def do_POST(self) -> None:  # noqa: N802
+            if not self._check_auth():
+                self._json(401, {"error": "unauthorized"})
+                return
+
+            path, _, query = self.path.partition("?")
+            if not path.startswith("/sync/"):
+                self._json(404, {"error": "not found"})
+                return
+
+            sync_name = path[len("/sync/"):].strip("/")
+            if not sync_name:
+                self._json(400, {"error": "sync name required"})
+                return
+
+            dry_run = "dry_run=true" in query
+
+            if not sync_lock.try_acquire():
+                self._json(
+                    423,
+                    {"error": "another sync is already running"},
+                )
+                return
+
+            try:
+                from drt.integrations._runner import run_drt_sync
+
+                result = run_drt_sync(
+                    sync_name=sync_name,
+                    project_dir=project_dir,
+                    dry_run=dry_run,
+                )
+                status = 200 if result["status"] == "success" else 207
+                self._json(status, result)
+            except ValueError as e:
+                self._json(404, {"error": str(e)})
+            except Exception as e:
+                self._json(
+                    500,
+                    {"error": f"sync failed: {e}"},
+                )
+            finally:
+                sync_lock.release()
+
+    return Handler
+
+
+def serve(
+    host: str = "127.0.0.1",
+    port: int = 8080,
+    token: str | None = None,
+    project_dir: str = ".",
+) -> None:
+    """Start the webhook server (blocking)."""
+    sync_lock = _SyncLock()
+    handler = make_handler(token, sync_lock, project_dir)
+    server = ThreadingHTTPServer((host, port), handler)
+    auth_note = (
+        "with bearer token auth"
+        if token
+        else "[yellow]without auth (local dev only)[/yellow]"
+    )
+    from drt.cli.output import console
+
+    console.print(
+        f"[bold]drt webhook server[/bold] listening on "
+        f"http://{host}:{port} {auth_note}"
+    )
+    console.print("  POST /sync/<name>[?dry_run=true]  → trigger sync")
+    console.print("  GET  /health                       → status")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        console.print("\n[dim]Shutting down...[/dim]")
+        server.shutdown()

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,0 +1,182 @@
+"""Tests for the webhook trigger server."""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.request
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from drt import __version__
+from drt.cli.server import _SyncLock, make_handler
+
+
+def _run_server(
+    token: str | None = None,
+    project_dir: str = ".",
+) -> tuple[ThreadingHTTPServer, threading.Thread, int]:
+    """Start a server on a random port and return (server, thread, port)."""
+    sync_lock = _SyncLock()
+    handler = make_handler(token, sync_lock, project_dir)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread, port
+
+
+def _get(url: str, token: str | None = None) -> tuple[int, dict[str, Any]]:
+    req = urllib.request.Request(url)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read())
+
+
+def _post(
+    url: str, token: str | None = None
+) -> tuple[int, dict[str, Any]]:
+    req = urllib.request.Request(url, method="POST")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read())
+
+
+def test_health_endpoint() -> None:
+    server, _, port = _run_server()
+    try:
+        status, body = _get(f"http://127.0.0.1:{port}/health")
+        assert status == 200
+        assert body == {"status": "ok", "version": __version__}
+    finally:
+        server.shutdown()
+
+
+def test_unknown_get_returns_404() -> None:
+    server, _, port = _run_server()
+    try:
+        status, body = _get(f"http://127.0.0.1:{port}/unknown")
+        assert status == 404
+        assert "error" in body
+    finally:
+        server.shutdown()
+
+
+def test_post_without_auth_when_required_returns_401() -> None:
+    server, _, port = _run_server(token="secret123")
+    try:
+        status, body = _post(f"http://127.0.0.1:{port}/sync/my_sync")
+        assert status == 401
+        assert "unauthorized" in body["error"]
+    finally:
+        server.shutdown()
+
+
+def test_post_with_wrong_token_returns_401() -> None:
+    server, _, port = _run_server(token="secret123")
+    try:
+        status, _ = _post(
+            f"http://127.0.0.1:{port}/sync/my_sync", token="wrong"
+        )
+        assert status == 401
+    finally:
+        server.shutdown()
+
+
+def test_post_missing_sync_name_returns_400() -> None:
+    server, _, port = _run_server()
+    try:
+        status, body = _post(f"http://127.0.0.1:{port}/sync/")
+        assert status == 400
+        assert "sync name" in body["error"]
+    finally:
+        server.shutdown()
+
+
+def test_post_sync_not_found_returns_404(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run_drt_sync raises ValueError for unknown sync → 404."""
+    # Create minimal project setup so load_project works
+    import yaml
+
+    (tmp_path / "drt_project.yml").write_text(
+        yaml.dump({"name": "test", "version": "0.1", "profile": "default"})
+    )
+    creds = tmp_path / "drt_home"
+    creds.mkdir()
+    (creds / "profiles.yml").write_text(
+        yaml.dump({"default": {"type": "duckdb", "database": ":memory:"}})
+    )
+    monkeypatch.setattr(
+        "drt.config.credentials._config_dir",
+        lambda override=None: override or creds,
+    )
+    (tmp_path / "syncs").mkdir()
+
+    server, _, port = _run_server(project_dir=str(tmp_path))
+    try:
+        status, body = _post(f"http://127.0.0.1:{port}/sync/nonexistent")
+        assert status == 404
+        assert "nonexistent" in body["error"]
+    finally:
+        server.shutdown()
+
+
+def test_concurrent_request_returns_423() -> None:
+    """Second concurrent sync request should get 423 Locked."""
+    sync_lock = _SyncLock()
+
+    # Simulate running sync by holding the lock
+    acquired = sync_lock.try_acquire()
+    assert acquired
+
+    handler = make_handler(None, sync_lock, ".")
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        status, body = _post(f"http://127.0.0.1:{port}/sync/any")
+        assert status == 423
+        assert "already running" in body["error"]
+    finally:
+        sync_lock.release()
+        server.shutdown()
+
+
+def test_sync_lock_releases_after_success() -> None:
+    """After one sync completes, next request is not blocked."""
+    with patch("drt.integrations._runner.run_drt_sync") as mock_run:
+        mock_run.return_value = {
+            "sync_name": "s",
+            "status": "success",
+            "rows_synced": 1,
+            "rows_failed": 0,
+            "duration_seconds": 0.1,
+            "dry_run": False,
+            "errors": [],
+        }
+        server, _, port = _run_server()
+        try:
+            status1, body1 = _post(f"http://127.0.0.1:{port}/sync/s")
+            assert status1 == 200
+            assert body1["status"] == "success"
+            # Second call should also work (lock released)
+            status2, _ = _post(f"http://127.0.0.1:{port}/sync/s")
+            assert status2 == 200
+        finally:
+            server.shutdown()


### PR DESCRIPTION
## Summary

New \`drt serve\` command starts a lightweight HTTP server (stdlib only — no new deps) so you can trigger syncs from webhooks, CI, or other orchestrators.

\`\`\`bash
drt serve --port 8080 --token-env DRT_WEBHOOK_TOKEN

curl -X POST http://localhost:8080/sync/sync_users \\
  -H "Authorization: Bearer \$DRT_WEBHOOK_TOKEN"
\`\`\`

Closes #218.

### Routes

| Method | Path | Purpose |
|--------|------|---------|
| GET  | /health | status + version |
| POST | /sync/<name>[?dry_run=true] | run sync, return SyncResult JSON |

### Design

- **Stdlib only** — \`http.server.ThreadingHTTPServer\`, no FastAPI/uvicorn
- **Bearer auth** — optional via env var; empty/unset = no auth (local dev)
- **One sync at a time** — concurrent requests get 423 Locked, keeps state consistent without queue/DB
- **No persistent state** beyond existing StateManager (\`.drt/state.json\`)

This is per the design discussion on #218.

## Test plan
- [x] 8 tests covering health, auth (wrong/missing token), routing, sync-not-found, concurrency lock, lock release
- [x] 452 total tests passing
- [x] ruff + mypy clean
- [x] Guide: \`docs/guides/using-webhook-trigger.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)