### PR TITLE
feat: add SMTP email destination

### DIFF
--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -98,35 +98,22 @@ class SlackDestinationConfig(BaseModel):
         return f"{self.type} (webhook)"
 
 
-class TwilioDestinationConfig(BaseModel):
-    type: Literal["twilio"]
+class EmailDestinationConfig(BaseModel):
+    type: Literal["email"]
+    from_email: str
+    password: str
+    to_email: str | list[str]
+    smtp_server: str = "smtp.gmail.com"
+    smtp_port: int = 587
+    # Jinja2 template for Email message. Support plain text.
+    # Plain text example: "New user: {{ row.name }} ({{ row.email }})"
+    subject_template: str | None = None
+    message_template: str = "Data: {{ row }}"
 
-    account_sid: str | None = None
-    account_sid_env: str | None = None
+    def describe(self):
+        return f"{self.type} (SMTP)"
 
-    auth_token: str | None = None
-    auth_token_env: str | None = None
 
-    from_number: str  # Twilio phone number (E.164 format)
-
-    # Jinja2 template → destination phone number
-    to_template: str  # e.g. "{{ row.phone }}"
-
-    # Jinja2 template → SMS body
-    message_template: str
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.from_number})"
-
-    @model_validator(mode="after")
-    def _check_auth(self) -> "TwilioDestinationConfig":
-        if not (self.account_sid or self.account_sid_env):
-            raise ValueError("account_sid or account_sid_env is required.")
-        if not (self.auth_token or self.auth_token_env):
-            raise ValueError("auth_token or auth_token_env is required.")
-        return self
-    
-    
 class DiscordDestinationConfig(BaseModel):
     type: Literal["discord"]
     webhook_url: str | None = None
@@ -183,18 +170,6 @@ class HubSpotDestinationConfig(BaseModel):
         return f"{self.type} ({self.object_type})"
 
 
-class IntercomDestinationConfig(BaseModel):
-    type: Literal["intercom"]
-
-    auth: AuthConfig
-
-    # Jinja2 JSON template for contact payload
-    properties_template: str
-
-    def describe(self) -> str:
-        return f"{self.type} (contacts)"
-
-
 class SendGridDestinationConfig(BaseModel):
     type: Literal["sendgrid"]
     from_email: str
@@ -223,36 +198,6 @@ class LinearDestinationConfig(BaseModel):
         return "linear (issue)"
 
 
-class LookupConfig(BaseModel):
-    """Resolve a column value by querying the destination DB.
-
-    Used to resolve foreign key values when syncing related tables.
-    The destination DB is queried once per lookup to build an in-memory
-    mapping, then each source row is enriched with the resolved value.
-
-    Example YAML::
-
-        lookups:
-          interviewer_profile_id:
-            table: interviewer_profiles
-            match: { user_id: user_id }
-            select: id
-            on_miss: skip
-    """
-
-    table: str  # destination DB table to query
-    match: dict[str, str]  # { destination_column: source_column }
-    select: str  # column to fetch from the lookup table
-    on_miss: Literal["skip", "fail", "null"] = "skip"
-    drop_match_columns: bool = True  # remove match source columns from INSERT
-
-    @model_validator(mode="after")
-    def _check_match_not_empty(self) -> "LookupConfig":
-        if not self.match:
-            raise ValueError("lookups.match must contain at least one mapping.")
-        return self
-
-
 class SslConfig(BaseModel):
     """SSL/TLS connection options for DB destinations."""
 
@@ -277,7 +222,6 @@ class PostgresDestinationConfig(BaseModel):
     table: str  # e.g. "public.analytics_scores"
     upsert_key: list[str]  # columns for ON CONFLICT
     ssl: SslConfig | None = None
-    lookups: dict[str, LookupConfig] | None = None
 
     def describe(self) -> str:
         return f"{self.type} ({self.table})"
@@ -308,7 +252,6 @@ class MySQLDestinationConfig(BaseModel):
     table: str  # e.g. "interviewer_learning_profiles"
     upsert_key: list[str]  # columns for ON DUPLICATE KEY
     ssl: SslConfig | None = None
-    lookups: dict[str, LookupConfig] | None = None
 
     def describe(self) -> str:
         return f"{self.type} ({self.table})"
@@ -370,7 +313,6 @@ class ClickHouseDestinationConfig(BaseModel):
     # ReplacingMergeTree tables or apply upsert semantics from this field.
     upsert_key: list[str] | None = None
     secure: bool = False  # use HTTPS/TLS; set port explicitly for your deployment (commonly 8443)
