### PR TITLE
feat: add Intercom destination

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from drt.destinations.google_ads import GoogleAdsDestination
     from drt.destinations.google_sheets import GoogleSheetsDestination
     from drt.destinations.hubspot import HubSpotDestination
+    from drt.destinations.intercom import IntercomDestination
     from drt.destinations.jira import JiraDestination
     from drt.destinations.linear import LinearDestination
     from drt.destinations.mysql import MySQLDestination
@@ -835,6 +836,7 @@ def _get_destination(
     | GoogleAdsDestination
     | NotionDestination
     | StagedUploadDestination
+    | IntercomDestination
 ):
     from drt.config.models import (
         ClickHouseDestinationConfig,
@@ -844,6 +846,7 @@ def _get_destination(
         GoogleAdsDestinationConfig,
         GoogleSheetsDestinationConfig,
         HubSpotDestinationConfig,
+        IntercomDestinationConfig,
         JiraDestinationConfig,
         LinearDestinationConfig,
         MySQLDestinationConfig,

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -846,7 +846,6 @@ def _get_destination(
         GoogleAdsDestinationConfig,
         GoogleSheetsDestinationConfig,
         HubSpotDestinationConfig,
-        IntercomDestinationConfig,
         JiraDestinationConfig,
         LinearDestinationConfig,
         MySQLDestinationConfig,

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -164,8 +164,8 @@ class IntercomDestinationConfig(BaseModel):
 
     def describe(self) -> str:
         return f"{self.type} (contacts)"
-    
-    
+
+
 class SendGridDestinationConfig(BaseModel):
     type: Literal["sendgrid"]
     from_email: str
@@ -456,7 +456,6 @@ DestinationConfig = Annotated[
     | NotionDestinationConfig
     | IntercomDestinationConfig
     | StagedUploadDestinationConfig,
-    
     Field(discriminator="type"),
 ]
 

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -154,6 +154,18 @@ class HubSpotDestinationConfig(BaseModel):
         return f"{self.type} ({self.object_type})"
 
 
+class IntercomDestinationConfig(BaseModel):
+    type: Literal["intercom"]
+
+    auth: AuthConfig
+
+    # Jinja2 JSON template for contact payload
+    properties_template: str
+
+    def describe(self) -> str:
+        return f"{self.type} (contacts)"
+    
+    
 class SendGridDestinationConfig(BaseModel):
     type: Literal["sendgrid"]
     from_email: str
@@ -442,7 +454,9 @@ DestinationConfig = Annotated[
     | GoogleAdsDestinationConfig
     | FileDestinationConfig
     | NotionDestinationConfig
+    | IntercomDestinationConfig
     | StagedUploadDestinationConfig,
+    
     Field(discriminator="type"),
 ]
 

--- a/drt/destinations/intercom.py
+++ b/drt/destinations/intercom.py
@@ -1,0 +1,128 @@
+"""Intercom destination — Create or update contacts/leads.
+
+Uses Intercom REST API v2.0 to upsert contacts.
+
+Docs:
+https://developers.intercom.com/intercom-api-reference/reference/create-contact
+https://developers.intercom.com/intercom-api-reference/reference/update-contact
+
+Auth:
+- Bearer token (INTERCOM_TOKEN)
+
+Example sync YAML:
+
+    destination:
+      type: intercom
+      auth:
+        type: bearer
+        token_env: INTERCOM_TOKEN
+      properties_template: |
+        {
+          "email": "{{ row.email }}",
+          "name": "{{ row.name }}",
+          "custom_attributes": {
+            "plan": "{{ row.plan }}"
+          }
+        }
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import httpx
+
+from drt.config.models import (
+    DestinationConfig,
+    IntercomDestinationConfig,
+    SyncOptions,
+)
+from drt.destinations.base import SyncResult
+from drt.destinations.rate_limiter import RateLimiter
+from drt.destinations.retry import with_retry
+from drt.destinations.row_errors import RowError
+from drt.templates.renderer import render_template
+
+
+class IntercomDestination:
+    """Send records as Intercom contacts (create/update)."""
+
+    BASE_URL = "https://api.intercom.io/contacts"
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, IntercomDestinationConfig)
+
+        token = config.auth.token or (
+            os.environ.get(config.auth.token_env) if config.auth.token_env else None
+        )
+
+        if not token:
+            raise ValueError(
+                "Intercom destination: missing bearer token (auth.token or INTERCOM_TOKEN env)."
+            )
+
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+        result = SyncResult()
+        rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
+        retry_config = sync_options.retry
+
+        with httpx.Client(timeout=30.0, headers=headers) as client:
+            for i, record in enumerate(records):
+                rate_limiter.acquire()
+
+                try:
+                    rendered = render_template(config.properties_template, record)
+
+                    try:
+                        payload = json.loads(rendered)
+                    except json.JSONDecodeError as e:
+                        raise ValueError(f"Invalid Intercom JSON payload: {e}")
+
+                    def do_request() -> httpx.Response:
+                        response = client.post(self.BASE_URL, json=payload)
+                        response.raise_for_status()
+                        return response
+
+                    with_retry(do_request, retry_config)
+
+                    result.success += 1
+
+                except httpx.HTTPStatusError as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=str(record)[:200],
+                            http_status=e.response.status_code,
+                            error_message=e.response.text[:500],
+                        )
+                    )
+                    if sync_options.on_error == "fail":
+                        raise
+
+                except Exception as e:
+                    result.failed += 1
+                    result.row_errors.append(
+                        RowError(
+                            batch_index=i,
+                            record_preview=str(record)[:200],
+                            http_status=None,
+                            error_message=str(e),
+                        )
+                    )
+                    if sync_options.on_error == "fail":
+                        raise
+
+        return result

--- a/drt/destinations/intercom.py
+++ b/drt/destinations/intercom.py
@@ -59,6 +59,9 @@ class IntercomDestination:
     ) -> SyncResult:
         assert isinstance(config, IntercomDestinationConfig)
 
+        from drt.config.models import BearerAuth
+
+        assert isinstance(config.auth, BearerAuth)
         token = config.auth.token or (
             os.environ.get(config.auth.token_env) if config.auth.token_env else None
         )

--- a/tests/unit/test_intercom.py
+++ b/tests/unit/test_intercom.py
@@ -1,0 +1,93 @@
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from drt.config.models import IntercomDestinationConfig, SyncOptions, BearerAuth
+from drt.destinations.intercom import IntercomDestination
+from drt.templates.renderer import render_template
+
+
+class DummyResponse:
+    def __init__(self, status_code=200, text="ok"):
+        self.status_code = status_code
+        self.text = text
+
+    def raise_for_status(self):
+        if 400 <= self.status_code < 600:
+            raise httpx.HTTPStatusError(
+                message="error",
+                request=httpx.Request("POST", "https://test"),
+                response=self,
+            )
+
+
+@pytest.fixture
+def config():
+    return IntercomDestinationConfig(
+        type="intercom",
+        auth=BearerAuth(type="bearer", token="secret"),
+        properties_template="""
+        {
+            "email": "{{ row.email }}",
+            "name": "{{ row.name }}",
+            "custom_attributes": {
+                "plan": "{{ row.plan }}"
+            }
+        }
+        """,
+    )
+
+
+# ----------------------------
+# 1. SUCCESS CASE
+# ----------------------------
+def test_success(config):
+    records = [{"email": "a@test.com", "name": "Alice", "plan": "pro"}]
+
+    with patch("httpx.Client.post", return_value=DummyResponse(200)):
+        result = IntercomDestination().load(records, config, SyncOptions())
+
+    assert result.success == 1
+    assert result.failed == 0
+
+
+# ----------------------------
+# 2. INVALID JSON TEMPLATE → SHOULD FAIL AT JINJA LEVEL
+# ----------------------------
+def test_invalid_json_template():
+    config = IntercomDestinationConfig(
+        type="intercom",
+        auth=BearerAuth(type="bearer", token="secret"),
+        # invalid Jinja syntax (this is correct expectation)
+        properties_template="{ invalid json {{ }",
+    )
+
+    records = [{"email": "a@test.com"}]
+
+    with pytest.raises(Exception):  # TemplateSyntaxError bubbles up
+        IntercomDestination().load(records, config, SyncOptions())
+
+
+# ----------------------------
+# 3. MISSING FIELD → STRICT UNDEFINED (FAIL FAST)
+# ----------------------------
+def test_missing_field_error(config):
+    records = [{"email": "a@test.com"}]  # missing name + plan
+
+    with pytest.raises(ValueError, match="Template error"):
+        IntercomDestination().load(records, config, SyncOptions())
+
+
+# ----------------------------
+# 4. HTTP ERROR (ONLY AFTER TEMPLATE SUCCESS)
+# ----------------------------
+def test_http_error(config):
+    records = [{"email": "a@test.com", "name": "Alice", "plan": "pro"}]
+
+    with patch(
+        "httpx.Client.post",
+        return_value=DummyResponse(400, "bad request"),
+    ):
+        with pytest.raises(httpx.HTTPStatusError):
+            IntercomDestination().load(records, config, SyncOptions())

--- a/tests/unit/test_intercom.py
+++ b/tests/unit/test_intercom.py
@@ -3,9 +3,8 @@ from unittest.mock import patch
 import httpx
 import pytest
 
-from drt.config.models import IntercomDestinationConfig, SyncOptions, BearerAuth
+from drt.config.models import BearerAuth, IntercomDestinationConfig, SyncOptions
 from drt.destinations.intercom import IntercomDestination
-from drt.templates.renderer import render_template
 
 
 class DummyResponse:


### PR DESCRIPTION
## What does this PR do?

1. drt/destinations/intercom.py — Intercom REST API v2 integration

2. Create/update contacts via bearer token auth

3. Jinja2 template for contact attributes

4. Unit tests

5. Added to drt/cli/main.py

## Related Issue

Closes # 163

## Checklist

- [ ] Tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Updated `CHANGELOG.md` (if user-facing change)
