### PR TITLE
fix(postgres): wrap dict values with Json adapter for JSONB columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **PostgreSQL destination**: crash when dict values are bound for JSONB columns — `dict` values are now wrapped with `psycopg2.extras.Json` before binding (#315)
+
 - **`${VAR}` env substitution in sync YAML** (#385): Environment variable placeholders now work in all string fields of sync YAML (e.g. `watermark.bucket`, `destination.url`), not just `model:` SQL. Also shipped in [0.6.1](#061---2026-04-20).
 
 ## [0.6.1] - 2026-04-20

--- a/drt/destinations/postgres.py
+++ b/drt/destinations/postgres.py
@@ -21,6 +21,15 @@ from __future__ import annotations
 import json
 from typing import Any
 
+
+def _serialize_value(value: Any) -> Any:
+    """Wrap dict values so psycopg2 can adapt them for JSONB columns."""
+    if isinstance(value, dict):
+        from psycopg2.extras import Json
+
+        return Json(value)
+    return value
+
 from drt.config.credentials import resolve_env
 from drt.config.models import DestinationConfig, PostgresDestinationConfig, SyncOptions
 from drt.destinations.base import SyncResult
@@ -120,7 +129,7 @@ class PostgresDestination:
 
         for i, record in enumerate(records):
             try:
-                values = [record.get(c) for c in columns]
+                values = [_serialize_value(record.get(c)) for c in columns]
                 cur.execute(sql, values)
                 result.success += 1
             except Exception as e:
@@ -166,7 +175,7 @@ class PostgresDestination:
 
         for i, record in enumerate(records):
             try:
-                values = [record.get(c) for c in columns]
+                values = [_serialize_value(record.get(c)) for c in columns]
                 cur.execute(sql, values)
                 result.success += 1
             except Exception as e:

--- a/tests/unit/test_postgres_destination.py
+++ b/tests/unit/test_postgres_destination.py
@@ -191,6 +191,65 @@ class TestPostgresDestinationLoad:
 
 
 # ---------------------------------------------------------------------------
+# Value serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeValue:
+    def test_dict_wrapped_as_json(self) -> None:
+        from drt.destinations.postgres import _serialize_value
+        from unittest.mock import patch
+
+        val = {"lang": "ja"}
+        with patch("psycopg2.extras.Json") as MockJson:
+            mock_json = MockJson.return_value
+            result = _serialize_value(val)
+            MockJson.assert_called_once_with(val)
+            assert result is mock_json
+
+    def test_non_dict_passthrough(self) -> None:
+        from drt.destinations.postgres import _serialize_value
+
+        assert _serialize_value("hello") == "hello"
+        assert _serialize_value(42) == 42
+        assert _serialize_value(None) is None
+        assert _serialize_value([1, 2, 3]) == [1, 2, 3]
+
+
+class TestPostgresDestinationDictValues:
+    """Regression test: dict values bound to JSONB columns must not crash."""
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_dict_value_serialized_in_upsert(self, mock_connect: MagicMock) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        records = [{"id": 1, "profile": {"lang": "ja"}}]
+        result = PostgresDestination().load(records, _config(), _options())
+
+        assert result.success == 1
+        # Verify the value passed to execute is a Json wrapper, not a raw dict
+        call_args = cur.execute.call_args[0][1]
+        assert call_args[1].__class__.__name__ == "Json"
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_dict_value_serialized_in_replace(self, mock_connect: MagicMock) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        records = [{"id": 1, "profile": {"lang": "ja"}}]
+        result = PostgresDestination().load(
+            records, _config(), _options(mode="replace")
+        )
+
+        assert result.success == 1
+        call_args = cur.execute.call_args_list[1][0][1]  # second execute (after TRUNCATE)
+        assert call_args[1].__class__.__name__ == "Json"
+
+
+# ---------------------------------------------------------------------------
 # Replace mode
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Syncing records with `dict` values (e.g. from a BigQuery `JSON` column) to a PostgreSQL `JSONB` column crashes with `ProgrammingError: can't adapt type 'dict'`. psycopg2 has no default adapter for `dict`.

## Fix

Added a `_serialize_value()` helper that wraps `dict` values with `psycopg2.extras.Json` before binding them in both `_load_upsert` and `_load_replace`. Non-dict types pass through unchanged — fully backward compatible.

This is the same pattern used in the MySQL destination fix (#311).

## Changes

- **`drt/destinations/postgres.py`**: add `_serialize_value()` helper, use it in both load paths
- **`tests/unit/test_postgres_destination.py`**: new tests for dict serialization in upsert and replace modes
- **`CHANGELOG.md`**: entry under `[Unreleased] ### Fixed`

Fixes #315.