-    lookups: dict[str, LookupConfig] | None = None
 
     def describe(self) -> str:
         return f"{self.type} ({self.table})"
@@ -405,69 +347,11 @@ class FileDestinationConfig(BaseModel):
         return f"{self.type} ({self.path})"
 
 
-class NotionDestinationConfig(BaseModel):
-    type: Literal["notion"]
-    database_id: str
-    # Jinja2 template → JSON object of Notion page properties
-    # Example: see https://developers.notion.com/reference/post-page for template format
-    properties_template: str | None = None
-    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
-
-    def describe(self) -> str:
-        return f"{self.type} (database {self.database_id})"
-
-
-class GoogleAdsDestinationConfig(BaseModel):
-    type: Literal["google_ads"]
-    customer_id: str  # Google Ads customer ID (without hyphens)
-    conversion_action: str  # e.g. "customers/123/conversionActions/456"
-    gclid_field: str = "gclid"  # row field containing the click ID
-    conversion_time_field: str = "conversion_time"  # row field for timestamp
-    conversion_value_field: str | None = None  # optional: row field for value
-    currency_code: str = "USD"
-    developer_token_env: str = "GOOGLE_ADS_DEVELOPER_TOKEN"
-    auth: AuthConfig | None = None  # typically oauth2_client_credentials
-
-    def describe(self) -> str:
-        return f"google_ads ({self.customer_id})"
-
-
-class StagedUploadPhaseConfig(BaseModel):
-    url: str
-    method: str = "POST"
-    headers: dict[str, str] | None = None
-    auth: AuthConfig | None = None
-    body_template: str | None = None
-    response_extract: dict[str, str] | None = None
-
-
-class StagedUploadPollConfig(BaseModel):
-    url: str
-    method: str = "GET"
-    headers: dict[str, str] | None = None
-    auth: AuthConfig | None = None
-    status_field: str = "status"
-    success_values: list[str] = ["SUCCEEDED", "COMPLETED"]
-    failure_values: list[str] = ["FAILED", "ERROR"]
-    interval_seconds: int = 30
-    timeout_seconds: int = 3600
-
-
-class StagedUploadDestinationConfig(BaseModel):
-    type: Literal["staged_upload"]
-    stage: StagedUploadPhaseConfig
-    trigger: StagedUploadPhaseConfig
-    poll: StagedUploadPollConfig | None = None
-    format: Literal["csv", "json", "jsonl"] = "csv"
-
-    def describe(self) -> str:
-        return "staged_upload"
-
-
 # Discriminated union — add new destination types here
 DestinationConfig = Annotated[
     RestApiDestinationConfig
     | SlackDestinationConfig
+    | EmailDestinationConfig
     | DiscordDestinationConfig
     | GitHubActionsDestinationConfig
     | HubSpotDestinationConfig
@@ -480,12 +364,7 @@ DestinationConfig = Annotated[
     | JiraDestinationConfig
     | ClickHouseDestinationConfig
     | ParquetDestinationConfig
-    | GoogleAdsDestinationConfig
-    | FileDestinationConfig
-    | NotionDestinationConfig
-    | IntercomDestinationConfig
-    | StagedUploadDestinationConfig
-    | TwilioDestinationConfig,
+    | FileDestinationConfig,
     Field(discriminator="type"),
 ]
 
@@ -507,34 +386,9 @@ class RetryConfig(BaseModel):
     retryable_status_codes: tuple[int, ...] = (429, 500, 502, 503, 504)
 
 
-class WatermarkConfig(BaseModel):
-    """Configuration for remote watermark storage."""
-
-    storage: Literal["local", "gcs", "bigquery"] = "local"
-    # GCS
-    bucket: str | None = None
-    key: str | None = None
-    # BigQuery
-    project: str | None = None
-    dataset: str | None = None
-
-    @model_validator(mode="after")
-    def _check_backend_fields(self) -> "WatermarkConfig":
-        if self.storage == "gcs" and not self.bucket:
-            raise ValueError("watermark.bucket is required when storage is 'gcs'.")
-        if self.storage == "gcs" and not self.key:
-            raise ValueError("watermark.key is required when storage is 'gcs'.")
-        if self.storage == "bigquery" and not self.project:
-            raise ValueError("watermark.project is required when storage is 'bigquery'.")
-        if self.storage == "bigquery" and not self.dataset:
-            raise ValueError("watermark.dataset is required when storage is 'bigquery'.")
-        return self
-
-
 class SyncOptions(BaseModel):
-    mode: Literal["full", "incremental", "upsert", "replace"] = "full"
+    mode: Literal["full", "incremental", "upsert"] = "full"
     cursor_field: str | None = None  # required when mode=incremental
-    watermark: WatermarkConfig | None = None
     batch_size: int = 100
     rate_limit: RateLimitConfig = Field(default_factory=RateLimitConfig)
     retry: RetryConfig = Field(default_factory=RetryConfig)

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -114,6 +114,35 @@ class EmailDestinationConfig(BaseModel):
         return f"{self.type} (SMTP)"
 
 
+class TwilioDestinationConfig(BaseModel):
+    type: Literal["twilio"]
+
+    account_sid: str | None = None
+    account_sid_env: str | None = None
+
+    auth_token: str | None = None
+    auth_token_env: str | None = None
+
+    from_number: str  # Twilio phone number (E.164 format)
+
+    # Jinja2 template → destination phone number
+    to_template: str  # e.g. "{{ row.phone }}"
+
+    # Jinja2 template → SMS body
+    message_template: str
+
+    def describe(self) -> str:
+        return f"{self.type} ({self.from_number})"
+
+    @model_validator(mode="after")
+    def _check_auth(self) -> "TwilioDestinationConfig":
+        if not (self.account_sid or self.account_sid_env):
+            raise ValueError("account_sid or account_sid_env is required.")
+        if not (self.auth_token or self.auth_token_env):
+            raise ValueError("auth_token or auth_token_env is required.")
+        return self
+    
+    
 class DiscordDestinationConfig(BaseModel):
     type: Literal["discord"]
     webhook_url: str | None = None
@@ -170,6 +199,18 @@ class HubSpotDestinationConfig(BaseModel):
         return f"{self.type} ({self.object_type})"
 
 
+class IntercomDestinationConfig(BaseModel):
+    type: Literal["intercom"]
+
+    auth: AuthConfig
+
+    # Jinja2 JSON template for contact payload
+    properties_template: str
+
+    def describe(self) -> str:
+        return f"{self.type} (contacts)"
+
+
 class SendGridDestinationConfig(BaseModel):
     type: Literal["sendgrid"]
     from_email: str
@@ -198,6 +239,36 @@ class LinearDestinationConfig(BaseModel):
         return "linear (issue)"
 
 
+class LookupConfig(BaseModel):
+    """Resolve a column value by querying the destination DB.
+
+    Used to resolve foreign key values when syncing related tables.
+    The destination DB is queried once per lookup to build an in-memory
+    mapping, then each source row is enriched with the resolved value.
+
+    Example YAML::
+
+        lookups:
+          interviewer_profile_id:
+            table: interviewer_profiles
+            match: { user_id: user_id }
+            select: id
+            on_miss: skip
+    """
+
+    table: str  # destination DB table to query
+    match: dict[str, str]  # { destination_column: source_column }
+    select: str  # column to fetch from the lookup table
+    on_miss: Literal["skip", "fail", "null"] = "skip"
+    drop_match_columns: bool = True  # remove match source columns from INSERT
+
+    @model_validator(mode="after")
+    def _check_match_not_empty(self) -> "LookupConfig":
+        if not self.match:
+            raise ValueError("lookups.match must contain at least one mapping.")
+        return self
+
+
 class SslConfig(BaseModel):
     """SSL/TLS connection options for DB destinations."""
 
@@ -222,6 +293,7 @@ class PostgresDestinationConfig(BaseModel):
     table: str  # e.g. "public.analytics_scores"
     upsert_key: list[str]  # columns for ON CONFLICT
     ssl: SslConfig | None = None
+    lookups: dict[str, LookupConfig] | None = None
 
     def describe(self) -> str:
         return f"{self.type} ({self.table})"
@@ -252,6 +324,7 @@ class MySQLDestinationConfig(BaseModel):
     table: str  # e.g. "interviewer_learning_profiles"
     upsert_key: list[str]  # columns for ON DUPLICATE KEY
     ssl: SslConfig | None = None
+    lookups: dict[str, LookupConfig] | None = None
 
     def describe(self) -> str:
         return f"{self.type} ({self.table})"
@@ -313,6 +386,7 @@ class ClickHouseDestinationConfig(BaseModel):
     # ReplacingMergeTree tables or apply upsert semantics from this field.
     upsert_key: list[str] | None = None
     secure: bool = False  # use HTTPS/TLS; set port explicitly for your deployment (commonly 8443)
+    lookups: dict[str, LookupConfig] | None = None
 
     def describe(self) -> str:
         return f"{self.type} ({self.table})"
@@ -347,6 +421,65 @@ class FileDestinationConfig(BaseModel):
         return f"{self.type} ({self.path})"
 
 
+class NotionDestinationConfig(BaseModel):
+    type: Literal["notion"]
+    database_id: str
+    # Jinja2 template → JSON object of Notion page properties
+    # Example: see https://developers.notion.com/reference/post-page for template format
+    properties_template: str | None = None
+    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
+
+    def describe(self) -> str:
+        return f"{self.type} (database {self.database_id})"
+
+
+class GoogleAdsDestinationConfig(BaseModel):
+    type: Literal["google_ads"]
+    customer_id: str  # Google Ads customer ID (without hyphens)
+    conversion_action: str  # e.g. "customers/123/conversionActions/456"
+    gclid_field: str = "gclid"  # row field containing the click ID
+    conversion_time_field: str = "conversion_time"  # row field for timestamp
+    conversion_value_field: str | None = None  # optional: row field for value
+    currency_code: str = "USD"
+    developer_token_env: str = "GOOGLE_ADS_DEVELOPER_TOKEN"
+    auth: AuthConfig | None = None  # typically oauth2_client_credentials
+
+    def describe(self) -> str:
+        return f"google_ads ({self.customer_id})"
+
+
+class StagedUploadPhaseConfig(BaseModel):
+    url: str
+    method: str = "POST"
+    headers: dict[str, str] | None = None
+    auth: AuthConfig | None = None
+    body_template: str | None = None
+    response_extract: dict[str, str] | None = None
+
+
+class StagedUploadPollConfig(BaseModel):
+    url: str
+    method: str = "GET"
+    headers: dict[str, str] | None = None
+    auth: AuthConfig | None = None
+    status_field: str = "status"
+    success_values: list[str] = ["SUCCEEDED", "COMPLETED"]
+    failure_values: list[str] = ["FAILED", "ERROR"]
+    interval_seconds: int = 30
+    timeout_seconds: int = 3600
+
+
+class StagedUploadDestinationConfig(BaseModel):
+    type: Literal["staged_upload"]
+    stage: StagedUploadPhaseConfig
+    trigger: StagedUploadPhaseConfig
+    poll: StagedUploadPollConfig | None = None
+    format: Literal["csv", "json", "jsonl"] = "csv"
+
+    def describe(self) -> str:
+        return "staged_upload"
+
+
 # Discriminated union — add new destination types here
 DestinationConfig = Annotated[
     RestApiDestinationConfig
@@ -364,7 +497,12 @@ DestinationConfig = Annotated[
     | JiraDestinationConfig
     | ClickHouseDestinationConfig
     | ParquetDestinationConfig
-    | FileDestinationConfig,
+    | GoogleAdsDestinationConfig
+    | FileDestinationConfig
+    | NotionDestinationConfig
+    | IntercomDestinationConfig
+    | StagedUploadDestinationConfig
+    | TwilioDestinationConfig,
     Field(discriminator="type"),
 ]
 
@@ -386,9 +524,34 @@ class RetryConfig(BaseModel):
     retryable_status_codes: tuple[int, ...] = (429, 500, 502, 503, 504)
 
 
+class WatermarkConfig(BaseModel):
+    """Configuration for remote watermark storage."""
+
+    storage: Literal["local", "gcs", "bigquery"] = "local"
+    # GCS
+    bucket: str | None = None
+    key: str | None = None
+    # BigQuery
+    project: str | None = None
+    dataset: str | None = None
+
+    @model_validator(mode="after")
+    def _check_backend_fields(self) -> "WatermarkConfig":
+        if self.storage == "gcs" and not self.bucket:
+            raise ValueError("watermark.bucket is required when storage is 'gcs'.")
+        if self.storage == "gcs" and not self.key:
+            raise ValueError("watermark.key is required when storage is 'gcs'.")
+        if self.storage == "bigquery" and not self.project:
+            raise ValueError("watermark.project is required when storage is 'bigquery'.")
+        if self.storage == "bigquery" and not self.dataset:
+            raise ValueError("watermark.dataset is required when storage is 'bigquery'.")
+        return self
+
+
 class SyncOptions(BaseModel):
-    mode: Literal["full", "incremental", "upsert"] = "full"
+    mode: Literal["full", "incremental", "upsert", "replace"] = "full"
     cursor_field: str | None = None  # required when mode=incremental
+    watermark: WatermarkConfig | None = None
     batch_size: int = 100
     rate_limit: RateLimitConfig = Field(default_factory=RateLimitConfig)
     retry: RetryConfig = Field(default_factory=RetryConfig)

--- a/drt/destinations/email_smtp.py
+++ b/drt/destinations/email_smtp.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import time
+import json
+from typing import Any
+
+import smtplib
+from email.mime.text import MIMEText
+
+from drt.config.models import DestinationConfig, EmailDestinationConfig, SyncOptions, RetryConfig
+from drt.destinations.base import SyncResult
+from drt.destinations.row_errors import RowError
+from drt.destinations.rate_limiter import RateLimiter
+from drt.templates.renderer import render_template
+
+def smtp_with_retry(send_fn, config: RetryConfig) -> None:
+    backoff = config.initial_backoff
+
+    for attempt in range(1, config.max_attempts + 1):
+        try:
+            return send_fn()
+
+        except smtplib.SMTPException:
+            if attempt == config.max_attempts:
+                raise
+
+        if attempt < config.max_attempts:
+            time.sleep(min(backoff, config.max_backoff))
+            backoff *= config.backoff_multiplier
+
+
+class EmailDestination:
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, EmailDestinationConfig)
+        from_email = config.from_email
+        password = config.password
+        smtp_server = config.smtp_server
+        smtp_port = config.smtp_port
+        to_email = config.to_email
+
+        result = SyncResult()
+        rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
+
+        with smtplib.SMTP(smtp_server, smtp_port, timeout=30.0) as connection:
+            connection.starttls()
+            connection.login(from_email, password)
+
+            recipients = to_email if isinstance(to_email, list) else [to_email]
+
+            for i, record in enumerate(records):
+                rate_limiter.acquire()
+                try:                    
+                    message_rendered = render_template(config.message_template, record)
+                    subject = (
+                        render_template(config.subject_template, record)
+                        if config.subject_template
+                        else "Data Reverse Tool"
+                    )
+
+                    msg = MIMEText(message_rendered, "plain", "utf-8")
+                    msg["Subject"] = subject
+                    msg["From"] = from_email
+                    msg["To"] = ", ".join(recipients)
+
+                    def send():
+                        connection.noop()
+                        connection.send_message(msg, to_addrs=recipients)
+                    
+                    smtp_with_retry(send, sync_options.retry)
+                    result.success += 1
+
+                except Exception as e:
+                    result.failed += 1
+                    result.errors.append(
+                        RowError(
+                            batch_index= i,
+                            record_preview= json.dumps(record)[:200],
+                            http_status= None,
+                            error_message= str(e)
+                        )
+                    )
+        
+        return result

--- a/tests/unit/test_email_destination.py
+++ b/tests/unit/test_email_destination.py
@@ -1,0 +1,35 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from drt.destinations.email_smtp import EmailDestination
+from drt.config.models import EmailDestinationConfig, SyncOptions, RetryConfig, RateLimitConfig
+
+
+def test_email_retry_then_success():
+    mock_smtp = MagicMock()
+
+    mock_smtp.send_message.side_effect = [
+        Exception("fail"),
+        None,
+    ]
+
+    with patch("smtplib.SMTP", return_value=mock_smtp):
+        destination = EmailDestination()
+
+        config = EmailDestinationConfig(
+            type="email",
+            from_email="test@gmail.com",
+            password="123",
+            to_email="target@gmail.com",
+        )
+
+        sync_options = SyncOptions(
+            rate_limit=RateLimitConfig(requests_per_second=100),
+            retry=RetryConfig(max_attempts=2),
+        )
+
+        records = [{"name": "Saprol"}]
+
+        result = destination.load(records, config, sync_options)
+
+        assert result.success == 1


### PR DESCRIPTION
## What does this PR do?

Add Email (SMTP) destination support.

- Implement EmailDestination using SMTP
- Support plain text email rendering using Jinja2 templates
- Add subject templating via `subject_template`
- Implement retry logic with exponential backoff
- Support multiple recipients
- Add unit test for retry behavior

This implementation follows the existing destination pattern and does not modify existing behavior.

## Related Issue

Closes #86

## Checklist

- [x] Tests pass (`pytest tests/unit/test_email_destination.py`)
- [ ] Linter passes (`make lint`)
- [ ] Updated `CHANGELOG.md` (if user-facing change)