### PR TITLE
feat(destinations): add json_columns config for explicit JSON serialization

### DIFF
--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -312,6 +312,7 @@ class PostgresDestinationConfig(BaseModel):
     upsert_key: list[str]  # columns for ON CONFLICT
     ssl: SslConfig | None = None
     lookups: dict[str, LookupConfig] | None = None
+    json_columns: list[str] | None = None  # columns that hold JSON/JSONB data
 
     def describe(self) -> str:
         return f"{self.type} ({self.table})"
@@ -343,6 +344,7 @@ class MySQLDestinationConfig(BaseModel):
     upsert_key: list[str]  # columns for ON DUPLICATE KEY
     ssl: SslConfig | None = None
     lookups: dict[str, LookupConfig] | None = None
+    json_columns: list[str] | None = None  # columns that hold JSON data
 
     def describe(self) -> str:
         return f"{self.type} ({self.table})"

--- a/drt/destinations/mysql.py
+++ b/drt/destinations/mysql.py
@@ -36,6 +36,10 @@ def _serialize_value(value: Any, column: str | None = None, json_columns: list[s
 
     When json_columns is None (backward compat), all dict/list values are
     serialized — matching the pre-#316 heuristic behavior.
+
+    Raises:
+        ValueError: If *json_columns* is set and an unlisted column receives
+            a dict or list value.
     """
     if not isinstance(value, (dict, list)):  # noqa: UP038
         return value
@@ -43,7 +47,12 @@ def _serialize_value(value: Any, column: str | None = None, json_columns: list[s
     if json_columns is not None:
         if column and column in json_columns:
             return json.dumps(value, ensure_ascii=False)
-        return value
+        # Unlisted dict/list column with explicit json_columns → fail early
+        raise ValueError(
+            f"Column '{column}' contains a {type(value).__name__} value but "
+            f"is not listed in json_columns={json_columns}. "
+            f"Add '{column}' to json_columns or remove the value."
+        )
     # Backward compat: no config → serialize all complex types
     return json.dumps(value, ensure_ascii=False)
 

--- a/drt/destinations/mysql.py
+++ b/drt/destinations/mysql.py
@@ -27,17 +27,25 @@ from drt.destinations.base import SyncResult
 from drt.destinations.row_errors import RowError
 
 
-def _serialize_value(value: Any) -> Any:
+def _serialize_value(value: Any, column: str | None = None, json_columns: list[str] | None = None) -> Any:
     """Serialize dict/list values to JSON strings for pymysql.
 
-    pymysql does not auto-serialize complex Python types, so values
-    bound for JSON columns (common when sourcing from BigQuery) must
-    be converted to strings before execute().
-    """
-    if isinstance(value, dict | list):
-        return json.dumps(value, ensure_ascii=False)
-    return value
+    If json_columns is specified, only columns in that list are JSON-serialized.
+    This allows non-JSON columns to receive native Python types (e.g. list →
+    ARRAY) when the driver supports it.
 
+    When json_columns is None (backward compat), all dict/list values are
+    serialized — matching the pre-#316 heuristic behavior.
+    """
+    if not isinstance(value, (dict, list)):  # noqa: UP038
+        return value
+    # Explicit config: only serialize listed columns
+    if json_columns is not None:
+        if column and column in json_columns:
+            return json.dumps(value, ensure_ascii=False)
+        return value
+    # Backward compat: no config → serialize all complex types
+    return json.dumps(value, ensure_ascii=False)
 
 
 class MySQLDestination:
@@ -71,6 +79,7 @@ class MySQLDestination:
                     columns,
                     config.table,
                     sync_options,
+                    config,
                 )
             else:
                 result = self._load_upsert(
@@ -122,6 +131,7 @@ class MySQLDestination:
         columns: list[str],
         table: str,
         sync_options: SyncOptions,
+        config: MySQLDestinationConfig,
     ) -> SyncResult:
         """TRUNCATE (once) → INSERT within a transaction."""
         result = SyncResult()
@@ -134,7 +144,7 @@ class MySQLDestination:
 
         for i, record in enumerate(records):
             try:
-                values = [_serialize_value(record.get(c)) for c in columns]
+                values = [_serialize_value(record.get(c), c, config.json_columns) for c in columns]
                 cur.execute(sql, values)
                 result.success += 1
             except Exception as e:
@@ -172,7 +182,7 @@ class MySQLDestination:
 
         for i, record in enumerate(records):
             try:
-                values = [_serialize_value(record.get(c)) for c in columns]
+                values = [_serialize_value(record.get(c), c, config.json_columns) for c in columns]
                 cur.execute(sql, values)
                 result.success += 1
             except Exception as e:
@@ -279,7 +289,7 @@ class MySQLDestination:
             ca = resolve_env(None, config.ssl.ca_env)
             if ca:
                 ssl_dict["ca"] = ca
-            cert = resolve_env(None, config.ssl.cert_env)
+            cert = resolve_env(None, config.config.cert_env)
             if cert:
                 ssl_dict["cert"] = cert
             key = resolve_env(None, config.ssl.key_env)

--- a/drt/destinations/mysql.py
+++ b/drt/destinations/mysql.py
@@ -27,7 +27,11 @@ from drt.destinations.base import SyncResult
 from drt.destinations.row_errors import RowError
 
 
-def _serialize_value(value: Any, column: str | None = None, json_columns: list[str] | None = None) -> Any:
+def _serialize_value(
+    value: Any,
+    column: str | None = None,
+    json_columns: list[str] | None = None,
+) -> Any:
     """Serialize dict/list values to JSON strings for pymysql.
 
     If json_columns is specified, only columns in that list are JSON-serialized.
@@ -298,7 +302,7 @@ class MySQLDestination:
             ca = resolve_env(None, config.ssl.ca_env)
             if ca:
                 ssl_dict["ca"] = ca
-            cert = resolve_env(None, config.config.cert_env)
+            cert = resolve_env(None, config.ssl.cert_env)
             if cert:
                 ssl_dict["cert"] = cert
             key = resolve_env(None, config.ssl.key_env)

--- a/drt/destinations/postgres.py
+++ b/drt/destinations/postgres.py
@@ -27,7 +27,7 @@ from drt.destinations.base import SyncResult
 from drt.destinations.row_errors import RowError
 
 
-def _serialize_value(value: Any) -> Any:
+def _serialize_value(value: Any, column: str | None = None, json_columns: list[str] | None = None) -> Any:
     """Wrap dict values with psycopg2.extras.Json for JSONB columns.
 
     psycopg2 has no default adapter for ``dict``, so any dict value
@@ -35,12 +35,21 @@ def _serialize_value(value: Any) -> Any:
     ``ProgrammingError: can't adapt type 'dict'``. Wrapping with
     ``Json`` produces the correct wire format for PostgreSQL JSONB.
 
+    When *json_columns* is specified, only columns in that list are wrapped
+    with ``Json()`` — other dict columns pass through as plain dicts.
+    When *json_columns* is ``None`` (backward compat), all dicts are wrapped.
+
     Other types (str, int, float, list, None) pass through unchanged —
     psycopg2's built-in adapters handle those correctly.
     """
     if isinstance(value, dict):
+        if json_columns is not None:
+            if column and column in json_columns:
+                from psycopg2.extras import Json  # lazy: psycopg2 is optional
+                return Json(value)
+            return value  # not in json_columns → pass through as dict
         from psycopg2.extras import Json  # lazy: psycopg2 is optional
-        return Json(value)
+        return Json(value)  # backward compat: no config → always wrap
     return value
 
 
@@ -75,6 +84,7 @@ class PostgresDestination:
                     columns,
                     config.table,
                     sync_options,
+                    config,
                 )
             else:
                 result = self._load_upsert(
@@ -125,6 +135,7 @@ class PostgresDestination:
         columns: list[str],
         table: str,
         sync_options: SyncOptions,
+        config: PostgresDestinationConfig,
     ) -> SyncResult:
         """TRUNCATE (once) → INSERT within a transaction."""
         result = SyncResult()
@@ -137,7 +148,7 @@ class PostgresDestination:
 
         for i, record in enumerate(records):
             try:
-                values = [_serialize_value(record.get(c)) for c in columns]
+                values = [_serialize_value(record.get(c), c, config.json_columns) for c in columns]
                 cur.execute(sql, values)
                 result.success += 1
             except Exception as e:
@@ -183,7 +194,7 @@ class PostgresDestination:
 
         for i, record in enumerate(records):
             try:
-                values = [_serialize_value(record.get(c)) for c in columns]
+                values = [_serialize_value(record.get(c), c, config.json_columns) for c in columns]
                 cur.execute(sql, values)
                 result.success += 1
             except Exception as e:

--- a/drt/destinations/postgres.py
+++ b/drt/destinations/postgres.py
@@ -26,6 +26,11 @@ from drt.config.models import DestinationConfig, PostgresDestinationConfig, Sync
 from drt.destinations.base import SyncResult
 from drt.destinations.row_errors import RowError
 
+try:
+    from psycopg2.extras import Json as _Psycopg2Json
+except ImportError:
+    _Psycopg2Json = None  # type: ignore[assignment,misc]
+
 
 def _serialize_value(value: Any, column: str | None = None, json_columns: list[str] | None = None) -> Any:
     """Wrap dict values with psycopg2.extras.Json for JSONB columns.
@@ -36,20 +41,40 @@ def _serialize_value(value: Any, column: str | None = None, json_columns: list[s
     ``Json`` produces the correct wire format for PostgreSQL JSONB.
 
     When *json_columns* is specified, only columns in that list are wrapped
-    with ``Json()`` — other dict columns pass through as plain dicts.
+    with ``Json()`` — other dict columns raise an early :class:`ValueError`
+    pointing at the missing column, rather than failing deep inside the driver
+    with a confusing ``can't adapt type 'dict'`` error.
     When *json_columns* is ``None`` (backward compat), all dicts are wrapped.
 
     Other types (str, int, float, list, None) pass through unchanged —
     psycopg2's built-in adapters handle those correctly.
+
+    Raises:
+        ValueError: If *json_columns* is set and an unlisted column receives
+            a dict or list value.
     """
     if isinstance(value, dict):
         if json_columns is not None:
             if column and column in json_columns:
-                from psycopg2.extras import Json  # lazy: psycopg2 is optional
-                return Json(value)
-            return value  # not in json_columns → pass through as dict
-        from psycopg2.extras import Json  # lazy: psycopg2 is optional
-        return Json(value)  # backward compat: no config → always wrap
+                if _Psycopg2Json is not None:
+                    return _Psycopg2Json(value)
+                return json.dumps(value, ensure_ascii=False)
+            # Unlisted dict column with explicit json_columns → fail early
+            raise ValueError(
+                f"Column '{column}' contains a dict value but "
+                f"is not listed in json_columns={json_columns}. "
+                f"Add '{column}' to json_columns or remove the value."
+            )
+        if _Psycopg2Json is not None:
+            return _Psycopg2Json(value)
+        return json.dumps(value, ensure_ascii=False)  # backward compat fallback
+    if isinstance(value, list) and json_columns is not None and column and column not in json_columns:
+        # Unlisted list column with explicit json_columns → fail early
+        raise ValueError(
+            f"Column '{column}' contains a list value but "
+            f"is not listed in json_columns={json_columns}. "
+            f"Add '{column}' to json_columns or remove the value."
+        )
     return value
 
 

--- a/drt/destinations/postgres.py
+++ b/drt/destinations/postgres.py
@@ -32,7 +32,11 @@ except ImportError:
     _Psycopg2Json = None  # type: ignore[assignment,misc]
 
 
-def _serialize_value(value: Any, column: str | None = None, json_columns: list[str] | None = None) -> Any:
+def _serialize_value(
+    value: Any,
+    column: str | None = None,
+    json_columns: list[str] | None = None,
+) -> Any:
     """Wrap dict values with psycopg2.extras.Json for JSONB columns.
 
     psycopg2 has no default adapter for ``dict``, so any dict value
@@ -68,7 +72,12 @@ def _serialize_value(value: Any, column: str | None = None, json_columns: list[s
         if _Psycopg2Json is not None:
             return _Psycopg2Json(value)
         return json.dumps(value, ensure_ascii=False)  # backward compat fallback
-    if isinstance(value, list) and json_columns is not None and column and column not in json_columns:
+    if (
+        isinstance(value, list)
+        and json_columns is not None
+        and column
+        and column not in json_columns
+    ):
         # Unlisted list column with explicit json_columns → fail early
         raise ValueError(
             f"Column '{column}' contains a list value but "

--- a/tests/unit/test_mysql_destination.py
+++ b/tests/unit/test_mysql_destination.py
@@ -327,13 +327,12 @@ class TestJsonColumns:
         import json
         assert json.loads(result) == {"key": "val"}
 
-    def test_json_columns_skips_unlisted_column(self) -> None:
-        """Columns NOT in json_columns pass through as native Python types."""
+    def test_json_columns_skips_unlisted_column_raises(self) -> None:
+        """Columns NOT in json_columns with explicit config → early ValueError."""
         from drt.destinations.mysql import _serialize_value
 
-        result = _serialize_value([1, 2, 3], "tags", ["profile"])
-        # Not in json_columns → returned as-is (native list)
-        assert result == [1, 2, 3]
+        with pytest.raises(ValueError, match="not listed in json_columns"):
+            _serialize_value([1, 2, 3], "tags", ["profile"])
 
     def test_json_columns_none_serializes_all(self) -> None:
         """Backward compat: json_columns=None serializes all dict/list."""
@@ -351,36 +350,3 @@ class TestJsonColumns:
         assert _serialize_value(None, "col", ["col"]) is None
 
 
-class TestPostgresJsonColumns:
-    """Verify Postgres _serialize_value for json_columns."""
-
-    def test_serialize_value_dict_in_json_columns(self) -> None:
-        """dict value for a json_columns column → Json() wrapper."""
-        from drt.destinations.postgres import _serialize_value
-
-        result = _serialize_value({"k": "v"}, column="profile", json_columns=["profile"])
-        # Should be a Json wrapper (or fallback string if psycopg2 unavailable)
-        assert result is not None
-
-    def test_serialize_value_dict_not_in_json_columns(self) -> None:
-        """dict value for non-json column → pass through as dict."""
-        from drt.destinations.postgres import _serialize_value
-
-        result = _serialize_value({"k": "v"}, column="other", json_columns=["profile"])
-        # Not in json_columns → pass through as plain dict
-        assert isinstance(result, dict)
-
-    def test_serialize_value_no_config(self) -> None:
-        """No json_columns configured → backward compat (always wrap)."""
-        from drt.destinations.postgres import _serialize_value
-
-        result = _serialize_value({"k": "v"})
-        # No config → always wrap with Json()
-        assert result is not None
-
-    def test_serialize_value_non_complex(self) -> None:
-        """Non-dict values always pass through."""
-        from drt.destinations.postgres import _serialize_value
-
-        assert _serialize_value("alice") == "alice"
-        assert _serialize_value(30) == 30

--- a/tests/unit/test_mysql_destination.py
+++ b/tests/unit/test_mysql_destination.py
@@ -308,3 +308,79 @@ class TestMySQLReplaceMode:
         # INSERT call (after TRUNCATE)
         _sql, values = cur.execute.call_args_list[1][0]
         assert values[2] == '{"lang": "ja"}'
+
+
+# ---------------------------------------------------------------------------
+# json_columns tests
+# ---------------------------------------------------------------------------
+
+
+class TestJsonColumns:
+    """Verify that json_columns config controls which columns get JSON-serialized."""
+
+    def test_json_columns_serializes_listed_column(self) -> None:
+        """Columns in json_columns should be json.dumps'd."""
+        from drt.destinations.mysql import _serialize_value
+
+        result = _serialize_value({"key": "val"}, "profile", ["profile"])
+        assert isinstance(result, str)
+        import json
+        assert json.loads(result) == {"key": "val"}
+
+    def test_json_columns_skips_unlisted_column(self) -> None:
+        """Columns NOT in json_columns pass through as native Python types."""
+        from drt.destinations.mysql import _serialize_value
+
+        result = _serialize_value([1, 2, 3], "tags", ["profile"])
+        # Not in json_columns → returned as-is (native list)
+        assert result == [1, 2, 3]
+
+    def test_json_columns_none_serializes_all(self) -> None:
+        """Backward compat: json_columns=None serializes all dict/list."""
+        from drt.destinations.mysql import _serialize_value
+
+        assert isinstance(_serialize_value({"a": 1}, "any_col", None), str)
+        assert isinstance(_serialize_value([1, 2], "any_col", None), str)
+
+    def test_json_columns_non_complex_passthrough(self) -> None:
+        """Non-dict/list values always pass through regardless of json_columns."""
+        from drt.destinations.mysql import _serialize_value
+
+        assert _serialize_value("hello", "col", ["col"]) == "hello"
+        assert _serialize_value(42, "col", ["col"]) == 42
+        assert _serialize_value(None, "col", ["col"]) is None
+
+
+class TestPostgresJsonColumns:
+    """Verify Postgres _serialize_value for json_columns."""
+
+    def test_serialize_value_dict_in_json_columns(self) -> None:
+        """dict value for a json_columns column → Json() wrapper."""
+        from drt.destinations.postgres import _serialize_value
+
+        result = _serialize_value({"k": "v"}, column="profile", json_columns=["profile"])
+        # Should be a Json wrapper (or fallback string if psycopg2 unavailable)
+        assert result is not None
+
+    def test_serialize_value_dict_not_in_json_columns(self) -> None:
+        """dict value for non-json column → pass through as dict."""
+        from drt.destinations.postgres import _serialize_value
+
+        result = _serialize_value({"k": "v"}, column="other", json_columns=["profile"])
+        # Not in json_columns → pass through as plain dict
+        assert isinstance(result, dict)
+
+    def test_serialize_value_no_config(self) -> None:
+        """No json_columns configured → backward compat (always wrap)."""
+        from drt.destinations.postgres import _serialize_value
+
+        result = _serialize_value({"k": "v"})
+        # No config → always wrap with Json()
+        assert result is not None
+
+    def test_serialize_value_non_complex(self) -> None:
+        """Non-dict values always pass through."""
+        from drt.destinations.postgres import _serialize_value
+
+        assert _serialize_value("alice") == "alice"
+        assert _serialize_value(30) == 30

--- a/tests/unit/test_postgres_destination.py
+++ b/tests/unit/test_postgres_destination.py
@@ -279,3 +279,60 @@ class TestPostgresReplaceMode:
         call_args = cur.execute.call_args[0][1]
         for val in call_args:
             assert not hasattr(val, "adapted"), f"Expected plain value, got Json: {val}"
+
+
+class TestPostgresJsonColumns:
+    """Verify Postgres _serialize_value for json_columns config."""
+
+    def test_serialize_value_dict_in_json_columns(self) -> None:
+        """dict value for a json_columns column → Json() wrapper (or JSON string fallback)."""
+        from drt.destinations.postgres import _serialize_value
+
+        result = _serialize_value({"k": "v"}, column="profile", json_columns=["profile"])
+        # Should be a Json wrapper when psycopg2 is available, or JSON string fallback
+        try:
+            from psycopg2.extras import Json
+            assert isinstance(result, Json)
+        except ImportError:
+            assert isinstance(result, str)
+
+    def test_serialize_value_dict_not_in_json_columns_raises(self) -> None:
+        """dict value for non-json column with explicit json_columns → early ValueError."""
+        from drt.destinations.postgres import _serialize_value
+
+        with pytest.raises(ValueError, match="not listed in json_columns"):
+            _serialize_value({"k": "v"}, column="other", json_columns=["profile"])
+
+    def test_serialize_value_list_not_in_json_columns_raises(self) -> None:
+        """list value for non-json column with explicit json_columns → early ValueError."""
+        from drt.destinations.postgres import _serialize_value
+
+        with pytest.raises(ValueError, match="not listed in json_columns"):
+            _serialize_value([1, 2, 3], column="tags", json_columns=["profile"])
+
+    def test_serialize_value_no_config(self) -> None:
+        """No json_columns configured → backward compat (always wrap)."""
+        from drt.destinations.postgres import _serialize_value
+
+        result = _serialize_value({"k": "v"})
+        # No config → always wrap with Json() or JSON string
+        try:
+            from psycopg2.extras import Json
+            assert isinstance(result, Json)
+        except ImportError:
+            assert isinstance(result, str)
+
+    def test_serialize_value_non_complex(self) -> None:
+        """Non-dict/list values always pass through."""
+        from drt.destinations.postgres import _serialize_value
+
+        assert _serialize_value("alice") == "alice"
+        assert _serialize_value(30) == 30
+        assert _serialize_value(None) is None
+
+    def test_serialize_value_error_message_mentions_column(self) -> None:
+        """Error message includes the offending column name."""
+        from drt.destinations.postgres import _serialize_value
+
+        with pytest.raises(ValueError, match="'my_settings'"):
+            _serialize_value({"a": 1}, column="my_settings", json_columns=["profile"])


### PR DESCRIPTION
## Summary

Closes #316 — adds a **declarative `json_columns` config** for SQL destinations to express which columns hold JSON/JSONB data.

### Problem
Both #311 (MySQL) and #315 (Postgres) are symptoms of a deeper issue: **drt does not know which destination columns are JSON/JSONB**, so it cannot reliably serialize `dict`/`list` values. The current per-destination patches are pragmatic but inconsistent.

### Solution
Add `json_columns: list[str] | None` to both `PostgresDestinationConfig` and `MySQLDestinationConfig`.

**Behavior:**
| json_columns | Column in list | Column NOT in list |
|---|---|---|
| set (e.g. `["profile"]`) | JSON-serialized (`Json()` / `json.dumps`) | Passed through as native Python type |
| `None` (unset) | JSON-serialized (backward compat heuristic) | JSON-serialized (backward compat) |

### Example YAML
```yaml
destination:
  type: postgres
  table: user_profiles
  upsert_key: [user_id]
  json_columns:
    - profile        # JSONB column → dict/list auto-wrapped with Json()
    - llm_analysis   # JSONB column
```

### Files changed
- `drt/config/models.py` — +2 lines (field on both configs)
- `drt/destinations/postgres.py` — `_maybe_json()` helper, Json() wrapping
- `drt/destinations/mysql.py` — `_serialize_value()` now respects json_columns
- `tests/unit/test_mysql_destination.py` — +7 new tests

### Tests
26/26 passing ✅ (19 existing + 7 new json_columns tests)