### PR TITLE
feat/drt test validators 233

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`--output json` for validate/list** (#230): Structured JSON output for `drt validate` and `drt list`.
 - **MCP Server: `drt_list_connectors`** (#262): New tool listing all available sources and destinations.
 - **MCP Server: improved `drt_validate`** (#262): Per-file error reporting via `load_syncs_safe()`.
-- **`drt test` — freshness, unique, accepted_values validators** (#233): New test types for post-sync validation. `freshness` validates data recency (e.g., `max_age: "7 days"`), `unique` prevents duplicates, `accepted_values` enforces whitelists. Supports human-readable time formats, timezone-aware comparison, multi-column validation. Follow-up to #141 (row_count, not_null tests).
+- **`drt test` — freshness, unique, accepted_values validators** (#233): New test types for post-sync validation. `freshness` validates data recency (e.g., `max_age: "7 days"`), `unique` prevents duplicates, `accepted_values` enforces column whitelists. Supports human-readable time formats ("7 days", "24 hours", etc). Follow-up to #141 (row_count, not_null tests).
 - **BigQuery → Discord example** (#266): Alert pipeline that queries BigQuery for recent error rows and posts a Discord notification per row via Incoming Webhook using incremental sync. Includes `examples/bigquery_to_discord/`.
 - **Notion destination** (#38): Append rows to a Notion database via the Notion API. Supports `properties_template` (Jinja2 → JSON for page properties), `rich_text` fallback for records without a template, retry with backoff, rate limiting (3 req/s). Contributed by @armorbreak001, with credit to @PFCAaron12 and @pureqin.
 - **Twilio SMS destination** (#159): Send SMS per row via Twilio Messages API. Basic auth (Account SID + Auth Token), Jinja2 templates for message body and per-row phone number (`to_template`), E.164 format validation. Contributed by @PFCAaron12.
@@ -86,10 +86,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 #### Sources
+
 - **Snowflake source connector** (#162): Extract data from Snowflake using `snowflake-connector-python`. Supports account, user, password/password_env, database, schema, warehouse, and optional role. Install: `pip install drt-core[snowflake]`
 - **MySQL source connector** (#19): Extract data from MySQL databases using pymysql. Supports host, port, dbname, user, password via env var. Backtick quoting for table names. Install: `pip install drt-core[mysql]`
 
 #### Destinations
+
 - **ClickHouse destination** (#166): Insert rows via `clickhouse-connect` (HTTP). Supports connection string, HTTPS via `secure` flag. Install: `pip install drt-core[clickhouse]`
 - **Parquet file destination** (#171): Write to local Parquet files with snappy/gzip/zstd compression and partition columns. Install: `pip install drt-core[parquet]`
 - **CSV/JSON/JSONL file destination** (#67): Write to local files using stdlib csv/json. No extra dependencies
@@ -99,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SendGrid email destination** (#194): Transactional emails via SendGrid v3 Mail Send API
 
 #### CLI
+
 - **`drt test` command** (#141): Post-sync data validation. Supports `row_count` (min/max) and `not_null` (columns) tests for DB destinations (PostgreSQL, MySQL, ClickHouse)
 - **`--output json` flag** (#142): Structured JSON output for `drt run` and `drt status`. Designed for CI/scripting use
 - **`--profile` CLI override** (#238): Runtime profile switching via `--profile` flag or `DRT_PROFILE` env var. Precedence: flag > env var > drt_project.yml
@@ -106,11 +109,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dry-run summary** (#219): Enhanced `--dry-run` shows Source, Destination, Rows to sync, and Sync mode
 
 #### Multi-environment support
+
 - **`${VAR}` env var substitution** (#240): Use `${VAR}` syntax in `model:` field for environment-specific SQL queries
 - **dbt manifest resolution** (#239): `ref('model')` now resolves from dbt `target/manifest.json` when available. Resolution order: SQL file > dbt manifest > profile-based expansion
 - **`secrets.toml`** (#143): Local secret management via `.drt/secrets.toml` (dlt-like pattern). Resolution order: explicit value > env var > secrets.toml
 
 #### Infrastructure
+
 - **Dockerfile and docker-compose** (#161): `python:3.12-slim` image with `DRT_EXTRAS` build arg, non-root user
 - **Codecov integration** (#103): Coverage badge, PR reports. Patch checks set to informational
 - **Pre-commit hooks** (#105): ruff + mypy
@@ -118,6 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`duration_seconds` in SyncResult** (#226): Track sync execution time
 
 ### Tests
+
 - 382+ tests (up from 170+ in v0.4.3)
 - Source and destination protocol contract tests (#209, #210)
 - Slack Block Kit tests (#97), state persistence tests (#100)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`--output json` for validate/list** (#230): Structured JSON output for `drt validate` and `drt list`.
 - **MCP Server: `drt_list_connectors`** (#262): New tool listing all available sources and destinations.
 - **MCP Server: improved `drt_validate`** (#262): Per-file error reporting via `load_syncs_safe()`.
+- **`drt test` — freshness, unique, accepted_values validators** (#233): New test types for post-sync validation. `freshness` validates data recency (e.g., `max_age: "7 days"`), `unique` prevents duplicates, `accepted_values` enforces whitelists. Supports human-readable time formats, timezone-aware comparison, multi-column validation. Follow-up to #141 (row_count, not_null tests).
 - **BigQuery → Discord example** (#266): Alert pipeline that queries BigQuery for recent error rows and posts a Discord notification per row via Incoming Webhook using incremental sync. Includes `examples/bigquery_to_discord/`.
 - **Notion destination** (#38): Append rows to a Notion database via the Notion API. Supports `properties_template` (Jinja2 → JSON for page properties), `rich_text` fallback for records without a template, retry with backoff, rate limiting (3 req/s). Contributed by @armorbreak001, with credit to @PFCAaron12 and @pureqin.
 - **Twilio SMS destination** (#159): Send SMS per row via Twilio Messages API. Basic auth (Account SID + Auth Token), Jinja2 templates for message body and per-row phone number (`to_template`), E.164 format validation. Contributed by @PFCAaron12.

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -581,12 +581,12 @@ class FreshnessTest(BaseModel):
 
 
 class UniqueTest(BaseModel):
-    columns: list[str]
+    columns: list[str] = Field(min_length=1)
 
 
 class AcceptedValuesTest(BaseModel):
     column: str
-    values: list[str]
+    values: list[str] = Field(min_length=1)
 
 
 class SyncTest(BaseModel):
@@ -595,6 +595,22 @@ class SyncTest(BaseModel):
     freshness: FreshnessTest | None = None
     unique: UniqueTest | None = None
     accepted_values: AcceptedValuesTest | None = None
+
+    @model_validator(mode="after")
+    def _check_exactly_one_test(self) -> "SyncTest":
+        configured_tests = [
+            self.row_count,
+            self.not_null,
+            self.freshness,
+            self.unique,
+            self.accepted_values,
+        ]
+        configured_count = sum(test is not None for test in configured_tests)
+        if configured_count != 1:
+            raise ValueError(
+                "Exactly one sync test must be configured in each tests entry."
+            )
+        return self
 
 
 class SyncConfig(BaseModel):

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -575,9 +575,26 @@ class NotNullTest(BaseModel):
     columns: list[str]
 
 
+class FreshnessTest(BaseModel):
+    column: str
+    max_age: str  # e.g., "7 days", "1 hour", "30 minutes"
+
+
+class UniqueTest(BaseModel):
+    columns: list[str]
+
+
+class AcceptedValuesTest(BaseModel):
+    column: str
+    values: list[str]
+
+
 class SyncTest(BaseModel):
     row_count: RowCountTest | None = None
     not_null: NotNullTest | None = None
+    freshness: FreshnessTest | None = None
+    unique: UniqueTest | None = None
+    accepted_values: AcceptedValuesTest | None = None
 
 
 class SyncConfig(BaseModel):

--- a/drt/engine/test_runner.py
+++ b/drt/engine/test_runner.py
@@ -47,6 +47,10 @@ def _parse_max_age(max_age_str: str) -> timedelta:
         value = int(value_str)
     except ValueError:
         raise ValueError(f"Invalid max_age value: {value_str!r}. Must be an integer.")
+    if value <= 0:
+        raise ValueError(
+            f"Invalid max_age value: {value_str!r}. Must be a positive integer."
+        )
     
     unit_lower = unit.lower()
     if unit_lower in ("day", "days"):
@@ -90,7 +94,8 @@ def build_test_query(test: SyncTest, table: str) -> tuple[str, Callable[[int], b
 
     if test.not_null is not None:
         nn = test.not_null
-        conditions = " OR ".join(f"{col} IS NULL" for col in nn.columns)
+        safe_cols = [_safe_column(col) for col in nn.columns]
+        conditions = " OR ".join(f"{col} IS NULL" for col in safe_cols)
         query = f"SELECT COUNT(*) FROM {safe_table} WHERE {conditions}"
 
         def check_not_null(val: int) -> bool:
@@ -116,12 +121,17 @@ def build_test_query(test: SyncTest, table: str) -> tuple[str, Callable[[int], b
     if test.unique is not None:
         uniq = test.unique
         cols = ", ".join(_safe_column(col) for col in uniq.columns)
+        # Use portable GROUP BY + HAVING pattern (works on PostgreSQL, MySQL, BigQuery, ClickHouse)
         query = (
-            f"SELECT COUNT(*) - COUNT(DISTINCT {cols}) FROM {safe_table}"
+            f"SELECT COUNT(*) FROM {safe_table} "
+            f"WHERE ({cols}) IN ("
+            f"  SELECT {cols} FROM {safe_table} "
+            f"  GROUP BY {cols} HAVING COUNT(*) > 1"
+            f")"
         )
 
         def check_unique(val: int) -> bool:
-            # Test passes if duplicate count is 0
+            # Test passes if no duplicate rows exist
             return val == 0
 
         return query, check_unique
@@ -129,7 +139,9 @@ def build_test_query(test: SyncTest, table: str) -> tuple[str, Callable[[int], b
     if test.accepted_values is not None:
         av = test.accepted_values
         safe_col = _safe_column(av.column)
-        placeholders = ", ".join(f"'{val}'" for val in av.values)
+        # Escape single quotes in values to prevent SQL injection
+        escaped_values = [val.replace("'", "''") for val in av.values]
+        placeholders = ", ".join(f"'{val}'" for val in escaped_values)
         query = f"SELECT COUNT(*) FROM {safe_table} WHERE {safe_col} NOT IN ({placeholders})"
 
         def check_accepted_values(val: int) -> bool:

--- a/drt/engine/test_runner.py
+++ b/drt/engine/test_runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 
 from drt.config.models import SyncTest
 
@@ -21,6 +22,49 @@ def _safe_table(table: str) -> str:
         if not (ch.isalnum() or ch in "._"):
             raise ValueError(f"Invalid character in table name: {ch!r}")
     return table
+
+
+def _safe_column(column: str) -> str:
+    """Basic column name validation."""
+    for ch in column:
+        if not (ch.isalnum() or ch in "._"):
+            raise ValueError(f"Invalid character in column name: {ch!r}")
+    return column
+
+
+def _parse_max_age(max_age_str: str) -> timedelta:
+    """Parse max_age string like '7 days', '1 hour', etc."""
+    parts = max_age_str.strip().split()
+    if len(parts) != 2:
+        msg = (
+            f"Invalid max_age format: {max_age_str!r}. "
+            "Use format like '7 days' or '1 hour'"
+        )
+        raise ValueError(msg)
+    
+    value_str, unit = parts
+    try:
+        value = int(value_str)
+    except ValueError:
+        raise ValueError(f"Invalid max_age value: {value_str!r}. Must be an integer.")
+    
+    unit_lower = unit.lower()
+    if unit_lower in ("day", "days"):
+        return timedelta(days=value)
+    elif unit_lower in ("hour", "hours"):
+        return timedelta(hours=value)
+    elif unit_lower in ("minute", "minutes"):
+        return timedelta(minutes=value)
+    elif unit_lower in ("second", "seconds"):
+        return timedelta(seconds=value)
+    elif unit_lower in ("week", "weeks"):
+        return timedelta(weeks=value)
+    else:
+        msg = (
+            f"Unknown time unit: {unit!r}. "
+            "Supported: days, hours, minutes, seconds, weeks"
+        )
+        raise ValueError(msg)
 
 
 def build_test_query(test: SyncTest, table: str) -> tuple[str, Callable[[int], bool]]:
@@ -54,4 +98,45 @@ def build_test_query(test: SyncTest, table: str) -> tuple[str, Callable[[int], b
 
         return query, check_not_null
 
+    if test.freshness is not None:
+        fresh = test.freshness
+        safe_col = _safe_column(fresh.column)
+        max_age_delta = _parse_max_age(fresh.max_age)
+        threshold = datetime.now(timezone.utc) - max_age_delta
+        
+        # Count rows where column is older than max_age (stale data)
+        query = f"SELECT COUNT(*) FROM {safe_table} WHERE {safe_col} < '{threshold.isoformat()}'"
+
+        def check_freshness(val: int) -> bool:
+            # Test passes if there are no stale rows
+            return val == 0
+
+        return query, check_freshness
+
+    if test.unique is not None:
+        uniq = test.unique
+        cols = ", ".join(_safe_column(col) for col in uniq.columns)
+        query = (
+            f"SELECT COUNT(*) - COUNT(DISTINCT {cols}) FROM {safe_table}"
+        )
+
+        def check_unique(val: int) -> bool:
+            # Test passes if duplicate count is 0
+            return val == 0
+
+        return query, check_unique
+
+    if test.accepted_values is not None:
+        av = test.accepted_values
+        safe_col = _safe_column(av.column)
+        placeholders = ", ".join(f"'{val}'" for val in av.values)
+        query = f"SELECT COUNT(*) FROM {safe_table} WHERE {safe_col} NOT IN ({placeholders})"
+
+        def check_accepted_values(val: int) -> bool:
+            # Test passes if there are no invalid values
+            return val == 0
+
+        return query, check_accepted_values
+
     raise ValueError("No test type defined in SyncTest.")
+

--- a/tests/unit/test_test_runner.py
+++ b/tests/unit/test_test_runner.py
@@ -42,9 +42,8 @@ def test_build_not_null() -> None:
 
 
 def test_build_unknown_test_raises() -> None:
-    t = SyncTest()
-    with pytest.raises(ValueError, match="No test type"):
-        build_test_query(t, "public.users")
+    with pytest.raises(ValueError, match="Exactly one sync test must be configured"):
+        SyncTest()
 
 
 def test_safe_table_rejects_injection() -> None:

--- a/tests/unit/test_validators_233.py
+++ b/tests/unit/test_validators_233.py
@@ -63,6 +63,16 @@ class TestParseMaxAge:
         with pytest.raises(ValueError, match="Unknown time unit"):
             _parse_max_age("7 months")
 
+    def test_parse_zero_value(self) -> None:
+        """Reject zero max_age value."""
+        with pytest.raises(ValueError, match="Must be a positive integer"):
+            _parse_max_age("0 days")
+
+    def test_parse_negative_value(self) -> None:
+        """Reject negative max_age value."""
+        with pytest.raises(ValueError, match="Must be a positive integer"):
+            _parse_max_age("-7 days")
+
 
 class TestFreshnessTest:
     """Test freshness validator query generation."""
@@ -112,8 +122,9 @@ class TestUniqueTest:
         test = SyncTest(unique=UniqueTest(columns=["id"]))
         query, _ = build_test_query(test, "products")
         
-        assert "SELECT" in query
-        assert "COUNT(*) - COUNT(DISTINCT id)" in query
+        # Should use portable GROUP BY + HAVING pattern
+        assert "GROUP BY id" in query
+        assert "HAVING COUNT(*) > 1" in query
         assert "products" in query
 
     def test_unique_multiple_columns_query(self) -> None:
@@ -121,7 +132,9 @@ class TestUniqueTest:
         test = SyncTest(unique=UniqueTest(columns=["tenant_id", "user_id"]))
         query, _ = build_test_query(test, "subscriptions")
         
-        assert "DISTINCT tenant_id, user_id" in query
+        # Should use portable GROUP BY + HAVING pattern
+        assert "GROUP BY tenant_id, user_id" in query
+        assert "HAVING COUNT(*) > 1" in query
         assert "subscriptions" in query
 
     def test_unique_check_passes_on_no_duplicates(self) -> None:
@@ -199,43 +212,25 @@ class TestAcceptedValuesTest:
 
 
 class TestMultipleTestTypes:
-    """Test that only one test type should be used at a time."""
+    """Test that each test type generates correct SQL when used alone."""
 
-    def test_row_count_takes_precedence(self) -> None:
-        """If row_count is set, it takes precedence."""
-        test = SyncTest(
-            row_count={"min": 1, "max": 100},
-            unique=UniqueTest(columns=["id"])
-        )
+    def test_row_count_alone(self) -> None:
+        """Row count test generates correct SQL."""
+        test = SyncTest(row_count={"min": 1, "max": 100})
         query, _ = build_test_query(test, "users")
-        
-        # Should be row count query, not unique query
         assert "COUNT(*)" in query
-        assert "DISTINCT" not in query
 
-    def test_not_null_takes_second_precedence(self) -> None:
-        """If row_count not set, not_null takes precedence."""
-        test = SyncTest(
-            not_null={"columns": ["email"]},
-            freshness=FreshnessTest(column="updated_at", max_age="1 day")
-        )
+    def test_not_null_alone(self) -> None:
+        """Not null test generates correct SQL."""
+        test = SyncTest(not_null={"columns": ["email"]})
         query, _ = build_test_query(test, "users")
-        
-        # Should be not_null query
         assert "IS NULL" in query
-        assert "updated_at" not in query
 
-    def test_freshness_takes_third_precedence(self) -> None:
-        """If row_count/not_null not set, freshness takes precedence."""
-        test = SyncTest(
-            freshness=FreshnessTest(column="updated_at", max_age="1 day"),
-            unique=UniqueTest(columns=["id"])
-        )
+    def test_freshness_alone(self) -> None:
+        """Freshness test generates correct SQL."""
+        test = SyncTest(freshness=FreshnessTest(column="updated_at", max_age="1 day"))
         query, _ = build_test_query(test, "users")
-        
-        # Should be freshness query
         assert "updated_at" in query
-        assert "DISTINCT" not in query
 
 
 class TestInvalidTableNames:
@@ -254,3 +249,46 @@ class TestInvalidTableNames:
         
         with pytest.raises(ValueError, match="Invalid character"):
             build_test_query(test, "users")
+
+
+class TestValidationRules:
+    """Test model validation rules."""
+
+    def test_unique_columns_cannot_be_empty(self) -> None:
+        """UniqueTest requires at least one column."""
+        with pytest.raises(ValueError, match="at least"):
+            SyncTest(unique=UniqueTest(columns=[]))
+
+    def test_accepted_values_cannot_be_empty(self) -> None:
+        """AcceptedValuesTest requires at least one value."""
+        with pytest.raises(ValueError, match="at least"):
+            SyncTest(
+                accepted_values=AcceptedValuesTest(column="status", values=[])
+            )
+
+    def test_sync_test_must_have_exactly_one_test(self) -> None:
+        """SyncTest requires exactly one test type."""
+        with pytest.raises(ValueError, match="Exactly one"):
+            SyncTest(
+                row_count={"min": 1},
+                unique=UniqueTest(columns=["id"])
+            )
+
+    def test_sync_test_cannot_have_zero_tests(self) -> None:
+        """SyncTest cannot have no test types."""
+        with pytest.raises(ValueError, match="Exactly one"):
+            SyncTest()
+
+    def test_accepted_values_escapes_single_quotes(self) -> None:
+        """Accepted values should escape single quotes to prevent SQL injection."""
+        test = SyncTest(
+            accepted_values=AcceptedValuesTest(
+                column="name",
+                values=["O'Brien", "O'Connor"]
+            )
+        )
+        query, _ = build_test_query(test, "users")
+        
+        # Single quotes should be doubled (SQL standard escaping)
+        assert "O''Brien" in query
+        assert "O''Connor" in query

--- a/tests/unit/test_validators_233.py
+++ b/tests/unit/test_validators_233.py
@@ -1,0 +1,256 @@
+"""Tests for freshness, unique, and accepted_values test validators."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from drt.config.models import AcceptedValuesTest, FreshnessTest, SyncTest, UniqueTest
+from drt.engine.test_runner import _parse_max_age, build_test_query
+
+
+class TestParseMaxAge:
+    """Test max_age string parsing."""
+
+    def test_parse_days(self) -> None:
+        """Parse '7 days' correctly."""
+        result = _parse_max_age("7 days")
+        assert result == timedelta(days=7)
+
+    def test_parse_hours(self) -> None:
+        """Parse '1 hour' correctly."""
+        result = _parse_max_age("1 hour")
+        assert result == timedelta(hours=1)
+
+    def test_parse_minutes(self) -> None:
+        """Parse '30 minutes' correctly."""
+        result = _parse_max_age("30 minutes")
+        assert result == timedelta(minutes=30)
+
+    def test_parse_seconds(self) -> None:
+        """Parse '3600 seconds' correctly."""
+        result = _parse_max_age("3600 seconds")
+        assert result == timedelta(seconds=3600)
+
+    def test_parse_weeks(self) -> None:
+        """Parse '2 weeks' correctly."""
+        result = _parse_max_age("2 weeks")
+        assert result == timedelta(weeks=2)
+
+    def test_parse_singular_forms(self) -> None:
+        """Parse singular forms like '1 day'."""
+        assert _parse_max_age("1 day") == timedelta(days=1)
+        assert _parse_max_age("1 hour") == timedelta(hours=1)
+        assert _parse_max_age("1 minute") == timedelta(minutes=1)
+        assert _parse_max_age("1 second") == timedelta(seconds=1)
+        assert _parse_max_age("1 week") == timedelta(weeks=1)
+
+    def test_parse_invalid_format(self) -> None:
+        """Raise error for invalid format."""
+        with pytest.raises(ValueError, match="Invalid max_age format"):
+            _parse_max_age("7")
+        with pytest.raises(ValueError, match="Invalid max_age format"):
+            _parse_max_age("7 days 3 hours")
+
+    def test_parse_invalid_value(self) -> None:
+        """Raise error for non-integer value."""
+        with pytest.raises(ValueError, match="Invalid max_age value"):
+            _parse_max_age("abc days")
+
+    def test_parse_unknown_unit(self) -> None:
+        """Raise error for unknown time unit."""
+        with pytest.raises(ValueError, match="Unknown time unit"):
+            _parse_max_age("7 months")
+
+
+class TestFreshnessTest:
+    """Test freshness validator query generation."""
+
+    def test_freshness_query_generation(self) -> None:
+        """Freshness test should generate correct SQL."""
+        test = SyncTest(freshness=FreshnessTest(column="updated_at", max_age="7 days"))
+        query, check_func = build_test_query(test, "users")
+        
+        assert "SELECT COUNT(*)" in query
+        assert "updated_at" in query
+        assert "users" in query
+        # Query should use < operator (older than)
+        assert "<" in query
+
+    def test_freshness_check_passes_on_zero_stale(self) -> None:
+        """Freshness check passes when no stale rows."""
+        test = SyncTest(freshness=FreshnessTest(column="updated_at", max_age="7 days"))
+        _, check_func = build_test_query(test, "users")
+        
+        # 0 stale rows = all data is fresh
+        assert check_func(0) is True
+
+    def test_freshness_check_fails_on_stale_data(self) -> None:
+        """Freshness check fails when stale rows exist."""
+        test = SyncTest(freshness=FreshnessTest(column="updated_at", max_age="7 days"))
+        _, check_func = build_test_query(test, "users")
+        
+        # Any stale rows means test fails
+        assert check_func(1) is False
+        assert check_func(100) is False
+
+    def test_freshness_with_hours(self) -> None:
+        """Freshness test with hour-based max_age."""
+        test = SyncTest(freshness=FreshnessTest(column="created_at", max_age="24 hours"))
+        query, _ = build_test_query(test, "events")
+        
+        assert "created_at" in query
+        assert "events" in query
+
+
+class TestUniqueTest:
+    """Test unique validator query generation."""
+
+    def test_unique_single_column_query(self) -> None:
+        """Unique test with single column."""
+        test = SyncTest(unique=UniqueTest(columns=["id"]))
+        query, _ = build_test_query(test, "products")
+        
+        assert "SELECT" in query
+        assert "COUNT(*) - COUNT(DISTINCT id)" in query
+        assert "products" in query
+
+    def test_unique_multiple_columns_query(self) -> None:
+        """Unique test with multiple columns."""
+        test = SyncTest(unique=UniqueTest(columns=["tenant_id", "user_id"]))
+        query, _ = build_test_query(test, "subscriptions")
+        
+        assert "DISTINCT tenant_id, user_id" in query
+        assert "subscriptions" in query
+
+    def test_unique_check_passes_on_no_duplicates(self) -> None:
+        """Unique check passes when duplicate count is 0."""
+        test = SyncTest(unique=UniqueTest(columns=["id"]))
+        _, check_func = build_test_query(test, "users")
+        
+        assert check_func(0) is True
+
+    def test_unique_check_fails_on_duplicates(self) -> None:
+        """Unique check fails when duplicates exist."""
+        test = SyncTest(unique=UniqueTest(columns=["id"]))
+        _, check_func = build_test_query(test, "users")
+        
+        assert check_func(1) is False
+        assert check_func(10) is False
+
+
+class TestAcceptedValuesTest:
+    """Test accepted_values validator query generation."""
+
+    def test_accepted_values_query_generation(self) -> None:
+        """Accepted values test should generate correct SQL."""
+        test = SyncTest(
+            accepted_values=AcceptedValuesTest(
+                column="status",
+                values=["active", "inactive", "pending"]
+            )
+        )
+        query, _ = build_test_query(test, "users")
+        
+        assert "SELECT COUNT(*)" in query
+        assert "status NOT IN" in query
+        assert "'active'" in query
+        assert "'inactive'" in query
+        assert "'pending'" in query
+        assert "users" in query
+
+    def test_accepted_values_check_passes_on_no_invalid(self) -> None:
+        """Accepted values check passes when no invalid values."""
+        test = SyncTest(
+            accepted_values=AcceptedValuesTest(
+                column="status",
+                values=["active", "inactive"]
+            )
+        )
+        _, check_func = build_test_query(test, "users")
+        
+        # 0 invalid rows = all values are accepted
+        assert check_func(0) is True
+
+    def test_accepted_values_check_fails_on_invalid(self) -> None:
+        """Accepted values check fails when invalid values exist."""
+        test = SyncTest(
+            accepted_values=AcceptedValuesTest(
+                column="status",
+                values=["active", "inactive"]
+            )
+        )
+        _, check_func = build_test_query(test, "users")
+        
+        # Any invalid rows means test fails
+        assert check_func(1) is False
+        assert check_func(5) is False
+
+    def test_accepted_values_with_single_value(self) -> None:
+        """Accepted values test with single allowed value."""
+        test = SyncTest(
+            accepted_values=AcceptedValuesTest(column="type", values=["premium"])
+        )
+        query, _ = build_test_query(test, "subscriptions")
+        
+        assert "'premium'" in query
+        assert "NOT IN" in query
+
+
+class TestMultipleTestTypes:
+    """Test that only one test type should be used at a time."""
+
+    def test_row_count_takes_precedence(self) -> None:
+        """If row_count is set, it takes precedence."""
+        test = SyncTest(
+            row_count={"min": 1, "max": 100},
+            unique=UniqueTest(columns=["id"])
+        )
+        query, _ = build_test_query(test, "users")
+        
+        # Should be row count query, not unique query
+        assert "COUNT(*)" in query
+        assert "DISTINCT" not in query
+
+    def test_not_null_takes_second_precedence(self) -> None:
+        """If row_count not set, not_null takes precedence."""
+        test = SyncTest(
+            not_null={"columns": ["email"]},
+            freshness=FreshnessTest(column="updated_at", max_age="1 day")
+        )
+        query, _ = build_test_query(test, "users")
+        
+        # Should be not_null query
+        assert "IS NULL" in query
+        assert "updated_at" not in query
+
+    def test_freshness_takes_third_precedence(self) -> None:
+        """If row_count/not_null not set, freshness takes precedence."""
+        test = SyncTest(
+            freshness=FreshnessTest(column="updated_at", max_age="1 day"),
+            unique=UniqueTest(columns=["id"])
+        )
+        query, _ = build_test_query(test, "users")
+        
+        # Should be freshness query
+        assert "updated_at" in query
+        assert "DISTINCT" not in query
+
+
+class TestInvalidTableNames:
+    """Test SQL injection prevention."""
+
+    def test_invalid_table_names_rejected(self) -> None:
+        """Invalid characters in table names should raise error."""
+        test = SyncTest(row_count={"min": 1})
+        
+        with pytest.raises(ValueError, match="Invalid character"):
+            build_test_query(test, "users; DROP TABLE--")
+
+    def test_invalid_column_names_rejected(self) -> None:
+        """Invalid characters in column names should raise error."""
+        test = SyncTest(freshness=FreshnessTest(column="col; DROP--", max_age="1 day"))
+        
+        with pytest.raises(ValueError, match="Invalid character"):
+            build_test_query(test, "users")


### PR DESCRIPTION
## What does this PR do?

Adds three new test types to `drt test` for checking data quality after syncs:

- **freshness**: Checks that data is recent (e.g., "no data older than 7 days")
- **unique**: Checks for duplicate values in columns (e.g., "id column has no duplicates")
- **accepted_values**: Checks that values are in an allowed list (e.g., "status is only active/inactive/pending")

Supports human-readable time formats like "7 days", "24 hours", "30 minutes", etc.

## Related Issue

Closes #233

## Checklist

- [x] Tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Updated `CHANGELOG.md` (if user-facing change)