### PR TITLE
fix+refactor: cli/main.py cleanup (#399, #400, #401)

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -681,8 +681,6 @@ def test_syncs(
     select: str = typer.Option(None, "--select", "-s", help="Test a specific sync by name."),
 ) -> None:
     """Run post-sync validation tests."""
-    import json as json_mod
-
     from drt.config.parser import load_syncs
     from drt.destinations.query import (
         execute_test_query,
@@ -699,7 +697,7 @@ def test_syncs(
         if not json_mode:
             console.print("[dim]No syncs found.[/dim]")
         else:
-            print(json_mod.dumps({"status": "no_syncs", "results": []}))
+            print(json.dumps({"status": "no_syncs", "results": []}))
         return
 
     if select:
@@ -713,7 +711,7 @@ def test_syncs(
         if not json_mode:
             console.print("[dim]No tests defined in any sync.[/dim]")
         else:
-            print(json_mod.dumps({"status": "no_tests", "results": []}))
+            print(json.dumps({"status": "no_tests", "results": []}))
         return
 
     had_failures = False
@@ -760,7 +758,7 @@ def test_syncs(
 
     if json_mode:
         print(
-            json_mod.dumps(
+            json.dumps(
                 {"status": "failed" if had_failures else "passed", "results": results}
             )
         )

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -781,6 +781,14 @@ def _test_display_name(test_def: object) -> str:
     if test_def.not_null is not None:
         cols = ", ".join(test_def.not_null.columns)
         return f"not_null({cols})"
+    if test_def.freshness is not None:
+        return f"freshness({test_def.freshness.column}, max_age={test_def.freshness.max_age})"
+    if test_def.unique is not None:
+        cols = ", ".join(test_def.unique.columns)
+        return f"unique({cols})"
+    if test_def.accepted_values is not None:
+        vals = ", ".join(test_def.accepted_values.values)
+        return f"accepted_values({test_def.accepted_values.column}: {vals})"
     return "unknown"
 
 

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict
@@ -18,6 +19,7 @@ if TYPE_CHECKING:
     from drt.config.models import SyncConfig
     from drt.destinations.base import Destination
     from drt.sources.base import Source
+    from drt.state.manager import StateManager
 
 
 from drt import __version__
@@ -76,6 +78,132 @@ def _configure_json_logging() -> None:
     handler.setFormatter(_JsonFormatter())
     logging.root.handlers = [handler]
     logging.root.setLevel(logging.INFO)
+
+
+@dataclass
+class _RunContext:
+    """Shared context for executing a single sync within ``run()``."""
+
+    source: Source
+    state_mgr: StateManager
+    json_mode: bool
+    dry_run: bool
+    verbose: bool
+    log_json: bool
+    cursor_value: str | None
+
+
+def _run_one(
+    sync: SyncConfig,
+    ctx: _RunContext,
+    profile: ProfileConfig,
+) -> tuple[str, dict[str, object], bool]:
+    """Execute a single sync and return (name, result_dict, had_error)."""
+    from drt.engine.sync import run_sync
+
+    dest = _get_destination(sync)
+    wm_storage = _get_watermark_storage(sync, Path("."))
+    if not ctx.json_mode and not ctx.dry_run:
+        print_sync_start(sync.name, ctx.dry_run)
+    t0 = time.monotonic()
+    if ctx.log_json:
+        logging.info("sync_started", extra={"sync": sync.name})
+    try:
+        result = run_sync(
+            sync,
+            ctx.source,
+            dest,
+            profile,
+            Path("."),
+            ctx.dry_run,
+            ctx.state_mgr,
+            watermark_storage=wm_storage,
+            cursor_value_override=(
+                ctx.cursor_value if sync.sync.mode == "incremental" else None
+            ),
+        )
+    except Exception as e:
+        elapsed = round(time.monotonic() - t0, 2)
+        entry: dict[str, object] = {
+            "name": sync.name,
+            "status": "failed",
+            "rows_synced": 0,
+            "rows_failed": 0,
+            "duration_seconds": elapsed,
+            "dry_run": ctx.dry_run,
+            "error": str(e),
+        }
+        if ctx.log_json:
+            logging.error(
+                "sync_complete",
+                extra={
+                    "sync": sync.name,
+                    "rows": 0,
+                    "duration_ms": round(elapsed * 1000),
+                    "status": "failed",
+                },
+            )
+        if not ctx.json_mode:
+            print_error(f"[{sync.name}] Unexpected error: {e}")
+        return sync.name, entry, True
+
+    elapsed = round(time.monotonic() - t0, 2)
+    status_str = (
+        "success"
+        if result.failed == 0
+        else "partial"
+        if result.success > 0
+        else "failed"
+    )
+    entry = {
+        "name": sync.name,
+        "status": status_str,
+        "rows_extracted": result.rows_extracted,
+        "rows_synced": result.success,
+        "rows_failed": result.failed,
+        "duration_seconds": elapsed,
+        "dry_run": ctx.dry_run,
+    }
+    if result.watermark_source:
+        entry["watermark_source"] = result.watermark_source
+    if result.cursor_value_used is not None:
+        entry["cursor_value_used"] = result.cursor_value_used
+    if ctx.log_json:
+        logging.info(
+            "sync_complete",
+            extra={
+                "sync": sync.name,
+                "rows": result.success,
+                "duration_ms": round(elapsed * 1000),
+                "status": status_str,
+            },
+        )
+    if not ctx.json_mode:
+        if ctx.dry_run:
+            print_dry_run_summary(sync, profile, result.success, dest)
+        else:
+            print_sync_result(sync.name, result, elapsed)
+    if not ctx.json_mode and ctx.verbose and result.row_errors:
+        print_row_errors(result.row_errors)
+    return sync.name, entry, result.failed > 0
+
+
+def _print_watermark_summary(results: list[dict[str, object]]) -> None:
+    """Print notes about watermark sources used during a run."""
+    default_syncs = [e for e in results if e.get("watermark_source") == "default_value"]
+    override_syncs = [e for e in results if e.get("watermark_source") == "cli_override"]
+    if default_syncs:
+        names = ", ".join(str(e["name"]) for e in default_syncs)
+        console.print(
+            f"\n[yellow]Note: {len(default_syncs)} sync(s) used watermark.default_value "
+            f"(first run): {names}[/yellow]"
+        )
+    if override_syncs:
+        names = ", ".join(str(e["name"]) for e in override_syncs)
+        console.print(
+            f"\n[cyan]Note: {len(override_syncs)} sync(s) used --cursor-value "
+            f"override: {names}[/cyan]"
+        )
 
 
 def _resolve_profile_name(cli_flag: str | None, project_profile: str) -> str:
@@ -298,7 +426,6 @@ def run(
 
     from drt.config.credentials import load_profile
     from drt.config.parser import load_project, load_syncs
-    from drt.engine.sync import run_sync
     from drt.state.manager import StateManager
 
     if log_format == "json":
@@ -363,98 +490,22 @@ def run(
     succeeded = 0
     failed = 0
 
-    def _run_one(sync: SyncConfig) -> tuple[str, dict[str, object], bool]:
-        """Execute a single sync and return (name, result_dict, had_error)."""
-        dest = _get_destination(sync)
-        wm_storage = _get_watermark_storage(sync, Path("."))
-        if not json_mode and not dry_run:
-            print_sync_start(sync.name, dry_run)
-        t0 = time.monotonic()
-        if log_format == "json":
-            logging.info("sync_started", extra={"sync": sync.name})
-        try:
-            result = run_sync(
-                sync,
-                source,
-                dest,
-                profile,
-                Path("."),
-                dry_run,
-                state_mgr,
-                watermark_storage=wm_storage,
-                cursor_value_override=cursor_value if sync.sync.mode == "incremental" else None,
-            )
-        except Exception as e:
-            elapsed = round(time.monotonic() - t0, 2)
-            entry = {
-                "name": sync.name,
-                "status": "failed",
-                "rows_synced": 0,
-                "rows_failed": 0,
-                "duration_seconds": elapsed,
-                "dry_run": dry_run,
-                "error": str(e),
-            }
-            if log_format == "json":
-                logging.error(
-                    "sync_complete",
-                    extra={
-                        "sync": sync.name,
-                        "rows": 0,
-                        "duration_ms": round(elapsed * 1000),
-                        "status": "failed",
-                    },
-                )
-            if not json_mode:
-                print_error(f"[{sync.name}] Unexpected error: {e}")
-            return sync.name, entry, True
-
-        elapsed = round(time.monotonic() - t0, 2)
-        status_str = (
-            "success"
-            if result.failed == 0
-            else "partial"
-            if result.success > 0
-            else "failed"
-        )
-        entry = {
-            "name": sync.name,
-            "status": status_str,
-            "rows_extracted": result.rows_extracted,
-            "rows_synced": result.success,
-            "rows_failed": result.failed,
-            "duration_seconds": elapsed,
-            "dry_run": dry_run,
-        }
-        if result.watermark_source:
-            entry["watermark_source"] = result.watermark_source
-        if result.cursor_value_used is not None:
-            entry["cursor_value_used"] = result.cursor_value_used
-        if log_format == "json":
-            logging.info(
-                "sync_complete",
-                extra={
-                    "sync": sync.name,
-                    "rows": result.success,
-                    "duration_ms": round(elapsed * 1000),
-                    "status": status_str,
-                },
-            )
-        if not json_mode:
-            if dry_run:
-                print_dry_run_summary(sync, profile, result.success, dest)
-            else:
-                print_sync_result(sync.name, result, elapsed)
-        if not json_mode and verbose and result.row_errors:
-            print_row_errors(result.row_errors)
-        return sync.name, entry, result.failed > 0
+    ctx = _RunContext(
+        source=source,
+        state_mgr=state_mgr,
+        json_mode=json_mode,
+        dry_run=dry_run,
+        verbose=verbose,
+        log_json=log_format == "json",
+        cursor_value=cursor_value,
+    )
 
     # Execute syncs — parallel if threads > 1, sequential otherwise
     if threads > 1 and len(syncs) > 1:
         if not json_mode:
             console.print(f"[dim]Running {len(syncs)} syncs with {threads} threads[/dim]\n")
         with ThreadPoolExecutor(max_workers=threads) as pool:
-            futures = {pool.submit(_run_one, s): s for s in syncs}
+            futures = {pool.submit(_run_one, s, ctx, profile): s for s in syncs}
             for future in as_completed(futures):
                 name, entry, had_err = future.result()
                 json_results.append(entry)
@@ -464,7 +515,7 @@ def run(
                     succeeded += 1
     else:
         for sync in syncs:
-            name, entry, had_err = _run_one(sync)
+            name, entry, had_err = _run_one(sync, ctx, profile)
             json_results.append(entry)
             if had_err:
                 failed += 1
@@ -478,26 +529,8 @@ def run(
         console.print(f"\n[bold]Summary:[/bold] {succeeded} succeeded, {failed} failed, "
                        f"{total_duration}s total")
 
-    # Watermark source summary (#391)
     if not json_mode:
-        default_syncs = [
-            e for e in json_results if e.get("watermark_source") == "default_value"
-        ]
-        override_syncs = [
-            e for e in json_results if e.get("watermark_source") == "cli_override"
-        ]
-        if default_syncs:
-            names = ", ".join(str(e["name"]) for e in default_syncs)
-            console.print(
-                f"\n[yellow]Note: {len(default_syncs)} sync(s) used watermark.default_value "
-                f"(first run): {names}[/yellow]"
-            )
-        if override_syncs:
-            names = ", ".join(str(e["name"]) for e in override_syncs)
-            console.print(
-                f"\n[cyan]Note: {len(override_syncs)} sync(s) used --cursor-value "
-                f"override: {names}[/cyan]"
-            )
+        _print_watermark_summary(json_results)
 
     if json_mode:
         print(

--- a/tests/unit/test_test_display_name.py
+++ b/tests/unit/test_test_display_name.py
@@ -1,0 +1,47 @@
+"""Tests for _test_display_name helper."""
+
+from __future__ import annotations
+
+from drt.cli.main import _test_display_name
+from drt.config.models import (
+    AcceptedValuesTest,
+    FreshnessTest,
+    NotNullTest,
+    RowCountTest,
+    SyncTest,
+    UniqueTest,
+)
+
+
+def test_display_name_row_count_min_max() -> None:
+    t = SyncTest(row_count=RowCountTest(min=1, max=100))
+    assert _test_display_name(t) == "row_count(min=1, max=100)"
+
+
+def test_display_name_not_null() -> None:
+    t = SyncTest(not_null=NotNullTest(columns=["id", "name"]))
+    assert _test_display_name(t) == "not_null(id, name)"
+
+
+def test_display_name_freshness() -> None:
+    t = SyncTest(freshness=FreshnessTest(column="updated_at", max_age="7 days"))
+    assert _test_display_name(t) == "freshness(updated_at, max_age=7 days)"
+
+
+def test_display_name_unique() -> None:
+    t = SyncTest(unique=UniqueTest(columns=["email"]))
+    assert _test_display_name(t) == "unique(email)"
+
+
+def test_display_name_unique_multi() -> None:
+    t = SyncTest(unique=UniqueTest(columns=["first", "last"]))
+    assert _test_display_name(t) == "unique(first, last)"
+
+
+def test_display_name_accepted_values() -> None:
+    t = SyncTest(
+        accepted_values=AcceptedValuesTest(
+            column="status", values=["active", "inactive"]
+        )
+    )
+    assert _test_display_name(t) == "accepted_values(status: active, inactive)"


### PR DESCRIPTION
## Summary

- **#399** — Remove `json_mod` alias reintroduced by #384 merge order
- **#400** — Complete `_test_display_name()` for `freshness`, `unique`, `accepted_values` test types (were showing "unknown")
- **#401** — Extract `_run_one()` and `_print_watermark_summary()` from `run()` — `run()` drops from ~250 lines to ~80 lines

## Test plan
- [x] `make lint` — ruff + mypy all pass
- [x] `make test` — 705 passed, 2 skipped
- [x] New test file: `tests/unit/test_test_display_name.py` (6 tests covering all 5 test types)

Closes #399, closes #400, closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)