### PR TITLE
fix(config): support ${VAR} env substitution in all sync YAML fields

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "drt",
       "source": "./skills/drt",
       "description": "Create syncs, debug failures, initialize projects, and migrate from Census/Hightouch to drt",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "homepage": "https://github.com/drt-hub/drt",
       "repository": "https://github.com/drt-hub/drt",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "drt-hub",
   "description": "Skills for drt \u2014 Reverse ETL for the code-first data stack",
-  "version": "0.6.0"
+  "version": "0.6.1"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`${VAR}` env substitution in sync YAML** (#385): Environment variable placeholders now work in all string fields of sync YAML (e.g. `watermark.bucket`, `destination.url`), not just `model:` SQL. Also shipped in [0.6.1](#061---2026-04-20).
+
+## [0.6.1] - 2026-04-20
+
+### Fixed
+
+- **`${VAR}` env substitution in sync YAML** (#385): Environment variable placeholders like `${PIPES_GCS_BUCKET}` are now expanded in **all string fields** of sync YAML config — not just the `model:` SQL. This enables multi-environment setups (DEV/PRD) without duplicating sync files. Common use cases: `sync.watermark.bucket`, `destination.url`, `destination.host`. Missing variables raise `ValueError` consistently with the existing SQL expansion behaviour.
+
 ## [0.6.0] - 2026-04-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,12 +50,13 @@ make fmt      # ruff format + fix
 
 ## Current Status
 
-- **v0.6.0 released** — Notion/Twilio/Intercom/Email SMTP/Salesforce Bulk/Google Ads destinations, `--threads` parallel execution, `--log-format json`, `--select tag:`, JSON Schema validation, freshness/unique/accepted_values tests, `drt sources`/`drt destinations`, `--dry-run` row count diff, StagedDestination Protocol, destination_lookup, GOVERNANCE.md
+- **v0.6.1 released** — `${VAR}` env substitution in all sync YAML string fields (#385)
+- **v0.6.0** — Notion/Twilio/Intercom/Email SMTP/Salesforce Bulk/Google Ads destinations, `--threads` parallel execution, `--log-format json`, `--select tag:`, JSON Schema validation, freshness/unique/accepted_values tests, `drt sources`/`drt destinations`, `--dry-run` row count diff, StagedDestination Protocol, destination_lookup, GOVERNANCE.md
 - CLI fully wired: `init`, `run`, `list`, `validate`, `status`, `test`, `mcp run`, `serve`, `sources`, `destinations`
 - Sources: BigQuery, DuckDB, PostgreSQL, Redshift, SQLite, ClickHouse, Snowflake, MySQL, Databricks, SQL Server
 - Destinations: REST API, Slack, Discord, Microsoft Teams, GitHub Actions, HubSpot, Google Sheets, PostgreSQL, MySQL, ClickHouse, Parquet, CSV/JSON/JSONL, Jira, Linear, SendGrid, Notion, Twilio, Intercom, Email SMTP, Salesforce Bulk, Google Ads, Staged Upload
 - Integrations: MCP Server (`drt-core[mcp]`), dagster-drt, Airflow, Prefect, dbt manifest reader
-- 648+ tests, integration tests use `pytest-httpserver`
+- 659+ tests, integration tests use `pytest-httpserver`
 
 ## What NOT to do
 

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -14,7 +14,7 @@ dlt (load into DWH) → dbt (transform) → drt (activate out of DWH)
 - **Tagline:** "Reverse ETL for the code-first data stack"
 - **Install:** `pip install drt-core` or `uv add drt-core`
 - **Package name:** `drt-core` (PyPI) — CLI command is `drt`
-- **Current version:** v0.6.0
+- **Current version:** v0.6.1
 
 ## What drt is NOT
 

--- a/drt/config/parser.py
+++ b/drt/config/parser.py
@@ -2,13 +2,49 @@
 
 from __future__ import annotations
 
+import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import yaml
 from pydantic import ValidationError
 
 from drt.config.models import ProjectConfig, SyncConfig
+
+_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+
+def _expand_env_vars_in_str(value: str) -> str:
+    """Expand ``${VAR}`` placeholders in a single string.
+
+    Raises ``ValueError`` if a referenced variable is not set.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        var = match.group(1)
+        val = os.environ.get(var)
+        if val is None:
+            raise ValueError(f"Environment variable ${{{var}}} is not set")
+        return val
+
+    return _ENV_VAR_PATTERN.sub(_replace, value)
+
+
+def expand_env_vars(data: Any) -> Any:
+    """Recursively expand ``${VAR}`` in all string values of a parsed YAML tree.
+
+    Dicts, lists, and nested structures are walked. Non-string leaves
+    are returned unchanged.  Raises ``ValueError`` for unset variables.
+    """
+    if isinstance(data, str):
+        return _expand_env_vars_in_str(data)
+    if isinstance(data, dict):
+        return {k: expand_env_vars(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [expand_env_vars(item) for item in data]
+    return data
 
 
 @dataclass
@@ -52,6 +88,7 @@ def load_syncs(project_dir: Path = Path(".")) -> list[SyncConfig]:
     for path in sorted(syncs_dir.glob("*.yml")):
         with path.open() as f:
             data = yaml.safe_load(f)
+        data = expand_env_vars(data)
         syncs.append(SyncConfig.model_validate(data))
     return syncs
 
@@ -66,7 +103,11 @@ def load_syncs_safe(project_dir: Path = Path(".")) -> SyncLoadResult:
         with path.open() as f:
             data = yaml.safe_load(f)
         try:
+            data = expand_env_vars(data)
             result.syncs.append(SyncConfig.model_validate(data))
-        except ValidationError as e:
-            result.errors[path.stem] = _format_validation_errors(e)
+        except (ValidationError, ValueError) as e:
+            if isinstance(e, ValidationError):
+                result.errors[path.stem] = _format_validation_errors(e)
+            else:
+                result.errors[path.stem] = [str(e)]
     return result

--- a/drt/engine/resolver.py
+++ b/drt/engine/resolver.py
@@ -160,6 +160,10 @@ def _expand_env_vars(sql: str) -> str:
     """Expand ``${VAR}`` placeholders with environment variable values.
 
     Raises ``ValueError`` if a referenced variable is not set.
+
+    .. note::
+        For generic (non-SQL) expansion across YAML config trees,
+        see :func:`drt.config.parser.expand_env_vars`.
     """
 
     def _replace(match: re.Match[str]) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "drt-core"
-version = "0.6.0"
+version = "0.6.1"
 description = "Reverse ETL for the code-first data stack"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/skills/drt/.claude-plugin/plugin.json
+++ b/skills/drt/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drt",
   "description": "Skills for drt \u2014 create syncs, debug failures, initialize projects, and migrate from Census/Hightouch",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "drt-hub"
   },

--- a/tests/unit/test_cli_validate.py
+++ b/tests/unit/test_cli_validate.py
@@ -96,6 +96,33 @@ def test_load_syncs_safe_incremental_missing_cursor(tmp_path: Path) -> None:
     assert any("cursor_field" in e for e in result.errors["no-cursor"])
 
 
+def test_load_syncs_safe_expands_env_vars(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SAFE_URL", "https://safe.example.com")
+    _write_sync(
+        tmp_path / "syncs",
+        "env",
+        {**VALID_SYNC, "destination": {**VALID_SYNC["destination"], "url": "${SAFE_URL}"}},
+    )
+    result = load_syncs_safe(tmp_path)
+    assert len(result.syncs) == 1
+    assert result.syncs[0].destination.url == "https://safe.example.com"  # type: ignore[union-attr]
+    assert not result.errors
+
+
+def test_load_syncs_safe_missing_env_var_collected(tmp_path: Path) -> None:
+    _write_sync(
+        tmp_path / "syncs",
+        "bad-env",
+        {**VALID_SYNC, "destination": {**VALID_SYNC["destination"], "url": "${MISSING_VAR}"}},
+    )
+    result = load_syncs_safe(tmp_path)
+    assert not result.syncs
+    assert "bad-env" in result.errors
+    assert any("MISSING_VAR" in e for e in result.errors["bad-env"])
+
+
 # ---------------------------------------------------------------------------
 # _format_validation_errors
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -22,7 +22,7 @@ from drt.config.models import (
     SyncConfig,
     SyncOptions,
 )
-from drt.config.parser import load_project, load_syncs
+from drt.config.parser import expand_env_vars, load_project, load_syncs
 
 # ---------------------------------------------------------------------------
 # Auth model discrimination
@@ -138,6 +138,81 @@ def test_load_syncs(tmp_path: Path) -> None:
     syncs = load_syncs(tmp_path)
     assert len(syncs) == 2
     assert [s.name for s in syncs] == ["alpha", "beta"]
+
+
+# ---------------------------------------------------------------------------
+# expand_env_vars — generic ${VAR} expansion in YAML data
+# ---------------------------------------------------------------------------
+
+
+def test_expand_env_vars_simple_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_BUCKET", "prod-bucket")
+    assert expand_env_vars("${MY_BUCKET}") == "prod-bucket"
+
+
+def test_expand_env_vars_embedded(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROJECT", "analytics")
+    assert expand_env_vars("gs://${PROJECT}/data") == "gs://analytics/data"
+
+
+def test_expand_env_vars_multiple(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOST", "db.example.com")
+    monkeypatch.setenv("PORT", "5432")
+    assert expand_env_vars("${HOST}:${PORT}") == "db.example.com:5432"
+
+
+def test_expand_env_vars_nested_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BUCKET", "my-bucket")
+    monkeypatch.setenv("API_URL", "https://api.example.com")
+    data = {
+        "name": "test",
+        "sync": {"watermark": {"bucket": "${BUCKET}"}},
+        "destination": {"url": "${API_URL}"},
+    }
+    result = expand_env_vars(data)
+    assert result["sync"]["watermark"]["bucket"] == "my-bucket"
+    assert result["destination"]["url"] == "https://api.example.com"
+    assert result["name"] == "test"  # no substitution needed
+
+
+def test_expand_env_vars_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TAG", "production")
+    data = {"tags": ["static", "${TAG}"]}
+    result = expand_env_vars(data)
+    assert result["tags"] == ["static", "production"]
+
+
+def test_expand_env_vars_non_string_unchanged() -> None:
+    data = {"batch_size": 100, "enabled": True, "ratio": 0.5, "empty": None}
+    assert expand_env_vars(data) == data
+
+
+def test_expand_env_vars_missing_raises() -> None:
+    with pytest.raises(ValueError, match="NONEXISTENT_VAR"):
+        expand_env_vars("${NONEXISTENT_VAR}")
+
+
+def test_expand_env_vars_no_placeholders() -> None:
+    assert expand_env_vars("plain string") == "plain string"
+
+
+def test_load_syncs_expands_env_vars(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Environment variables in sync YAML are expanded before validation."""
+    monkeypatch.setenv("TEST_API_URL", "https://expanded.example.com")
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    (syncs_dir / "env_sync.yml").write_text(
+        "name: env-sync\n"
+        "model: SELECT 1\n"
+        "destination:\n"
+        "  type: rest_api\n"
+        "  url: ${TEST_API_URL}\n"
+    )
+    syncs = load_syncs(tmp_path)
+    assert len(syncs) == 1
+    assert syncs[0].destination.url == "https://expanded.example.com"  # type: ignore[union-attr]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #385

- Add generic `expand_env_vars()` to `drt/config/parser.py` that recursively walks parsed YAML dicts and expands `${VAR}` placeholders in all string values
- Apply expansion in `load_syncs()` and `load_syncs_safe()` before Pydantic validation
- Missing variables raise `ValueError` (consistent with existing SQL expansion in `resolver.py`)
- 11 new tests covering: nested dicts, lists, missing vars, integration with sync loading

## Use case

Multi-environment (DEV/PRD) setups can now use env vars in any sync YAML field:

```yaml
sync:
  watermark:
    bucket: ${PIPES_GCS_BUCKET}
destination:
  url: ${API_ENDPOINT}
```

## Also shipped in v0.6.1

This fix is targeted for immediate patch release.

## Test plan

- [x] `expand_env_vars` unit tests (9 cases)
- [x] `load_syncs_safe` env var integration tests (2 cases)  
- [x] All 659 existing tests pass
- [x] `make lint` clean (ruff + mypy)
- [x] `scripts/release-check.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)