### PR TITLE
docs: update all documentation for v0.6.0–v0.6.2 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+## [0.6.2] - 2026-04-20
 
-- **`${VAR}` env substitution in sync YAML** (#385): Environment variable placeholders now work in all string fields of sync YAML (e.g. `watermark.bucket`, `destination.url`), not just `model:` SQL. Also shipped in [0.6.1](#061---2026-04-20).
+### Added
+
+- **`watermark.default_value`** (#390): Configure a fallback cursor value for first-run incremental syncs. Prevents broken SQL (e.g. `WHERE TIMESTAMP(...) >= TIMESTAMP('')`) when no watermark file exists yet. Without a default, drt now raises a clear error with actionable guidance instead of silently rendering an empty string.
+- **`--cursor-value` CLI option** (#390): Override the cursor/watermark value at runtime for backfill and recovery scenarios. The override takes highest priority in the fallback chain and the resulting watermark is persisted on success.
+- **Watermark source observability** (#391): Operators can now see *where* the cursor value came from — `storage`, `default_value`, or `cli_override` — via structured INFO logs, `--output json` fields (`watermark_source`, `cursor_value_used`), and an end-of-run summary in text mode.
 
 ## [0.6.1] - 2026-04-20
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ make fmt      # ruff format + fix
 - v0.5 ✅: Snowflake/MySQL sources + ClickHouse/Parquet/CSV+JSON/Jira/Linear/SendGrid destinations + `drt test` + multi-environment + Docker
 - v0.5.4 ✅: `destination_lookup` — resolve FK values by querying destination DB during sync (MySQL / Postgres / ClickHouse)
 - v0.5.5 ✅: `drop_match_columns` — auto-remove lookup match columns from INSERT after FK resolution
-- [v0.6](https://github.com/drt-hub/drt/milestone/3): Salesforce + Airflow integration + Jira / Twilio / Intercom destinations
+- v0.6 ✅: Databricks/SQL Server sources · Notion/Twilio/Intercom/Email SMTP/Salesforce Bulk/Staged Upload destinations · Airflow/Prefect integrations · `drt serve` · `drt sources`/`drt destinations` · `--threads` · `--log-format json` · `--cursor-value` · `watermark.default_value` · test validators · JSON Schema validation · GOVERNANCE.md
 - [v0.7](https://github.com/drt-hub/drt/milestone/4): DWH destinations (Snowflake / BigQuery / ClickHouse / Databricks) + Cloud storage (S3 / GCS / Azure Blob)
 - [v0.8](https://github.com/drt-hub/drt/milestone/5): Lakehouse sources (Delta Lake / Apache Iceberg)
 - v1.x: Rust engine via PyO3

--- a/README.ja.md
+++ b/README.ja.md
@@ -125,13 +125,20 @@ drt run --dry-run           # ドライラン
 drt run --verbose           # 行レベルのエラー詳細を表示
 drt run --output json       # CI/スクリプト向け構造化JSON出力
 drt run --profile prd       # プロファイル切り替え（DRT_PROFILE環境変数でも可）
+drt sources                 # 利用可能なソースコネクタを一覧
+drt destinations            # 利用可能なデスティネーションコネクタを一覧
+drt run --all               # 全同期を検出して実行
+drt run --select tag:<tag>  # タグに一致する同期を実行
+drt run --threads 4         # 並列同期実行
+drt run --log-format json   # 構造化JSONログをstderrに出力
+drt run --cursor-value '…'  # バックフィル用にウォーターマークカーソルを上書き
 drt test                    # 同期後の検証テストを実行
 drt test --select <name>    # 特定の同期テストを実行
 drt validate                # 同期YAML設定を検証
 drt status                  # 直近の同期ステータスを表示
 drt status --output json    # JSON形式でステータスを出力
-drt mcp run                 # MCPサーバーを起動（drt-core[mcp]が必要）
 drt serve                   # HTTPウェブフックエンドポイントを起動
+drt mcp run                 # MCPサーバーを起動（drt-core[mcp]が必要）
 drt --install-completion    # シェル補完をインストール（bash/zsh/fish）
 drt --show-completion       # 補完スクリプトを表示
 ```
@@ -187,6 +194,7 @@ drt mcp run
 | `drt_get_status` | 前回の実行結果を取得 |
 | `drt_validate` | 同期YAML設定を検証 |
 | `drt_get_schema` | 設定ファイルのJSONスキーマを返す |
+| `drt_list_connectors` | 利用可能なソースとデスティネーションを一覧 |
 
 ---
 
@@ -258,7 +266,8 @@ Claude Codeの公式スキルをインストールすると、チャットイン
 | Twilio SMS | ✅ v0.6 | (core) | Basic（Account SID + Auth Token） |
 | Intercom | ✅ v0.6 | (core) | Bearer Token（環境変数） |
 | Email SMTP | ✅ v0.6 | (core) | ユーザー名/パスワード（環境変数） |
-| Salesforce | 🗓 v0.6 | `pip install drt-core[salesforce]` | — |
+| Salesforce Bulk API 2.0 | ✅ v0.6 | (core) | OAuth2（username-password） |
+| Staged Upload | ✅ v0.6 | (core) | プロバイダーごとに設定 |
 
 ### インテグレーション
 
@@ -284,7 +293,7 @@ Claude Codeの公式スキルをインストールすると、チャットイン
 | **v0.4** ✅ | Google Sheets / PostgreSQL / MySQL destinations · dagster-drt · dbt manifest reader · type safety overhaul |
 | **v0.5** ✅ | Snowflake / MySQL sources · ClickHouse / Parquet / Teams / CSV+JSON / Jira / Linear / SendGrid destinations · `drt test` · `--output json` · `--profile` · `${VAR}` 環境変数展開 · dbt manifest · secrets.toml · Docker |
 | **v0.5.4** ✅ | `destination_lookup` — 同期中にデスティネーションDBからFK値を解決（MySQL / Postgres / ClickHouse） |
-| [v0.6](https://github.com/drt-hub/drt/milestone/3) | Salesforce · Airflow integration · Twilio / Intercom destinations |
+| **v0.6** ✅ | Databricks / SQL Server sources · Notion / Twilio / Intercom / Email SMTP / Salesforce Bulk / Staged Upload destinations · Airflow / Prefect integrations · `drt serve` · `drt sources` / `drt destinations` · `--threads` 並列実行 · `--log-format json` · `--cursor-value` · `watermark.default_value` · テストバリデータ（freshness, unique, accepted_values） · JSON Schema validation · GOVERNANCE.md |
 | [v0.7](https://github.com/drt-hub/drt/milestone/4) | DWH destinations (Snowflake / BigQuery / ClickHouse / Databricks) · Cloud storage (S3 / GCS / Azure Blob) |
 | [v0.8](https://github.com/drt-hub/drt/milestone/5) | Lakehouse sources (Delta Lake / Apache Iceberg) |
 | v1.x | Rust engine (PyO3) |

--- a/README.md
+++ b/README.md
@@ -115,17 +115,25 @@ drt status          # check results
 ```bash
 drt init                    # initialize project
 drt list                    # list sync definitions
+drt sources                 # list available source connectors
+drt destinations            # list available destination connectors
 drt run                     # run all syncs
 drt run --select <name>     # run a specific sync
+drt run --all               # discover and run all syncs
+drt run --select tag:<tag>  # run syncs matching a tag
+drt run --threads 4         # parallel sync execution
 drt run --dry-run           # dry run
 drt run --verbose           # show row-level error details
 drt run --output json       # structured JSON output for CI/scripting
+drt run --log-format json   # structured JSON logging to stderr
 drt run --profile prd       # override profile (or DRT_PROFILE env var)
+drt run --cursor-value '…'  # override watermark cursor for backfill
 drt test                    # run post-sync validation tests
 drt test --select <name>    # test a specific sync
 drt validate                # validate sync YAML configs
 drt status                  # show recent sync status
 drt status --output json    # JSON output for status
+drt serve                   # start HTTP webhook endpoint
 drt mcp run                 # start MCP server (requires drt-core[mcp])
 drt --install-completion    # install shell completion (bash/zsh/fish)
 drt --show-completion       # show completion script
@@ -182,6 +190,7 @@ drt mcp run
 | `drt_get_status` | Get last run result(s) |
 | `drt_validate` | Validate sync YAML configs |
 | `drt_get_schema` | Return JSON Schema for config files |
+| `drt_list_connectors` | List available sources and destinations |
 
 ---
 
@@ -249,8 +258,12 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 | Jira | ✅ v0.5 | (core) | Basic (email + API token) |
 | Linear | ✅ v0.5 | (core) | API Key (env var) |
 | SendGrid | ✅ v0.5 | (core) | API Key (env var) |
-| Salesforce | 🗓 v0.6 | `pip install drt-core[salesforce]` | — |
-| Notion | 🗓 planned | (core) | — |
+| Notion | ✅ v0.6 | (core) | Bearer Token (env var) |
+| Twilio SMS | ✅ v0.6 | (core) | Basic (Account SID + Auth Token) |
+| Intercom | ✅ v0.6 | (core) | Bearer Token (env var) |
+| Email SMTP | ✅ v0.6 | (core) | Username / Password (env var) |
+| Salesforce Bulk API 2.0 | ✅ v0.6 | (core) | OAuth2 (username-password) |
+| Staged Upload | ✅ v0.6 | (core) | Configurable per provider |
 
 ### Integrations
 
@@ -276,7 +289,7 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 | **v0.4** ✅ | Google Sheets / PostgreSQL / MySQL destinations · dagster-drt · dbt manifest reader · type safety overhaul |
 | **v0.5** ✅ | Snowflake / MySQL sources · ClickHouse / Parquet / Teams / CSV+JSON / Jira / Linear / SendGrid destinations · `drt test` · `--output json` · `--profile` · `${VAR}` substitution · dbt manifest · secrets.toml · Docker |
 | **v0.5.4** ✅ | `destination_lookup` — resolve FK values by querying destination DB during sync (MySQL / Postgres / ClickHouse) |
-| [v0.6](https://github.com/drt-hub/drt/milestone/3) | Salesforce · Airflow integration · Twilio / Intercom destinations |
+| **v0.6** ✅ | Databricks / SQL Server sources · Notion / Twilio / Intercom / Email SMTP / Salesforce Bulk / Staged Upload destinations · Airflow / Prefect integrations · `drt serve` · `drt sources` / `drt destinations` · `--threads` parallel execution · `--log-format json` · `--cursor-value` · `watermark.default_value` · test validators (freshness, unique, accepted_values) · JSON Schema validation · GOVERNANCE.md |
 | [v0.7](https://github.com/drt-hub/drt/milestone/4) | DWH destinations (Snowflake / BigQuery / ClickHouse / Databricks) · Cloud storage (S3 / GCS / Azure Blob) |
 | [v0.8](https://github.com/drt-hub/drt/milestone/5) | Lakehouse sources (Delta Lake / Apache Iceberg) |
 | v1.x | Rust engine (PyO3) |

--- a/docs/llm/API_REFERENCE.md
+++ b/docs/llm/API_REFERENCE.md
@@ -84,15 +84,20 @@ SNOWFLAKE_PASSWORD = "dev-password"
 
 ---
 
-## Environment variable substitution in `model:`
+## Environment variable substitution
 
-Use `${VAR}` syntax for environment-specific SQL:
+Use `${VAR}` syntax in any string field of sync YAML (not just `model:`):
 
 ```yaml
 model: SELECT * FROM `${GCP_PROJECT}.${BQ_DATASET}.users`
+destination:
+  url: "https://${API_HOST}/api/v1/contacts"
+sync:
+  watermark:
+    bucket: ${PIPES_GCS_BUCKET}
 ```
 
-Raises an error if the variable is not set.
+Raises an error if the variable is not set. Supported since v0.6.1 for all string fields (previously only `model:`).
 
 ---
 
@@ -116,6 +121,7 @@ sync:                       # optional: all fields have defaults
     key: watermarks/s.json  # GCS only
     project: my-project     # BigQuery only
     dataset: my_dataset     # BigQuery only
+    default_value: "2026-01-01 00:00:00"  # optional: fallback cursor for first run (v0.6.2)
   batch_size: 100           # default: 100 — rows per destination call
   on_error: fail            # "fail" (default) | "skip"
   rate_limit:
@@ -133,6 +139,14 @@ tests:                      # optional: post-sync validation (DB destinations on
       max: 10000            # optional: maximum expected rows
   - not_null:
       columns: [id, name]   # required: columns that must not contain NULLs
+  - freshness:
+      column: updated_at    # required: timestamp column to check
+      max_age: "7 days"     # required: human-readable max age ("24 hours", "7 days", etc.)
+  - unique:
+      columns: [id]         # required: columns that must be unique
+  - accepted_values:
+      column: status        # required: column to check
+      values: [active, inactive, pending]  # required: allowed values
 ```
 
 ---

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -14,7 +14,7 @@ dlt (load into DWH) → dbt (transform) → drt (activate out of DWH)
 - **Tagline:** "Reverse ETL for the code-first data stack"
 - **Install:** `pip install drt-core` or `uv add drt-core`
 - **Package name:** `drt-core` (PyPI) — CLI command is `drt`
-- **Current version:** v0.6.1
+- **Current version:** v0.6.2
 
 ## What drt is NOT
 
@@ -95,6 +95,11 @@ default:
 | SendGrid | `sendgrid` | Transactional emails via v3 Mail Send API |
 | Google Ads | `google_ads` | Offline click conversion upload |
 | Staged Upload | `staged_upload` | Async bulk APIs: file upload → job trigger → poll |
+| Notion | `notion` | Append rows to Notion databases |
+| Twilio SMS | `twilio` | Send SMS per row via Twilio Messages API |
+| Intercom | `intercom` | Create/update contacts via Intercom REST API v2 |
+| Email SMTP | `email_smtp` | Send emails via SMTP (plain text or HTML) |
+| Salesforce Bulk API 2.0 | `salesforce_bulk` | Upsert via Bulk API 2.0 with CSV serialization |
 
 ## CLI Commands
 
@@ -107,9 +112,16 @@ drt run --select <sync-name>      # run one sync
 drt run --dry-run                 # preview without writing data
 drt run --verbose                 # show row-level error details on failure
 drt run --output json             # structured JSON output for CI/scripting
+drt run --log-format json         # structured JSON logging to stderr
 drt run --profile prd             # override profile (or DRT_PROFILE env var)
+drt run --all                     # discover and run all syncs
+drt run --select tag:<tag>        # run syncs matching a tag
+drt run --threads 4               # parallel sync execution
+drt run --cursor-value '2026-01-01 00:00:00'  # override watermark cursor for backfill
 drt test                          # run post-sync validation tests
 drt test --select <sync-name>     # test a specific sync
+drt sources                       # list available source connectors
+drt destinations                  # list available destination connectors
 drt status                        # show recent sync results
 drt status --output json          # JSON output for status
 drt mcp run                       # start MCP server (requires drt-core[mcp])
@@ -134,6 +146,7 @@ drt mcp run   # starts stdio MCP server
 | `drt_get_status(sync_name=None)` | Returns last run result(s); omit sync_name for all |
 | `drt_validate()` | Validates all sync YAMLs; returns valid list and errors dict |
 | `drt_get_schema(schema_type="sync")` | Returns JSON Schema for "sync" or "project" config |
+| `drt_list_connectors()` | Lists all available sources and destinations |
 
 The MCP server reads from the current working directory (the drt project root).
 

--- a/skills/drt/.claude-plugin/plugin.json
+++ b/skills/drt/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drt",
   "description": "Skills for drt \u2014 create syncs, debug failures, initialize projects, and migrate from Census/Hightouch",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": {
     "name": "drt-hub"
   },


### PR DESCRIPTION
## Summary

- **CHANGELOG.md**: Add missing v0.6.2 entry (`watermark.default_value`, `--cursor-value`, watermark source observability)
- **README.md / README.ja.md**: Add 6 missing destinations (Notion, Twilio, Intercom, Email SMTP, Salesforce Bulk, Staged Upload), 9 CLI commands/flags (`sources`, `destinations`, `--all`, `--threads`, `--log-format json`, `--cursor-value`, `serve`, `--select tag:`), update Roadmap v0.6 to ✅, add `drt_list_connectors` to MCP tools table
- **docs/llm/CONTEXT.md**: Update version to v0.6.2, add new connectors, CLI flags, and MCP tool
- **docs/llm/API_REFERENCE.md**: Add `watermark.default_value`, freshness/unique/accepted_values test types, update `${VAR}` expansion docs for all string fields (v0.6.1)
- **CLAUDE.md**: Update Roadmap v0.6 to ✅
- **skills plugin.json**: Bump version to 0.6.2

## Test plan

- [ ] Verify README destination tables render correctly on GitHub
- [ ] Verify CHANGELOG v0.6.2 entry matches GitHub Release notes
- [ ] Verify docs/llm/ files are consistent with actual CLI `--help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)