### PR TITLE
feat: add Snowflake destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Sync failure alerts** (#414): Configure `alerts.on_failure` in sync YAML to send Slack or generic HTTP webhook notifications when a sync ends with `failed > 0` or raises an exception. Two target types in v0.7: `slack` (Slack incoming webhook) and `webhook` (generic HTTP POST/PUT with optional `body_template`). Template variables: `sync_name`, `error`, `rows_processed`, `duration_s`, `started_at`. Dispatch is best-effort — alert failures are logged but never affect sync correctness or override the original exception.
+- **Snowflake destination** (#353): Write rows back to Snowflake tables. Supports `mode: insert` (append) and `mode: merge` (upsert via temp staging table + `MERGE` statement using `upsert_key`). Auth via `account_env` / `user_env` / `password_env`. Install: `pip install drt-core[snowflake]`. Contributed by @PFCAaron12.
 
 ### Changed
 

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from drt.destinations.rest_api import RestApiDestination
     from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.slack import SlackDestination
+    from drt.destinations.snowflake import SnowflakeDestination
     from drt.destinations.staged_upload import StagedUploadDestination
     from drt.destinations.teams import TeamsDestination
     from drt.sources.bigquery import BigQuerySource
@@ -835,6 +836,7 @@ def _get_destination(
     | GoogleAdsDestination
     | NotionDestination
     | StagedUploadDestination
+    | SnowflakeDestination
 ):
     from drt.config.models import (
         ClickHouseDestinationConfig,
@@ -853,6 +855,7 @@ def _get_destination(
         RestApiDestinationConfig,
         SendGridDestinationConfig,
         SlackDestinationConfig,
+        SnowflakeDestinationConfig,
         StagedUploadDestinationConfig,
         TeamsDestinationConfig,
     )
@@ -868,6 +871,7 @@ def _get_destination(
     from drt.destinations.rest_api import RestApiDestination
     from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.slack import SlackDestination
+    from drt.destinations.snowflake import SnowflakeDestination
 
     dest = sync.destination
     if isinstance(dest, RestApiDestinationConfig):
@@ -884,6 +888,8 @@ def _get_destination(
         return JiraDestination()
     if isinstance(dest, SendGridDestinationConfig):
         return SendGridDestination()
+    if isinstance(dest, SnowflakeDestinationConfig):
+        return SnowflakeDestination()
     if isinstance(dest, GoogleSheetsDestinationConfig):
         from drt.destinations.google_sheets import GoogleSheetsDestination
 

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -168,6 +168,27 @@ class SendGridDestinationConfig(BaseModel):
         return f"sendgrid ({self.from_email})"
 
 
+class SnowflakeDestinationConfig(BaseModel):
+    type: Literal["snowflake"]
+
+    account_env: str
+    user_env: str
+    password_env: str
+
+    database: str
+    schema: str
+    table: str
+
+    warehouse: str
+
+    mode: Literal["insert", "merge"] = "insert"
+
+    upsert_key: list[str] | None = None
+
+    def describe(self) -> str:
+        return f"{self.type} ({self.database}.{self.schema}.{self.table})"
+    
+    
 class LinearDestinationConfig(BaseModel):
     type: Literal["linear"]
     team_id: str | None = None
@@ -442,7 +463,8 @@ DestinationConfig = Annotated[
     | GoogleAdsDestinationConfig
     | FileDestinationConfig
     | NotionDestinationConfig
-    | StagedUploadDestinationConfig,
+    | StagedUploadDestinationConfig
+    | SnowflakeDestinationConfig,
     Field(discriminator="type"),
 ]
 

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -243,6 +243,29 @@ class SendGridDestinationConfig(BaseModel):
         return f"sendgrid ({self.from_email})"
 
 
+class SnowflakeDestinationConfig(BaseModel):
+    type: Literal["snowflake"]
+
+    account_env: str
+    user_env: str
+    password_env: str
+
+    database: str
+    # Use alias because BaseModel.schema() shadows a plain `schema` attribute
+    # under mypy strict mode; YAML key stays `schema:`.
+    schema_: str = Field(alias="schema")
+    table: str
+
+    warehouse: str
+
+    mode: Literal["insert", "merge"] = "insert"
+
+    upsert_key: list[str] | None = None
+
+    def describe(self) -> str:
+        return f"{self.type} ({self.database}.{self.schema_}.{self.table})"
+    
+    
 class LinearDestinationConfig(BaseModel):
     type: Literal["linear"]
     team_id: str | None = None
@@ -563,7 +586,8 @@ DestinationConfig = Annotated[
     | IntercomDestinationConfig
     | StagedUploadDestinationConfig
     | SalesforceBulkDestinationConfig
-    | TwilioDestinationConfig,
+    | TwilioDestinationConfig
+    | SnowflakeDestinationConfig,
     Field(discriminator="type"),
 ]
 

--- a/drt/connectors/registry.py
+++ b/drt/connectors/registry.py
@@ -159,6 +159,7 @@ def _register_all_connectors() -> None:
         SalesforceBulkDestinationConfig,
         SendGridDestinationConfig,
         SlackDestinationConfig,
+        SnowflakeDestinationConfig,
         StagedUploadDestinationConfig,
         TeamsDestinationConfig,
         TwilioDestinationConfig,
@@ -184,6 +185,7 @@ def _register_all_connectors() -> None:
     from drt.destinations.salesforce_bulk import SalesforceBulkDestination
     from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.slack import SlackDestination
+    from drt.destinations.snowflake import SnowflakeDestination
     from drt.destinations.staged_upload import StagedUploadDestination
     from drt.destinations.teams import TeamsDestination
     from drt.destinations.twilio import TwilioDestination
@@ -225,6 +227,7 @@ def _register_all_connectors() -> None:
     )
     register_destination("staged_upload", StagedUploadDestinationConfig, StagedUploadDestination)
     register_destination("intercom", IntercomDestinationConfig, IntercomDestination)
+    register_destination("snowflake", SnowflakeDestinationConfig, SnowflakeDestination)
 
     # Register all sources
     register_source("bigquery", BigQueryProfile, BigQuerySource)

--- a/drt/destinations/snowflake.py
+++ b/drt/destinations/snowflake.py
@@ -1,0 +1,129 @@
+"""Snowflake destination — write data back to Snowflake tables.
+
+Supports:
+- INSERT (append)
+- MERGE (upsert using key columns)
+
+Install: snowflake-connector-python.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import snowflake.connector
+
+from drt.config.models import DestinationConfig, SnowflakeDestinationConfig, SyncOptions
+from drt.destinations.base import SyncResult
+from drt.destinations.row_errors import RowError
+
+
+class SnowflakeDestination:
+    """Write records into Snowflake tables."""
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, SnowflakeDestinationConfig)
+
+        account = os.environ.get(config.account_env)
+        user = os.environ.get(config.user_env)
+        password = os.environ.get(config.password_env)
+
+        if not account or not user or not password:
+            raise ValueError("Missing Snowflake credentials in environment variables.")
+
+        conn = snowflake.connector.connect(
+            account=account,
+            user=user,
+            password=password,
+            warehouse=config.warehouse,
+            database=config.database,
+            schema=config.schema,
+        )
+
+        result = SyncResult()
+
+        try:
+            with conn.cursor() as cur:
+                columns = list(records[0].keys())
+                col_list = ", ".join(columns)
+
+                placeholders = ", ".join(["%s"] * len(columns))
+
+                table_fq = f"{config.database}.{config.schema}.{config.table}"
+
+                if config.mode == "insert":
+                    sql = f"""
+                        INSERT INTO {table_fq} ({col_list})
+                        VALUES ({placeholders})
+                    """
+
+                    for i, row in enumerate(records):
+                        try:
+                            cur.execute(sql, list(row.values()))
+                            result.success += 1
+                        except Exception as e:
+                            result.failed += 1
+                            result.row_errors.append(
+                                RowError(
+                                    batch_index=i,
+                                    record_preview=str(row)[:200],
+                                    http_status=None,
+                                    error_message=str(e),
+                                )
+                            )
+                            if sync_options.on_error == "fail":
+                                raise
+
+                elif config.mode == "merge":
+                    if not config.upsert_key:
+                        raise ValueError("upsert_key is required for merge mode")
+
+                    key_clause = " AND ".join(
+                        [f"target.{k} = source.{k}" for k in config.upsert_key]
+                    )
+
+                    update_clause = ", ".join(
+                        [f"{c} = source.{c}" for c in columns if c not in config.upsert_key]
+                    )
+
+                    insert_cols = col_list
+                    insert_vals = ", ".join([f"source.{c}" for c in columns])
+
+                    staging_table = f"TMP_{config.table.upper()}"
+
+                    cur.execute(f"CREATE TEMP TABLE {staging_table} LIKE {table_fq}")
+
+                    for row in records:
+                        cur.execute(
+                            f"""
+                            INSERT INTO {staging_table} ({col_list})
+                            VALUES ({placeholders})
+                            """,
+                            list(row.values()),
+                        )
+
+                    merge_sql = f"""
+                        MERGE INTO {table_fq} target
+                        USING {staging_table} source
+                        ON {key_clause}
+                        WHEN MATCHED THEN UPDATE SET {update_clause}
+                        WHEN NOT MATCHED THEN INSERT ({insert_cols})
+                        VALUES ({insert_vals})
+                    """
+
+                    cur.execute(merge_sql)
+                    result.success += len(records)
+
+                else:
+                    raise ValueError(f"Unsupported mode: {config.mode}")
+
+        finally:
+            conn.close()
+
+        return result

--- a/drt/destinations/snowflake.py
+++ b/drt/destinations/snowflake.py
@@ -1,0 +1,131 @@
+"""Snowflake destination — write data back to Snowflake tables.
+
+Supports:
+- INSERT (append)
+- MERGE (upsert using key columns)
+
+Install: snowflake-connector-python.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import snowflake.connector
+
+from drt.config.models import DestinationConfig, SnowflakeDestinationConfig, SyncOptions
+from drt.destinations.base import SyncResult
+from drt.destinations.row_errors import RowError
+
+
+class SnowflakeDestination:
+    """Write records into Snowflake tables."""
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, SnowflakeDestinationConfig)
+        if not records:
+            return SyncResult()
+
+        account = os.environ.get(config.account_env)
+        user = os.environ.get(config.user_env)
+        password = os.environ.get(config.password_env)
+
+        if not account or not user or not password:
+            raise ValueError("Missing Snowflake credentials in environment variables.")
+
+        conn = snowflake.connector.connect(
+            account=account,
+            user=user,
+            password=password,
+            warehouse=config.warehouse,
+            database=config.database,
+            schema=config.schema_,
+        )
+
+        result = SyncResult()
+
+        try:
+            with conn.cursor() as cur:
+                columns = list(records[0].keys())
+                col_list = ", ".join(columns)
+
+                placeholders = ", ".join(["%s"] * len(columns))
+
+                table_fq = f"{config.database}.{config.schema_}.{config.table}"
+
+                if config.mode == "insert":
+                    sql = f"""
+                        INSERT INTO {table_fq} ({col_list})
+                        VALUES ({placeholders})
+                    """
+
+                    for i, row in enumerate(records):
+                        try:
+                            cur.execute(sql, list(row.values()))
+                            result.success += 1
+                        except Exception as e:
+                            result.failed += 1
+                            result.row_errors.append(
+                                RowError(
+                                    batch_index=i,
+                                    record_preview=str(row)[:200],
+                                    http_status=None,
+                                    error_message=str(e),
+                                )
+                            )
+                            if sync_options.on_error == "fail":
+                                raise
+
+                elif config.mode == "merge":
+                    if not config.upsert_key:
+                        raise ValueError("upsert_key is required for merge mode")
+
+                    key_clause = " AND ".join(
+                        [f"target.{k} = source.{k}" for k in config.upsert_key]
+                    )
+
+                    update_clause = ", ".join(
+                        [f"{c} = source.{c}" for c in columns if c not in config.upsert_key]
+                    )
+
+                    insert_cols = col_list
+                    insert_vals = ", ".join([f"source.{c}" for c in columns])
+
+                    staging_table = f"TMP_{config.table.upper()}"
+
+                    cur.execute(f"CREATE TEMP TABLE {staging_table} LIKE {table_fq}")
+
+                    for row in records:
+                        cur.execute(
+                            f"""
+                            INSERT INTO {staging_table} ({col_list})
+                            VALUES ({placeholders})
+                            """,
+                            list(row.values()),
+                        )
+
+                    merge_sql = f"""
+                        MERGE INTO {table_fq} target
+                        USING {staging_table} source
+                        ON {key_clause}
+                        WHEN MATCHED THEN UPDATE SET {update_clause}
+                        WHEN NOT MATCHED THEN INSERT ({insert_cols})
+                        VALUES ({insert_vals})
+                    """
+
+                    cur.execute(merge_sql)
+                    result.success += len(records)
+
+                else:
+                    raise ValueError(f"Unsupported mode: {config.mode}")
+
+        finally:
+            conn.close()
+
+        return result

--- a/drt/destinations/snowflake.py
+++ b/drt/destinations/snowflake.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 import os
 from typing import Any
 
-import snowflake.connector
-
 from drt.config.models import DestinationConfig, SnowflakeDestinationConfig, SyncOptions
 from drt.destinations.base import SyncResult
 from drt.destinations.row_errors import RowError
@@ -31,6 +29,13 @@ class SnowflakeDestination:
         assert isinstance(config, SnowflakeDestinationConfig)
         if not records:
             return SyncResult()
+
+        try:
+            import snowflake.connector
+        except ImportError as e:
+            raise ImportError(
+                "Snowflake destination requires: pip install drt-core[snowflake]"
+            ) from e
 
         account = os.environ.get(config.account_env)
         user = os.environ.get(config.user_env)

--- a/tests/unit/test_snowflake_destination.py
+++ b/tests/unit/test_snowflake_destination.py
@@ -1,0 +1,201 @@
+"""Unit tests for Snowflake destination.
+
+Uses sys.modules injection to mock snowflake.connector — no real Snowflake
+account or snowflake-connector-python install required (matches the pattern
+in test_snowflake.py for the source-side connector).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from drt.config.models import SnowflakeDestinationConfig, SyncOptions
+from drt.destinations.snowflake import SnowflakeDestination
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _options(**kwargs: Any) -> SyncOptions:
+    return SyncOptions(**kwargs)
+
+
+def _config(**overrides: Any) -> SnowflakeDestinationConfig:
+    defaults: dict[str, Any] = {
+        "type": "snowflake",
+        "account_env": "SF_ACCOUNT",
+        "user_env": "SF_USER",
+        "password_env": "SF_PASSWORD",
+        "database": "ANALYTICS",
+        "schema": "PUBLIC",  # alias form — populated into schema_ on the model
+        "table": "USER_SCORES",
+        "warehouse": "COMPUTE_WH",
+    }
+    defaults.update(overrides)
+    return SnowflakeDestinationConfig.model_validate(defaults)
+
+
+def _set_creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SF_ACCOUNT", "acct.us-east-1")
+    monkeypatch.setenv("SF_USER", "test_user")
+    monkeypatch.setenv("SF_PASSWORD", "test_pass")
+
+
+def _fake_conn() -> MagicMock:
+    """Fake snowflake.connector connection with a context-managed cursor."""
+    conn = MagicMock()
+    cur = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+    conn.cursor.return_value.__exit__.return_value = False
+    conn._cur = cur  # for assertions
+    return conn
+
+
+def _mocked_snowflake_modules(conn: MagicMock | None = None) -> dict[str, MagicMock]:
+    """Build sys.modules entries that satisfy `import snowflake.connector`."""
+    mock_module = MagicMock()
+    mock_connector = MagicMock()
+    if conn is not None:
+        mock_connector.connect.return_value = conn
+    mock_module.connector = mock_connector
+    return {"snowflake": mock_module, "snowflake.connector": mock_connector}
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestSnowflakeDestinationConfig:
+    def test_valid_config(self) -> None:
+        config = _config()
+        assert config.database == "ANALYTICS"
+        assert config.schema_ == "PUBLIC"
+        assert config.table == "USER_SCORES"
+        assert config.mode == "insert"
+
+    def test_yaml_uses_schema_alias(self) -> None:
+        """YAML key `schema:` populates the `schema_` field (mypy-strict workaround)."""
+        config = SnowflakeDestinationConfig.model_validate(
+            {
+                "type": "snowflake",
+                "account_env": "SF_ACCOUNT",
+                "user_env": "SF_USER",
+                "password_env": "SF_PASSWORD",
+                "database": "DB",
+                "schema": "SCH",
+                "table": "T",
+                "warehouse": "WH",
+            }
+        )
+        assert config.schema_ == "SCH"
+
+    def test_describe_uses_schema(self) -> None:
+        assert _config().describe() == "snowflake (ANALYTICS.PUBLIC.USER_SCORES)"
+
+
+# ---------------------------------------------------------------------------
+# Load behavior
+# ---------------------------------------------------------------------------
+
+
+class TestSnowflakeDestinationLoad:
+    def test_empty_records_short_circuits_before_import(self) -> None:
+        """No records → returns early before even attempting the snowflake import."""
+        # No sys.modules patch; if load() reached the import it would raise.
+        result = SnowflakeDestination().load([], _config(), _options())
+        assert result.success == 0
+        assert result.failed == 0
+
+    def test_missing_credentials_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("SF_ACCOUNT", raising=False)
+        monkeypatch.delenv("SF_USER", raising=False)
+        monkeypatch.delenv("SF_PASSWORD", raising=False)
+        with patch.dict("sys.modules", _mocked_snowflake_modules()):
+            with pytest.raises(ValueError, match="Missing Snowflake credentials"):
+                SnowflakeDestination().load([{"id": 1}], _config(), _options())
+
+    def test_import_error_when_extras_missing(self) -> None:
+        with patch("builtins.__import__", side_effect=ImportError):
+            with pytest.raises(ImportError, match="drt-core\\[snowflake\\]"):
+                SnowflakeDestination().load([{"id": 1}], _config(), _options())
+
+    def test_insert_mode_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_creds(monkeypatch)
+        conn = _fake_conn()
+        modules = _mocked_snowflake_modules(conn)
+
+        records = [
+            {"id": 1, "score": 0.95},
+            {"id": 2, "score": 0.80},
+        ]
+        with patch.dict("sys.modules", modules):
+            result = SnowflakeDestination().load(records, _config(), _options())
+
+        assert result.success == 2
+        assert result.failed == 0
+        cur = conn._cur
+        assert cur.execute.call_count == 2
+        first_sql = cur.execute.call_args_list[0][0][0]
+        assert "INSERT INTO ANALYTICS.PUBLIC.USER_SCORES" in first_sql
+        assert "id, score" in first_sql
+        conn.close.assert_called_once()
+
+    def test_merge_mode_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_creds(monkeypatch)
+        conn = _fake_conn()
+        modules = _mocked_snowflake_modules(conn)
+
+        records = [
+            {"id": 1, "score": 0.95},
+            {"id": 2, "score": 0.80},
+        ]
+        config = _config(mode="merge", upsert_key=["id"])
+        with patch.dict("sys.modules", modules):
+            result = SnowflakeDestination().load(records, config, _options())
+
+        assert result.success == 2
+        sqls = [
+            (call.args[0] if call.args else "")
+            for call in conn._cur.execute.call_args_list
+        ]
+        assert any("CREATE TEMP TABLE" in s for s in sqls)
+        assert any("MERGE INTO ANALYTICS.PUBLIC.USER_SCORES" in s for s in sqls)
+        assert any("WHEN MATCHED THEN UPDATE" in s for s in sqls)
+
+    def test_merge_mode_requires_upsert_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_creds(monkeypatch)
+        modules = _mocked_snowflake_modules(_fake_conn())
+        config = _config(mode="merge", upsert_key=None)
+        with patch.dict("sys.modules", modules):
+            with pytest.raises(ValueError, match="upsert_key is required"):
+                SnowflakeDestination().load([{"id": 1}], config, _options())
+
+    def test_insert_row_error_on_error_skip(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_creds(monkeypatch)
+        conn = _fake_conn()
+        conn._cur.execute.side_effect = [Exception("type mismatch"), None]
+        modules = _mocked_snowflake_modules(conn)
+
+        records = [
+            {"id": 1, "score": 0.5},
+            {"id": 2, "score": 0.9},
+        ]
+        with patch.dict("sys.modules", modules):
+            result = SnowflakeDestination().load(
+                records, _config(), _options(on_error="skip")
+            )
+        assert result.failed == 1
+        assert result.success == 1
+        assert len(result.row_errors) == 1
+        assert "type mismatch" in result.row_errors[0].error_message


### PR DESCRIPTION
## What does this PR do?

1. drt/destinations/snowflake.py — Destination implementation

2. drt/config/models.py — SnowflakeDestinationConfig

3. Supports MERGE (upsert) and INSERT (append) modes

4. Auth via password_env or key pair

5. Added in drt/cli/main.py

## Related Issue

Closes # 164

## Checklist

- [ ] Tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Updated `CHANGELOG.md` (if user-facing change)
