### PR TITLE
Add --output json flag to drt test command

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -8,7 +8,7 @@ import os
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import click
 import typer
@@ -710,6 +710,15 @@ def status(
 # ---------------------------------------------------------------------------
 
 
+class _SyncTestResult(TypedDict, total=False):
+    """Type hint for test result dict in JSON output."""
+
+    sync: str
+    tests: list[dict[str, object]]
+    skipped: bool
+    reason: str
+
+
 @app.command(name="test")
 def test_syncs(
     output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
@@ -727,7 +736,7 @@ def test_syncs(
     from drt.engine.test_runner import build_test_query
 
     json_mode = output == "json"
-    results = []
+    results: list[_SyncTestResult] = []
 
     syncs = load_syncs(Path("."))
     if not syncs:
@@ -756,7 +765,7 @@ def test_syncs(
     for sync in syncs_with_tests:
         if not json_mode:
             print_test_header(sync.name)
-        sync_results = {"sync": sync.name, "tests": []}
+        sync_results: _SyncTestResult = {"sync": sync.name, "tests": []}
 
         if not is_queryable(sync.destination):
             if not json_mode:

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -712,9 +712,11 @@ def status(
 
 @app.command(name="test")
 def test_syncs(
+    output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
     select: str = typer.Option(None, "--select", "-s", help="Test a specific sync by name."),
 ) -> None:
     """Run post-sync validation tests."""
+    import json as json_mod
     from drt.config.parser import load_syncs
     from drt.destinations.query import (
         execute_test_query,
@@ -723,9 +725,15 @@ def test_syncs(
     )
     from drt.engine.test_runner import build_test_query
 
+    json_mode = output == "json"
+    results = []
+
     syncs = load_syncs(Path("."))
     if not syncs:
-        console.print("[dim]No syncs found.[/dim]")
+        if not json_mode:
+            console.print("[dim]No syncs found.[/dim]")
+        else:
+            print(json_mod.dumps({"status": "no_syncs", "results": []}))
         return
 
     if select:
@@ -736,19 +744,28 @@ def test_syncs(
 
     syncs_with_tests = [s for s in syncs if s.tests]
     if not syncs_with_tests:
-        console.print("[dim]No tests defined in any sync.[/dim]")
+        if not json_mode:
+            console.print("[dim]No tests defined in any sync.[/dim]")
+        else:
+            print(json_mod.dumps({"status": "no_tests", "results": []}))
         return
 
     had_failures = False
 
     for sync in syncs_with_tests:
-        print_test_header(sync.name)
+        if not json_mode:
+            print_test_header(sync.name)
+        sync_results = {"sync": sync.name, "tests": []}
 
         if not is_queryable(sync.destination):
-            print_test_skip(
-                sync.name,
-                f"tests not supported for {sync.destination.type} destinations",
-            )
+            if not json_mode:
+                print_test_skip(
+                    sync.name,
+                    f"tests not supported for {sync.destination.type} destinations",
+                )
+            sync_results["skipped"] = True
+            sync_results["reason"] = f"tests not supported for {sync.destination.type}"
+            results.append(sync_results)
             continue
 
         table = get_table_name(sync.destination)
@@ -758,13 +775,21 @@ def test_syncs(
                 query, check = build_test_query(test_def, table)
                 result_val = execute_test_query(sync.destination, query)
                 passed = check(result_val)
-                print_test_result(test_name, passed, str(result_val))
+                if not json_mode:
+                    print_test_result(test_name, passed, str(result_val))
+                sync_results["tests"].append({"name": test_name, "passed": passed, "value": str(result_val)})
                 if not passed:
                     had_failures = True
             except Exception as e:
-                print_test_result(test_name, False, str(e))
+                if not json_mode:
+                    print_test_result(test_name, False, str(e))
+                sync_results["tests"].append({"name": test_name, "passed": False, "error": str(e)})
                 had_failures = True
+        
+        results.append(sync_results)
 
+    if json_mode:
+        print(json_mod.dumps({"status": "failed" if had_failures else "passed", "results": results}))
     if had_failures:
         raise typer.Exit(1)
 

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -717,6 +717,7 @@ def test_syncs(
 ) -> None:
     """Run post-sync validation tests."""
     import json as json_mod
+
     from drt.config.parser import load_syncs
     from drt.destinations.query import (
         execute_test_query,
@@ -777,19 +778,27 @@ def test_syncs(
                 passed = check(result_val)
                 if not json_mode:
                     print_test_result(test_name, passed, str(result_val))
-                sync_results["tests"].append({"name": test_name, "passed": passed, "value": str(result_val)})
+                sync_results["tests"].append(
+                    {"name": test_name, "passed": passed, "value": str(result_val)}
+                )
                 if not passed:
                     had_failures = True
             except Exception as e:
                 if not json_mode:
                     print_test_result(test_name, False, str(e))
-                sync_results["tests"].append({"name": test_name, "passed": False, "error": str(e)})
+                sync_results["tests"].append(
+                    {"name": test_name, "passed": False, "error": str(e)}
+                )
                 had_failures = True
         
         results.append(sync_results)
 
     if json_mode:
-        print(json_mod.dumps({"status": "failed" if had_failures else "passed", "results": results}))
+        print(
+            json_mod.dumps(
+                {"status": "failed" if had_failures else "passed", "results": results}
+            )
+        )
     if had_failures:
         raise typer.Exit(1)
 

--- a/tests/unit/test_cli_test_output_json.py
+++ b/tests/unit/test_cli_test_output_json.py
@@ -1,0 +1,112 @@
+"""Tests for drt test --output json."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from drt.cli.main import app
+
+runner = CliRunner()
+
+
+def _write_sync(tmp_path: Path, data: dict) -> None:
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir(exist_ok=True)
+    with (syncs_dir / "sync.yml").open("w") as f:
+        yaml.dump(data, f)
+
+
+def _write_credentials(tmp_path: Path) -> None:
+    """Write minimal credentials for tests."""
+    creds_dir = tmp_path / ".drt"
+    creds_dir.mkdir(exist_ok=True)
+    with (creds_dir / "credentials.yml").open("w") as f:
+        yaml.dump(
+            {"profiles": {"default": {"type": "duckdb", "path": "/tmp/test.db"}}},
+            f,
+        )
+
+
+def test_test_json_no_syncs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """test --output json with no syncs should return empty results."""
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["test", "--output", "json"])
+    data = json.loads(result.output)
+    assert data["status"] == "no_syncs"
+    assert data["results"] == []
+
+
+def test_test_json_no_tests(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """test --output json with syncs but no tests defined."""
+    monkeypatch.chdir(tmp_path)
+    _write_sync(
+        tmp_path,
+        {
+            "name": "no-tests",
+            "model": "SELECT 1",
+            "destination": {
+                "type": "rest_api",
+                "url": "http://example.com",
+                "method": "POST",
+            },
+        },
+    )
+    result = runner.invoke(app, ["test", "--output", "json"])
+    data = json.loads(result.output)
+    assert data["status"] == "no_tests"
+    assert data["results"] == []
+
+
+def test_test_json_non_queryable_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """test --output json with non-queryable destination marks sync as skipped."""
+    monkeypatch.chdir(tmp_path)
+    _write_sync(
+        tmp_path,
+        {
+            "name": "api-sync",
+            "model": "SELECT 1",
+            "destination": {
+                "type": "rest_api",
+                "url": "http://example.com",
+                "method": "POST",
+            },
+            "tests": [{"row_count": {"min": 1}}],
+        },
+    )
+    result = runner.invoke(app, ["test", "--output", "json"])
+    data = json.loads(result.output)
+    assert data["status"] == "passed"
+    assert len(data["results"]) == 1
+    assert data["results"][0]["sync"] == "api-sync"
+    assert data["results"][0]["skipped"] is True
+
+
+def test_test_json_no_rich_markup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """JSON output should not contain Rich markup."""
+    monkeypatch.chdir(tmp_path)
+    _write_sync(
+        tmp_path,
+        {
+            "name": "test-sync",
+            "model": "SELECT 1",
+            "destination": {
+                "type": "rest_api",
+                "url": "http://example.com",
+                "method": "POST",
+            },
+            "tests": [{"row_count": {"min": 1}}],
+        },
+    )
+    result = runner.invoke(app, ["test", "--output", "json"])
+    # Should not contain rich markup
+    assert "[dim]" not in result.output
+    assert "[bold" not in result.output
+    # Should be valid JSON
+    json.loads(result.output)


### PR DESCRIPTION
## Description

Adds --output json / -o json flag to the drt test command, matching the functionality already available in drt run, drt status, drt list, and drt validate.

## Changes

- Added output parameter with typer.Option to test_syncs() function
- Added JSON mode detection and handling
- Implemented JSON output path that skips Rich markup
- Maintains backward compatibility (default remains text output)
- Structured JSON response includes status and results array

## Testing

- Follows existing pattern from other commands
- JSON output avoids Rich markup as required
- Tested locally with various scenarios

## Disclosure

This contribution was generated with AI assistance and reviewed before submission.

Closes #366