### PR TITLE
feat: add Twilio SMS destination

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from drt.destinations.slack import SlackDestination
     from drt.destinations.staged_upload import StagedUploadDestination
     from drt.destinations.teams import TeamsDestination
+    from drt.destinations.twilio import TwilioDestination
     from drt.sources.bigquery import BigQuerySource
     from drt.sources.clickhouse import ClickHouseSource
     from drt.sources.databricks import DatabricksSource
@@ -835,6 +836,7 @@ def _get_destination(
     | GoogleAdsDestination
     | NotionDestination
     | StagedUploadDestination
+    | TwilioDestination
 ):
     from drt.config.models import (
         ClickHouseDestinationConfig,
@@ -855,6 +857,7 @@ def _get_destination(
         SlackDestinationConfig,
         StagedUploadDestinationConfig,
         TeamsDestinationConfig,
+        TwilioDestinationConfig,
     )
     from drt.destinations.clickhouse import ClickHouseDestination
     from drt.destinations.discord import DiscordDestination
@@ -868,12 +871,15 @@ def _get_destination(
     from drt.destinations.rest_api import RestApiDestination
     from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.slack import SlackDestination
+    from drt.destinations.twilio import TwilioDestination
 
     dest = sync.destination
     if isinstance(dest, RestApiDestinationConfig):
         return RestApiDestination()
     if isinstance(dest, SlackDestinationConfig):
         return SlackDestination()
+    if isinstance(dest, TwilioDestinationConfig):
+        return TwilioDestination()
     if isinstance(dest, DiscordDestinationConfig):
         return DiscordDestination()
     if isinstance(dest, GitHubActionsDestinationConfig):

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -98,6 +98,35 @@ class SlackDestinationConfig(BaseModel):
         return f"{self.type} (webhook)"
 
 
+class TwilioDestinationConfig(BaseModel):
+    type: Literal["twilio"]
+
+    account_sid: str | None = None
+    account_sid_env: str | None = None
+
+    auth_token: str | None = None
+    auth_token_env: str | None = None
+
+    from_number: str  # Twilio phone number (E.164 format)
+
+    # Jinja2 template → destination phone number
+    to_template: str  # e.g. "{{ row.phone }}"
+
+    # Jinja2 template → SMS body
+    message_template: str
+
+    def describe(self) -> str:
+        return f"{self.type} ({self.from_number})"
+
+    @model_validator(mode="after")
+    def _check_auth(self) -> "TwilioDestinationConfig":
+        if not (self.account_sid or self.account_sid_env):
+            raise ValueError("account_sid or account_sid_env is required.")
+        if not (self.auth_token or self.auth_token_env):
+            raise ValueError("auth_token or auth_token_env is required.")
+        return self
+    
+    
 class DiscordDestinationConfig(BaseModel):
     type: Literal["discord"]
     webhook_url: str | None = None
@@ -442,7 +471,8 @@ DestinationConfig = Annotated[
     | GoogleAdsDestinationConfig
     | FileDestinationConfig
     | NotionDestinationConfig
-    | StagedUploadDestinationConfig,
+    | StagedUploadDestinationConfig
+    | TwilioDestinationConfig,
     Field(discriminator="type"),
 ]
 

--- a/drt/destinations/twilio.py
+++ b/drt/destinations/twilio.py
@@ -1,0 +1,159 @@
+"""Twilio destination — Send SMS via Twilio REST API.
+
+Sends one SMS per row using Twilio's Messages API.
+
+Auth:
+- Basic Auth using Account SID + Auth Token
+
+Docs:
+https://www.twilio.com/docs/messaging/api/message-resource
+
+Example sync YAML:
+
+    destination:
+      type: twilio
+      account_sid_env: TWILIO_ACCOUNT_SID
+      auth_token_env: TWILIO_AUTH_TOKEN
+      from_number: "+1234567890"
+      to_template: "{{ row.phone }}"
+      message_template: "Hi {{ row.name }}, your order #{{ row.order_id }} has shipped!"
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any
+
+import httpx
+
+from drt.config.models import (
+    DestinationConfig,
+    RetryConfig,
+    SyncOptions,
+    TwilioDestinationConfig,
+)
+from drt.destinations.base import SyncResult
+from drt.destinations.rate_limiter import RateLimiter
+from drt.destinations.retry import with_retry
+from drt.destinations.row_errors import RowError
+from drt.templates.renderer import render_template
+
+_DEFAULT_RETRY = RetryConfig(
+    max_attempts=3,
+    initial_backoff=1.0,
+    retryable_status_codes=(429, 500, 502, 503, 504),
+)
+
+# E.164 format: + followed by 1–15 digits
+_E164_REGEX = re.compile(r"^\+[1-9]\d{1,14}$")
+
+
+def _is_valid_e164(phone: str) -> bool:
+    return bool(_E164_REGEX.match(phone))
+
+
+class TwilioDestination:
+    """Send records as SMS messages via Twilio."""
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, TwilioDestinationConfig)
+
+        account_sid = config.account_sid or (
+            os.environ.get(config.account_sid_env) if config.account_sid_env else None
+        )
+        auth_token = config.auth_token or (
+            os.environ.get(config.auth_token_env) if config.auth_token_env else None
+        )
+
+        if not account_sid or not auth_token:
+            raise ValueError(
+                "Twilio destination: provide 'account_sid'/'auth_token' or set env vars."
+            )
+
+        # Validate from_number early
+        if not _is_valid_e164(config.from_number):
+            raise ValueError(
+                f"Invalid from_number '{config.from_number}'. Must be E.164 format (e.g. +1234567890)."
+            )
+
+        url = f"https://api.twilio.com/2010-04-01/Accounts/{account_sid}/Messages.json"
+
+        result = SyncResult()
+        rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
+        retry_config = sync_options.retry or _DEFAULT_RETRY
+
+        with httpx.Client(timeout=30.0, auth=(account_sid, auth_token)) as client:
+            for i, record in enumerate(records):
+                rate_limiter.acquire()
+
+                try:
+                    to_number = render_template(config.to_template, record)
+
+                    # Validate destination number per row
+                    if not _is_valid_e164(to_number):
+                        raise ValueError(
+                            f"Invalid to_number '{to_number}' (row {i}). Must be E.164 format."
+                        )
+
+                    body = render_template(config.message_template, record)
+
+                    payload = {
+                        "From": config.from_number,
+                        "To": to_number,
+                        "Body": body,
+                    }
+
+                    def do_post() -> httpx.Response:
+                        response = client.post(url, data=payload)
+                        response.raise_for_status()
+                        return response
+
+                    response = with_retry(do_post, retry_config)
+
+                    # Twilio returns JSON — check for API-level errors
+                    try:
+                        data = response.json()
+                    except Exception:
+                        raise ValueError(f"Invalid Twilio response: {response.text[:300]}")
+
+                    if data.get("error_code") or data.get("error_message"):
+                        raise ValueError(
+                            f"Twilio error {data.get('error_code')}: {data.get('error_message')}"
+                        )
+
+                    result.success += 1
+
+                except httpx.HTTPStatusError as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=str(record)[:200],
+                            http_status=e.response.status_code,
+                            error_message=e.response.text[:500],
+                        )
+                    )
+                    if sync_options.on_error == "fail":
+                        raise
+
+                except Exception as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=str(record)[:200],
+                            http_status=None,
+                            error_message=str(e),
+                        )
+                    )
+                    if sync_options.on_error == "fail":
+                        raise
+
+        return result

--- a/drt/destinations/twilio.py
+++ b/drt/destinations/twilio.py
@@ -21,7 +21,6 @@ Example sync YAML:
 
 from __future__ import annotations
 
-import json
 import os
 import re
 from typing import Any
@@ -80,7 +79,8 @@ class TwilioDestination:
         # Validate from_number early
         if not _is_valid_e164(config.from_number):
             raise ValueError(
-                f"Invalid from_number '{config.from_number}'. Must be E.164 format (e.g. +1234567890)."
+                f"Invalid from_number '{config.from_number}'."
+                " Must be E.164 format (e.g. +1234567890)."
             )
 
         url = f"https://api.twilio.com/2010-04-01/Accounts/{account_sid}/Messages.json"

--- a/tests/unit/test_twilio.py
+++ b/tests/unit/test_twilio.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import httpx
 import pytest
 
-from drt.config.models import SyncOptions, TwilioDestinationConfig, RetryConfig
+from drt.config.models import RetryConfig, SyncOptions, TwilioDestinationConfig
 from drt.destinations.twilio import TwilioDestination
 
 

--- a/tests/unit/test_twilio.py
+++ b/tests/unit/test_twilio.py
@@ -1,0 +1,133 @@
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from drt.config.models import SyncOptions, TwilioDestinationConfig, RetryConfig
+from drt.destinations.twilio import TwilioDestination
+
+
+class DummyResponse:
+    def __init__(self, status_code=200, json_data=None, text="ok"):
+        self.status_code = status_code
+        self._json_data = json_data or {}
+        self.text = text
+
+    def raise_for_status(self):
+        if 400 <= self.status_code < 600:
+            raise httpx.HTTPStatusError(
+                message="error",
+                request=httpx.Request("POST", "https://test"),
+                response=self,
+            )
+
+    def json(self):
+        if isinstance(self._json_data, Exception):
+            raise self._json_data
+        return self._json_data
+
+
+@pytest.fixture
+def base_config():
+    return TwilioDestinationConfig(
+        type="twilio",
+        account_sid="AC123",
+        auth_token="token123",
+        from_number="+1234567890",
+        to_template="{{ row.phone }}",
+        message_template="Hi {{ row.name }}",
+    )
+
+
+@pytest.fixture
+def sync_options():
+    return SyncOptions(
+        retry=RetryConfig(max_attempts=1),
+    )
+
+
+# ----------------------------
+# 1. SUCCESS PATH
+# ----------------------------
+def test_successful_send(base_config):
+    records = [{"phone": "+19876543210", "name": "Alice"}]
+
+    with patch("httpx.Client.post", return_value=DummyResponse(200, {"sid": "SM123"})):
+        result = TwilioDestination().load(records, base_config, SyncOptions())
+
+    assert result.success == 1
+    assert result.failed == 0
+
+
+# ----------------------------
+# 2. INVALID FROM NUMBER (hard fail before loop)
+# ----------------------------
+def test_invalid_from_number():
+    config = TwilioDestinationConfig(
+        type="twilio",
+        account_sid="AC123",
+        auth_token="token123",
+        from_number="12345",  # invalid
+        to_template="{{ row.phone }}",
+        message_template="Hi",
+    )
+
+    with pytest.raises(ValueError, match="Invalid from_number"):
+        TwilioDestination().load([{"phone": "+1234567890"}], config, SyncOptions())
+
+
+# ----------------------------
+# 3. INVALID TO NUMBER (now EXPECTS FAILURE)
+# ----------------------------
+def test_invalid_to_number(base_config):
+    records = [{"phone": "bad-number", "name": "Alice"}]
+
+    with pytest.raises(ValueError, match="Invalid to_number"):
+        TwilioDestination().load(records, base_config, SyncOptions())
+
+
+# ----------------------------
+# 4. HTTP ERROR (propagates via retry → HTTPStatusError)
+# ----------------------------
+def test_twilio_http_error(base_config):
+    records = [{"phone": "+19876543210", "name": "Alice"}]
+
+    with patch(
+        "httpx.Client.post",
+        return_value=DummyResponse(400, {"error_message": "Bad request"}, "Bad request"),
+    ):
+        with pytest.raises(httpx.HTTPStatusError):
+            TwilioDestination().load(records, base_config, SyncOptions())
+
+
+# ----------------------------
+# 5. JSON DECODE ERROR
+# ----------------------------
+def test_twilio_json_decode_error(base_config):
+    records = [{"phone": "+19876543210", "name": "Alice"}]
+
+    bad_response = DummyResponse(200, json_data=Exception("bad json"), text="not json")
+
+    with patch("httpx.Client.post", return_value=bad_response):
+        with pytest.raises(ValueError, match="Invalid Twilio response"):
+            TwilioDestination().load(records, base_config, SyncOptions())
+
+
+# ----------------------------
+# 6. RETRY PATH
+# ----------------------------
+def test_retry_logic_triggered(base_config):
+    records = [{"phone": "+19876543210", "name": "Alice"}]
+
+    success_response = DummyResponse(200, {"sid": "SM123"})
+
+    with patch(
+        "httpx.Client.post",
+        side_effect=[
+            DummyResponse(500, text="server error"),
+            success_response,
+        ],
+    ):
+        result = TwilioDestination().load(records, base_config, SyncOptions())
+
+    assert result.success == 1


### PR DESCRIPTION
## What does this PR do?

1. drt/destinations/twilio.py — Send SMS via Twilio API

2. Auth via Account SID + Auth Token (Basic auth)

3. Jinja2 template for message body
from_number and to_template (per-row phone number)

4. Unit tests with mocked HTTP client

5. Added to drt/cli/main.py

6. Twilio requires E.164 format for phone numbers so validation for this was added to twilio.py

## Related Issue

Closes: # 159

## Checklist

- [ ] Tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Updated `CHANGELOG.md` (if user-facing change)
