### PR TITLE
Fix BasicAuth not reading credentials from secrets.toml

### DIFF
--- a/drt/destinations/auth.py
+++ b/drt/destinations/auth.py
@@ -7,7 +7,6 @@ and future Rust portability.
 from __future__ import annotations
 
 import base64
-import os
 
 from drt.config.credentials import resolve_env
 
@@ -51,8 +50,8 @@ class AuthHandler:
             return {auth.header: value}
 
         if isinstance(auth, BasicAuth):
-            username = os.environ.get(auth.username_env, "")
-            password = os.environ.get(auth.password_env, "")
+            username = resolve_env(None, auth.username_env)
+            password = resolve_env(None, auth.password_env)
             if not username:
                 raise ValueError(f"BasicAuth: env var '{auth.username_env}' is not set.")
             if not password:


### PR DESCRIPTION
## Problem

BasicAuth was the only auth type that couldn't resolve credentials from `.drt/secrets.toml`. It used `os.environ.get()` directly, while BearerAuth, ApiKeyAuth, and OAuth2 all use `resolve_env()` which checks both environment variables **and** `secrets.toml`.

This meant any user storing BasicAuth credentials in `secrets.toml` would get a misleading error:
```
BasicAuth: env var 'BASIC_AUTH_USER' is not set.
```

...even though the value exists in `secrets.toml`.

## Fix

Replace `os.environ.get()` calls in `BasicAuth` handling with `resolve_env(None, env_var)`, matching the pattern used by all other auth types. Remove the now-unused `import os`.

## Files changed
- `drt/destinations/auth.py`: 3 lines changed