### PR TITLE
fix(postgres): wrap dict values with Json adapter for JSONB columns

### DIFF
--- a/drt/destinations/postgres.py
+++ b/drt/destinations/postgres.py
@@ -22,6 +22,19 @@ import json
 from typing import Any
 
 from drt.config.credentials import resolve_env
+
+
+def _serialize_value(value: Any) -> Any:
+    """Wrap dict values with psycopg2 Json adapter for JSONB columns.
+
+    psycopg2 has no default adapter for dict, so bare dict values cause
+    ``ProgrammingError: can't adapt type 'dict'`` when bound to JSONB columns.
+    """
+    from psycopg2.extras import Json
+
+    if isinstance(value, dict):
+        return Json(value)
+    return value
 from drt.config.models import DestinationConfig, PostgresDestinationConfig, SyncOptions
 from drt.destinations.base import SyncResult
 from drt.destinations.row_errors import RowError
@@ -120,7 +133,7 @@ class PostgresDestination:
 
         for i, record in enumerate(records):
             try:
-                values = [record.get(c) for c in columns]
+                values = [_serialize_value(record.get(c)) for c in columns]
                 cur.execute(sql, values)
                 result.success += 1
             except Exception as e:
@@ -166,7 +179,7 @@ class PostgresDestination:
 
         for i, record in enumerate(records):
             try:
-                values = [record.get(c) for c in columns]
+                values = [_serialize_value(record.get(c)) for c in columns]
                 cur.execute(sql, values)
                 result.success += 1
             except Exception as e:

--- a/tests/unit/test_postgres_destination.py
+++ b/tests/unit/test_postgres_destination.py
@@ -189,6 +189,30 @@ class TestPostgresDestinationLoad:
         PostgresDestination().load([{"id": 1, "score": 0.5}], _config(), _options(on_error="fail"))
         conn.close.assert_called_once()
 
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_dict_value_wrapped_as_json_for_jsonb(self, mock_connect: MagicMock) -> None:
+        """dict values must be wrapped with psycopg2.extras.Json for JSONB columns."""
+        from unittest.mock import call
+        from psycopg2.extras import Json
+
+        conn = _fake_connection()
+        mock_connect.return_value = conn
+
+        records = [
+            {"id": 1, "profile": {"lang": "ja", "level": 5}},
+            {"id": 2, "profile": {"lang": "en"}},
+        ]
+        result = PostgresDestination().load(records, _config(), _options())
+
+        assert result.success == 2
+        assert result.failed == 0
+        # Verify dict values were wrapped with Json adapter
+        execute_calls = conn.cursor().execute.call_args_list
+        for call_item in execute_calls:
+            values = call_item[0][1]  # second positional arg = values tuple/list
+            profile_val = values[1]  # profile column (index 1 after id)
+            assert isinstance(profile_val, Json), f"Expected Json adapter, got {type(profile_val)}"
+
 
 # ---------------------------------------------------------------------------
 # Replace mode


### PR DESCRIPTION
## Problem

Syncing records that contain `dict` values (e.g. a BigQuery JSON column read as a Python dict, written to a Postgres JSONB column) crashes with:

```
ProgrammingError: can't adapt type 'dict'
```

psycopg2 does not ship a default adapter for `dict`, so bare dict values cannot be bound directly.

## Fix

Added a `_serialize_value()` helper that wraps `dict` values with `psycopg2.extras.Json` before passing them to `cursor.execute()`. Non-dict values pass through unchanged. The helper is used in both `_load_replace()` and `_load_upsert()`.

This is the same approach taken for the MySQL destination in #311 / v0.5.1.

## Testing

- Added unit test verifying that dict record values are wrapped with the `Json` adapter
- All 18 existing + new tests pass

Fixes #315
