### PR TITLE
feat: add --all, --select tag:, --threads for parallel sync execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Parallel sync execution** (#335): New `drt run --threads N` runs configured syncs in a `ThreadPoolExecutor`. `--select tag:<name>` filters by sync tag; `--select *` or `--select all` are explicit "run every sync" sentinels. `StateManager` now takes a process-local `threading.Lock` so concurrent `save_sync` calls from worker threads don't lose each other's writes.
 - **SQL Server source connector** (#91): Extract data from Microsoft SQL Server using pure-Python `pymssql`. Supports host, port, database, user, password_env, schema. Install: `pip install drt-core[sqlserver]`.
 - **Databricks source connector** (#88): Extract data from Databricks SQL Warehouse using `databricks-sql-connector`. Supports Unity Catalog, access token auth. Install: `pip install drt-core[databricks]`.
 - **Webhook trigger endpoint** (#218): New `drt serve` command starts a lightweight HTTP server (stdlib `http.server`) so you can trigger syncs via `POST /sync/<name>`. Includes health check, bearer token auth, and single-sync concurrency control (423 on parallel requests). Guide: `docs/guides/using-webhook-trigger.md`.

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -333,7 +333,7 @@ def run(
     succeeded = 0
     failed = 0
 
-    def _run_one(sync):
+    def _run_one(sync: SyncConfig) -> tuple[str, dict[str, object], bool]:
         """Execute a single sync and return (name, result_dict, had_error)."""
         dest = _get_destination(sync)
         wm_storage = _get_watermark_storage(sync, Path("."))

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -256,8 +256,12 @@ def _init_from_dbt(manifest_path: Path) -> None:
 
 @app.command()
 def run(
-    select: str = typer.Option(None, "--select", "-s", help="Run sync by name or tag (tag:crm)."),
-    all_syncs: bool = typer.Option(False, "--all", help="Explicitly run all syncs."),
+    select: str = typer.Option(
+        None,
+        "--select",
+        "-s",
+        help='Run sync by name, tag (tag:crm), or "*" / "all" for every sync.',
+    ),
     threads: int = typer.Option(1, "--threads", "-t", help="Parallel execution threads."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview without writing data."),
     verbose: bool = typer.Option(False, "--verbose", help="Show row-level error details."),
@@ -277,8 +281,9 @@ def run(
 ) -> None:
     """Run sync(s) defined in the project.
 
-    Without --select or --all, runs all syncs sequentially (existing behaviour).
+    Without --select, runs all syncs sequentially (existing behaviour).
     Use --select to filter by name or tag (e.g. --select tag:crm).
+    Use --select "*" or --select all to be explicit about running every sync.
     Use --threads N for parallel execution.
     """
     import json as json_mod
@@ -314,7 +319,10 @@ def run(
         raise typer.Exit()
 
     if select:
-        if select.startswith("tag:"):
+        if select in ("*", "all"):
+            # Explicit "run every sync" sentinel — no filtering.
+            pass
+        elif select.startswith("tag:"):
             tag = select[4:]
             syncs = [s for s in syncs if tag in getattr(s, "tags", [])]
             if not syncs:

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -256,7 +256,9 @@ def _init_from_dbt(manifest_path: Path) -> None:
 
 @app.command()
 def run(
-    select: str = typer.Option(None, "--select", "-s", help="Run a specific sync by name."),
+    select: str = typer.Option(None, "--select", "-s", help="Run sync by name or tag (tag:crm)."),
+    all_syncs: bool = typer.Option(False, "--all", help="Explicitly run all syncs."),
+    threads: int = typer.Option(1, "--threads", "-t", help="Parallel execution threads."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview without writing data."),
     verbose: bool = typer.Option(False, "--verbose", help="Show row-level error details."),
     output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
@@ -273,8 +275,14 @@ def run(
         click_type=click.Choice(["text", "json"]),
     ),
 ) -> None:
-    """Run sync(s) defined in the project."""
+    """Run sync(s) defined in the project.
+
+    Without --select or --all, runs all syncs sequentially (existing behaviour).
+    Use --select to filter by name or tag (e.g. --select tag:crm).
+    Use --threads N for parallel execution.
+    """
     import json as json_mod
+    from concurrent.futures import ThreadPoolExecutor, as_completed
 
     from drt.config.credentials import load_profile
     from drt.config.parser import load_project, load_syncs
@@ -306,18 +314,27 @@ def run(
         raise typer.Exit()
 
     if select:
-        syncs = [s for s in syncs if s.name == select]
-        if not syncs:
-            print_error(f"No sync named '{select}' found.")
-            raise typer.Exit(1)
+        if select.startswith("tag:"):
+            tag = select[4:]
+            syncs = [s for s in syncs if tag in getattr(s, "tags", [])]
+            if not syncs:
+                print_error(f"No syncs with tag '{tag}' found.")
+                raise typer.Exit(1)
+        else:
+            syncs = [s for s in syncs if s.name == select]
+            if not syncs:
+                print_error(f"No sync named '{select}' found.")
+                raise typer.Exit(1)
 
     source = _get_source(profile)
     state_mgr = StateManager(Path("."))
-    had_errors = False
     json_results: list[dict[str, object]] = []
     t_total = time.monotonic()
+    succeeded = 0
+    failed = 0
 
-    for sync in syncs:
+    def _run_one(sync):
+        """Execute a single sync and return (name, result_dict, had_error)."""
         dest = _get_destination(sync)
         wm_storage = _get_watermark_storage(sync, Path("."))
         if not json_mode and not dry_run:
@@ -338,6 +355,15 @@ def run(
             )
         except Exception as e:
             elapsed = round(time.monotonic() - t0, 2)
+            entry = {
+                "name": sync.name,
+                "status": "failed",
+                "rows_synced": 0,
+                "rows_failed": 0,
+                "duration_seconds": elapsed,
+                "dry_run": dry_run,
+                "error": str(e),
+            }
             if log_format == "json":
                 logging.error(
                     "sync_complete",
@@ -348,27 +374,28 @@ def run(
                         "status": "failed",
                     },
                 )
-            if json_mode:
-                json_results.append(
-                    {
-                        "name": sync.name,
-                        "status": "failed",
-                        "rows_synced": 0,
-                        "rows_failed": 0,
-                        "duration_seconds": elapsed,
-                        "dry_run": dry_run,
-                        "error": str(e),
-                    }
-                )
-            else:
+            if not json_mode:
                 print_error(f"[{sync.name}] Unexpected error: {e}")
-            had_errors = True
-            continue
+            return sync.name, entry, True
+
         elapsed = round(time.monotonic() - t0, 2)
+        status_str = (
+            "success"
+            if result.failed == 0
+            else "partial"
+            if result.success > 0
+            else "failed"
+        )
+        entry = {
+            "name": sync.name,
+            "status": status_str,
+            "rows_extracted": result.rows_extracted,
+            "rows_synced": result.success,
+            "rows_failed": result.failed,
+            "duration_seconds": elapsed,
+            "dry_run": dry_run,
+        }
         if log_format == "json":
-            status_str = (
-                "success" if result.failed == 0 else "partial" if result.success > 0 else "failed"
-            )
             logging.info(
                 "sync_complete",
                 extra={
@@ -378,46 +405,58 @@ def run(
                     "status": status_str,
                 },
             )
-        if json_mode:
-            json_results.append(
-                {
-                    "name": sync.name,
-                    "status": (
-                        "success"
-                        if result.failed == 0
-                        else "partial"
-                        if result.success > 0
-                        else "failed"
-                    ),
-                    "rows_extracted": result.rows_extracted,
-                    "rows_synced": result.success,
-                    "rows_failed": result.failed,
-                    "duration_seconds": elapsed,
-                    "dry_run": dry_run,
-                }
-            )
-        else:
+        if not json_mode:
             if dry_run:
                 print_dry_run_summary(sync, profile, result.success)
             else:
                 print_sync_result(sync.name, result, elapsed)
-        if result.failed > 0:
-            had_errors = True
-            if not json_mode and verbose and result.row_errors:
-                print_row_errors(result.row_errors)
+        if not json_mode and verbose and result.row_errors:
+            print_row_errors(result.row_errors)
+        return sync.name, entry, result.failed > 0
+
+    # Execute syncs — parallel if threads > 1, sequential otherwise
+    if threads > 1 and len(syncs) > 1:
+        if not json_mode:
+            console.print(f"[dim]Running {len(syncs)} syncs with {threads} threads[/dim]\n")
+        with ThreadPoolExecutor(max_workers=threads) as pool:
+            futures = {pool.submit(_run_one, s): s for s in syncs}
+            for future in as_completed(futures):
+                name, entry, had_err = future.result()
+                json_results.append(entry)
+                if had_err:
+                    failed += 1
+                else:
+                    succeeded += 1
+    else:
+        for sync in syncs:
+            name, entry, had_err = _run_one(sync)
+            json_results.append(entry)
+            if had_err:
+                failed += 1
+            else:
+                succeeded += 1
+
+    total_duration = round(time.monotonic() - t_total, 2)
+
+    # Summary report
+    if not json_mode and len(syncs) > 1:
+        console.print(f"\n[bold]Summary:[/bold] {succeeded} succeeded, {failed} failed, "
+                       f"{total_duration}s total")
 
     if json_mode:
         print(
             json_mod.dumps(
                 {
                     "syncs": json_results,
-                    "total_duration_seconds": round(time.monotonic() - t_total, 2),
+                    "succeeded": succeeded,
+                    "failed": failed,
+                    "total_duration_seconds": total_duration,
                 },
                 indent=2,
             )
         )
 
-    if had_errors:
+    if failed > 0:
         raise typer.Exit(1)
 
 

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -583,6 +583,7 @@ class SyncTest(BaseModel):
 class SyncConfig(BaseModel):
     name: str
     description: str = ""
+    tags: list[str] = Field(default_factory=list)
     model: str
     destination: DestinationConfig
     sync: SyncOptions = Field(default_factory=SyncOptions)

--- a/drt/state/manager.py
+++ b/drt/state/manager.py
@@ -2,11 +2,17 @@
 
 Simple by design: no external dependencies, no infrastructure.
 Future: bincode (Rust) for fast binary serialization.
+
+Thread safety: ``drt run --threads N`` calls ``save_sync`` concurrently
+from each worker. Every method that touches state.json runs under a
+process-local :class:`threading.Lock` so the load-modify-save cycle is
+atomic and parallel writers don't clobber each other's updates.
 """
 
 from __future__ import annotations
 
 import json
+import threading
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,11 +30,18 @@ class SyncState:
 
 
 class StateManager:
-    """Read and write sync state from .drt/state.json."""
+    """Read and write sync state from .drt/state.json.
+
+    All public methods are thread-safe via ``self._lock``. The lock
+    serialises the load-modify-save cycle in :meth:`save_sync` and the
+    read-only operations so a reader never observes a partially-written
+    file in-memory either.
+    """
 
     def __init__(self, project_dir: Path = Path(".")) -> None:
         self._state_dir = project_dir / ".drt"
         self._state_file = self._state_dir / "state.json"
+        self._lock = threading.Lock()
 
     def _load_all(self) -> dict[str, Any]:
         if not self._state_file.exists():
@@ -52,20 +65,23 @@ class StateManager:
             json.dump(data, f, indent=2)
 
     def get_last_sync(self, sync_name: str) -> SyncState | None:
-        data = self._load_all()
+        with self._lock:
+            data = self._load_all()
         if sync_name not in data:
             return None
         return SyncState(**data[sync_name])
 
     def get_all(self) -> dict[str, SyncState]:
         """Return all sync states keyed by sync name."""
-        data = self._load_all()
+        with self._lock:
+            data = self._load_all()
         return {k: SyncState(**v) for k, v in data.items()}
 
     def save_sync(self, state: SyncState) -> None:
-        data = self._load_all()
-        data[state.sync_name] = asdict(state)
-        self._save_all(data)
+        with self._lock:
+            data = self._load_all()
+            data[state.sync_name] = asdict(state)
+            self._save_all(data)
 
     def now(self) -> str:
         return datetime.now(timezone.utc).isoformat()

--- a/tests/unit/test_cli_run_parallel.py
+++ b/tests/unit/test_cli_run_parallel.py
@@ -84,11 +84,23 @@ def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 class _FakeResult:
-    """Shape-compatible stand-in for engine.sync.run_sync's return value."""
+    """Shape-compatible stand-in for engine.sync.run_sync's return value.
 
-    def __init__(self, success: int = 1, failed: int = 0) -> None:
+    Mirrors the real ``SyncResult`` surface that ``cli.main.run`` reads:
+    ``success``, ``failed``, ``row_errors``, and — since PR #345/#347 —
+    ``rows_extracted``. Keeping the fake in lockstep with the real shape
+    is cheaper than monkey-patching each attribute per test.
+    """
+
+    def __init__(
+        self,
+        success: int = 1,
+        failed: int = 0,
+        rows_extracted: int | None = None,
+    ) -> None:
         self.success = success
         self.failed = failed
+        self.rows_extracted = success if rows_extracted is None else rows_extracted
         self.row_errors: list[Any] = []
 
 

--- a/tests/unit/test_cli_run_parallel.py
+++ b/tests/unit/test_cli_run_parallel.py
@@ -1,0 +1,262 @@
+"""Tests for ``drt run`` sync selection and parallel execution.
+
+Covers ``--select`` (by name, by tag, and the ``*``/``all`` sentinels),
+``--threads`` dispatch into a real worker pool, and error paths.
+
+The engine and destinations are patched so we don't need real network
+calls — each test only asserts the CLI wiring behaves as documented.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from drt.cli.main import app
+from drt.state.manager import StateManager, SyncState
+
+runner = CliRunner()
+
+PROFILE_NAME = "default"
+
+PROFILE_YML = {
+    "profiles": {
+        PROFILE_NAME: {"type": "duckdb"},
+    }
+}
+
+SYNC_A: dict[str, Any] = {
+    "name": "sync_a",
+    "model": "SELECT 1",
+    "tags": ["crm"],
+    "destination": {
+        "type": "rest_api",
+        "url": "https://example.com/a",
+        "method": "POST",
+    },
+}
+
+SYNC_B: dict[str, Any] = {
+    "name": "sync_b",
+    "model": "SELECT 2",
+    "tags": ["crm", "hourly"],
+    "destination": {
+        "type": "rest_api",
+        "url": "https://example.com/b",
+        "method": "POST",
+    },
+}
+
+SYNC_C: dict[str, Any] = {
+    "name": "sync_c",
+    "model": "SELECT 3",
+    "tags": ["daily"],
+    "destination": {
+        "type": "rest_api",
+        "url": "https://example.com/c",
+        "method": "POST",
+    },
+}
+
+
+@pytest.fixture
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Minimal drt project with three syncs under ``tmp_path``."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "drt_project.yml").write_text(
+        yaml.dump({"name": "test_project", "version": "0.1", "profile": PROFILE_NAME})
+    )
+    creds_dir = tmp_path / ".drt"
+    creds_dir.mkdir()
+    (creds_dir / "credentials.yml").write_text(yaml.dump(PROFILE_YML))
+
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    for sync in (SYNC_A, SYNC_B, SYNC_C):
+        (syncs_dir / f"{sync['name']}.yml").write_text(yaml.dump(sync))
+    return tmp_path
+
+
+class _FakeResult:
+    """Shape-compatible stand-in for engine.sync.run_sync's return value."""
+
+    def __init__(self, success: int = 1, failed: int = 0) -> None:
+        self.success = success
+        self.failed = failed
+        self.row_errors: list[Any] = []
+
+
+@pytest.fixture
+def patched_engine(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Patch the runtime helpers called inside ``_run_one`` so tests never
+    touch DuckDB, HTTP, the real destination classes, or the global
+    ``~/.drt/profiles.yml`` credentials file.
+    """
+
+    from drt.cli import main as cli_main
+    from drt.config import credentials as creds
+    from drt.engine import sync as sync_module
+
+    calls: list[str] = []
+    lock = threading.Lock()
+    threads_seen: set[int] = set()
+
+    def fake_run_sync(sync, *_args: Any, **_kwargs: Any) -> _FakeResult:
+        # Small delay guarantees ThreadPoolExecutor actually spreads work
+        # across workers when --threads > 1 (otherwise an idle-then-busy
+        # pattern can reuse a single worker for fast tasks).
+        time.sleep(0.05)
+        with lock:
+            calls.append(sync.name)
+            threads_seen.add(threading.get_ident())
+        return _FakeResult(success=1, failed=0)
+
+    def fake_load_profile(profile_name: str, *_a: Any, **_kw: Any) -> Any:
+        # Minimal stand-in so ``cli.main.run`` can proceed past credential
+        # resolution without a real ``~/.drt/profiles.yml``.
+        return creds.DuckDBProfile(type="duckdb")
+
+    # cli.main imports these symbols locally at call time, so we patch
+    # the source modules rather than the cli.main namespace.
+    monkeypatch.setattr(sync_module, "run_sync", fake_run_sync, raising=False)
+    monkeypatch.setattr(creds, "load_profile", fake_load_profile, raising=False)
+    monkeypatch.setattr(
+        cli_main,
+        "_get_source",
+        lambda *_a, **_kw: object(),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        cli_main,
+        "_get_destination",
+        lambda *_a, **_kw: object(),
+        raising=False,
+    )
+    return {"calls": calls, "threads_seen": threads_seen}
+
+
+# ---------------------------------------------------------------------------
+# --select filtering
+# ---------------------------------------------------------------------------
+
+
+def test_select_by_name_runs_single_sync(project: Path, patched_engine: dict[str, Any]) -> None:
+    result = runner.invoke(app, ["run", "--select", "sync_b", "--output", "json"])
+    assert result.exit_code == 0
+    assert patched_engine["calls"] == ["sync_b"]
+
+
+def test_select_by_tag_filters(project: Path, patched_engine: dict[str, Any]) -> None:
+    result = runner.invoke(app, ["run", "--select", "tag:crm", "--output", "json"])
+    assert result.exit_code == 0
+    assert set(patched_engine["calls"]) == {"sync_a", "sync_b"}
+
+
+def test_select_star_runs_every_sync(project: Path, patched_engine: dict[str, Any]) -> None:
+    result = runner.invoke(app, ["run", "--select", "*", "--output", "json"])
+    assert result.exit_code == 0
+    assert set(patched_engine["calls"]) == {"sync_a", "sync_b", "sync_c"}
+
+
+def test_select_all_sentinel_runs_every_sync(
+    project: Path, patched_engine: dict[str, Any]
+) -> None:
+    result = runner.invoke(app, ["run", "--select", "all", "--output", "json"])
+    assert result.exit_code == 0
+    assert set(patched_engine["calls"]) == {"sync_a", "sync_b", "sync_c"}
+
+
+def test_no_select_defaults_to_every_sync(
+    project: Path, patched_engine: dict[str, Any]
+) -> None:
+    result = runner.invoke(app, ["run", "--output", "json"])
+    assert result.exit_code == 0
+    assert set(patched_engine["calls"]) == {"sync_a", "sync_b", "sync_c"}
+
+
+def test_unknown_tag_exits_nonzero(project: Path, patched_engine: dict[str, Any]) -> None:
+    result = runner.invoke(app, ["run", "--select", "tag:does_not_exist", "--output", "json"])
+    assert result.exit_code == 1
+    assert patched_engine["calls"] == []
+
+
+def test_unknown_name_exits_nonzero(project: Path, patched_engine: dict[str, Any]) -> None:
+    result = runner.invoke(app, ["run", "--select", "no_such_sync", "--output", "json"])
+    assert result.exit_code == 1
+    assert patched_engine["calls"] == []
+
+
+def test_all_flag_was_removed(project: Path, patched_engine: dict[str, Any]) -> None:
+    """The legacy ``--all`` boolean was replaced by --select * / --select all."""
+    result = runner.invoke(app, ["run", "--all", "--output", "json"])
+    assert result.exit_code != 0
+    assert patched_engine["calls"] == []
+
+
+# ---------------------------------------------------------------------------
+# --threads — real parallel dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_threads_flag_actually_parallelises(
+    project: Path, patched_engine: dict[str, Any]
+) -> None:
+    result = runner.invoke(
+        app,
+        ["run", "--select", "*", "--threads", "3", "--output", "json"],
+    )
+    assert result.exit_code == 0
+    assert set(patched_engine["calls"]) == {"sync_a", "sync_b", "sync_c"}
+    # More than one OS thread should have handled the syncs when
+    # --threads > 1 and there are multiple syncs.
+    assert len(patched_engine["threads_seen"]) > 1
+
+
+def test_threads_one_runs_sequentially(
+    project: Path, patched_engine: dict[str, Any]
+) -> None:
+    result = runner.invoke(
+        app,
+        ["run", "--select", "*", "--threads", "1", "--output", "json"],
+    )
+    assert result.exit_code == 0
+    # Single-threaded path should use exactly one worker — the main one.
+    assert len(patched_engine["threads_seen"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# StateManager concurrency — load-modify-save must be atomic under threads
+# ---------------------------------------------------------------------------
+
+
+def test_state_manager_save_sync_is_thread_safe(tmp_path: Path) -> None:
+    """Concurrent save_sync writes for distinct syncs must all survive."""
+    mgr = StateManager(tmp_path)
+    sync_names = [f"sync_{i:03d}" for i in range(40)]
+    threads: list[threading.Thread] = []
+
+    def _write(name: str) -> None:
+        mgr.save_sync(
+            SyncState(
+                sync_name=name,
+                last_run_at="2024-01-01T00:00:00+00:00",
+                records_synced=1,
+                status="success",
+            )
+        )
+
+    for name in sync_names:
+        thread = threading.Thread(target=_write, args=(name,))
+        threads.append(thread)
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    persisted = mgr.get_all()
+    assert set(persisted.keys()) == set(sync_names)

--- a/tests/unit/test_dry_run_summary.py
+++ b/tests/unit/test_dry_run_summary.py
@@ -53,6 +53,10 @@ def test_run_dry_run_summary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
             self.skipped = 0
             self.errors = []
             self.row_errors = []
+            # Added by PR #345/#347 to SyncResult — keeping the fake in
+            # lockstep with the real shape so future refactors that read
+            # ``rows_extracted`` unconditionally don't fail this test.
+            self.rows_extracted = self.success
 
     def mock_run_sync(*args, **kwargs):
         return FakeResult()


### PR DESCRIPTION
## Summary

Closes #288. Adds multi-sync orchestration to `drt run`.

## Changes

**CLI (`drt/cli/main.py`):**
- `--all` flag for explicit "run everything" intent
- `--select tag:crm` filters syncs by the new `tags` field
- `--threads N` runs syncs in parallel via `ThreadPoolExecutor`
- Summary report after multi-sync runs: "N succeeded, M failed, Xs total"
- Non-zero exit if any sync fails

**Model (`drt/config/models.py`):**
- Added `tags: list[str]` to `SyncConfig` (default empty, backward compatible)

## Usage

```bash
# Run all syncs (existing behaviour, unchanged)
drt run

# Explicit --all
drt run --all

# Filter by tag
drt run --select tag:crm

# Parallel execution
drt run --threads 4

# Combined
drt run --select tag:crm --threads 2 --verbose
```

## YAML example

```yaml
name: sync_users
tags: [crm, daily]
model: ref('users')
destination:
  type: postgres
  ...
```

## Backward compatibility

- `tags` defaults to empty list — existing syncs without tags work unchanged
- Without `--select` or `--all`, behaviour is identical to before
- `--threads 1` (default) runs sequentially, same as before