### PR TITLE
chore: post-merge followup for #394 connector registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Connector registry** (#381): Replaced hardcoded `isinstance` chains in `_get_destination()` / `_get_source()` with a centralized registry (`drt/connectors/registry.py`). Adding a new connector no longer requires editing `main.py`. Error messages now list available connectors on typo. Contributed by @Muawiya-contact.
+- **REST API destination pagination** (#260): Fetch data from paginated APIs. 3 strategies: offset/limit, cursor-based, HTTP Link headers. Contributed by @Muawiya-contact.
+
+### Fixed
+
+- **PostgreSQL destination**: crash on `dict` values bound for JSONB columns — wrapped with `psycopg2.extras.Json` (#315). Contributed by @armorbreak001.
+
 ## [0.6.2] - 2026-04-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Key design principle: **module boundaries are drawn for future Rust rewrite (PyO
 drt/
 ├── cli/          # Typer CLI commands
 ├── config/       # Pydantic models + YAML parser
+├── connectors/   # Connector registry — auto-discovery of sources/destinations
 ├── sources/      # Source Protocol + BigQuery impl
 ├── destinations/ # Destination Protocol + REST API impl
 ├── engine/       # Sync orchestration (future Rust core)
@@ -37,7 +38,7 @@ drt/
 - `Destination.load(records: list[dict], config: DestinationConfig, sync_options: SyncOptions) -> SyncResult`
 - `StateManager.get_last_sync / save_sync`
 
-Implementations use `assert isinstance(config, SpecificConfig)` for type narrowing. `type: ignore` is only allowed for external library issues.
+Connector dispatch uses a centralized registry (`drt/connectors/registry.py`) — adding a new connector requires registering it there, not editing `main.py`. Implementations use `assert isinstance(config, SpecificConfig)` for type narrowing. `type: ignore` is only allowed for external library issues.
 
 ## Development Commands
 


### PR DESCRIPTION
## Summary

Post-merge documentation updates after #394 (connector registry):

- **CLAUDE.md**: Add `connectors/` to package layout, update dispatch description from isinstance chains to registry pattern
- **CHANGELOG.md**: Add connector registry (#381), REST API pagination (#260), and JSONB fix (#315) to Unreleased section with contributor credits

## Related

- #394 (merged)
- #381 (closed)
- #380 (merged)
- #395 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)