### PR TITLE
docs: add ROADMAP.md and refocus v0.7 on Production Ready

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,18 +69,10 @@ make fmt      # ruff format + fix
 
 ## Roadmap Reference
 
-**SSoT: [GitHub Milestones](https://github.com/drt-hub/drt/milestones)** — all issues are tracked there.
+**SSoT for upcoming releases: [ROADMAP.md](ROADMAP.md)** — each version has Theme / Scope / Out of scope / Target / Progress link.
 
-- v0.1 ✅: BigQuery → REST API working end-to-end
-- v0.2 ✅: Incremental sync + retry from config
-- v0.3 ✅: MCP Server + AI Skills for Claude Code + LLM-readable docs + row-level errors + security hardening + Redshift source
-- v0.4 ✅: Google Sheets / PostgreSQL / MySQL destinations + dagster-drt + dbt manifest reader + type safety overhaul
-- v0.5 ✅: Snowflake/MySQL sources + ClickHouse/Parquet/CSV+JSON/Jira/Linear/SendGrid destinations + `drt test` + multi-environment + Docker
-- v0.5.4 ✅: `destination_lookup` — resolve FK values by querying destination DB during sync (MySQL / Postgres / ClickHouse)
-- v0.5.5 ✅: `drop_match_columns` — auto-remove lookup match columns from INSERT after FK resolution
-- v0.6 ✅: Databricks/SQL Server sources · Notion/Twilio/Intercom/Email SMTP/Salesforce Bulk/Staged Upload destinations · Airflow/Prefect integrations · `drt serve` · `drt sources`/`drt destinations` · `--threads` · `--log-format json` · `--cursor-value` · `watermark.default_value` · test validators · JSON Schema validation · GOVERNANCE.md
-- [v0.7](https://github.com/drt-hub/drt/milestone/4): DWH destinations (Snowflake / BigQuery / ClickHouse / Databricks) + Cloud storage (S3 / GCS / Azure Blob)
-- [v0.8](https://github.com/drt-hub/drt/milestone/5): Lakehouse sources (Delta Lake / Apache Iceberg)
-- v1.x: Rust engine via PyO3
+- **Shipped releases:** see [CHANGELOG.md](CHANGELOG.md) or [GitHub Releases](https://github.com/drt-hub/drt/releases)
+- **Issue-level tracking:** [GitHub Milestones](https://github.com/drt-hub/drt/milestones)
+- **Good First Issues:** https://github.com/drt-hub/drt/issues?q=is%3Aopen+label%3A%22good+first+issue%22
 
-**Good First Issues:** https://github.com/drt-hub/drt/issues?q=is%3Aopen+label%3A%22good+first+issue%22
+When scope shifts between versions, update ROADMAP.md first, then re-label issues to match.

--- a/README.md
+++ b/README.md
@@ -278,8 +278,11 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 
 ## Roadmap
 
-> **Detailed plans & progress → [GitHub Milestones](https://github.com/drt-hub/drt/milestones)**
+> **Upcoming releases → [ROADMAP.md](ROADMAP.md)** (scope, themes, targets)
+> **Issue-level tracking → [GitHub Milestones](https://github.com/drt-hub/drt/milestones)**
 > **Looking to contribute? → [Good First Issues](https://github.com/drt-hub/drt/issues?q=is%3Aopen+label%3A%22good+first+issue%22)**
+
+**Shipped:**
 
 | Version | Focus |
 |---------|-------|
@@ -290,9 +293,8 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 | **v0.5** ✅ | Snowflake / MySQL sources · ClickHouse / Parquet / Teams / CSV+JSON / Jira / Linear / SendGrid destinations · `drt test` · `--output json` · `--profile` · `${VAR}` substitution · dbt manifest · secrets.toml · Docker |
 | **v0.5.4** ✅ | `destination_lookup` — resolve FK values by querying destination DB during sync (MySQL / Postgres / ClickHouse) |
 | **v0.6** ✅ | Databricks / SQL Server sources · Notion / Twilio / Intercom / Email SMTP / Salesforce Bulk / Staged Upload destinations · Airflow / Prefect integrations · `drt serve` · `drt sources` / `drt destinations` · `--threads` parallel execution · `--log-format json` · `--cursor-value` · `watermark.default_value` · test validators (freshness, unique, accepted_values) · JSON Schema validation · GOVERNANCE.md |
-| [v0.7](https://github.com/drt-hub/drt/milestone/4) | DWH destinations (Snowflake / BigQuery / ClickHouse / Databricks) · Cloud storage (S3 / GCS / Azure Blob) |
-| [v0.8](https://github.com/drt-hub/drt/milestone/5) | Lakehouse sources (Delta Lake / Apache Iceberg) |
-| v1.x | Rust engine (PyO3) |
+
+**Next:** [v0.7 Production Ready](ROADMAP.md#v07--production-ready) → [v0.8 Cloud Destinations & Growth](ROADMAP.md#v08--cloud-destinations--growth) → [v0.9 Enterprise Foundation](ROADMAP.md#v09--enterprise-foundation) → [v1.0 Stable Release](ROADMAP.md#v10--stable-release) → [v1.x Rust Engine](ROADMAP.md#v1x--rust-engine)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,75 @@
+# Roadmap
+
+> **SSoT for upcoming releases.** For shipped releases, see [CHANGELOG.md](CHANGELOG.md) and [GitHub Releases](https://github.com/drt-hub/drt/releases). For issue-level tracking, see each version's [milestone](https://github.com/drt-hub/drt/milestones).
+
+Targets are indicative, not guarantees. Scope may shift between versions — when that happens, this file is updated first and issues are re-labeled to match.
+
+---
+
+## v0.7 — Production Ready
+
+**Theme:** Reliability, observability, and correctness for real production use.
+
+**Scope:**
+- **Reliability** — retry policy in sync YAML (#277) · graceful shutdown on SIGTERM/SIGINT (#279) · sync execution history as local JSON log + `drt status --history` tail (#276, scope-reduced)
+- **Correctness** — `json_columns` explicit JSON serialization (#316) · FK existence check without value resolution (#354) · zero-downtime replace via staging table swap (#338)
+- **DX** — `drt doctor` environment diagnostics (#264) · `--quiet` flag for `drt run` (#265)
+- **Tests** — `on_error='fail'` and retry config tests across all destinations (#365)
+
+**Out of scope (→ v0.8):** Cloud destinations (Snowflake / BigQuery / Databricks / S3 / GCS / Azure), dead letter queue, opt-in telemetry, benchmark suite, Growth/README refresh items, schema-aware serialization epic.
+
+**Target:** 2026-05 · **Progress:** [milestone/4](https://github.com/drt-hub/drt/milestone/4)
+
+---
+
+## v0.8 — Cloud Destinations & Growth
+
+**Theme:** DWH/Lakehouse destinations + community growth push.
+
+**Scope:**
+- **Cloud destinations** — Snowflake (#164) · BigQuery (#165) · Databricks Delta Lake (#167) · S3 Parquet/CSV (#168) · GCS (#169) · Azure Blob (#170)
+- **Lakehouse sources** — Delta Lake (#172) · Apache Iceberg (#173)
+- **Reliability follow-on** — dead letter queue (#278) · opt-in anonymous usage telemetry (#263)
+- **Correctness epic** — schema-aware serialization via INFORMATION_SCHEMA (#317)
+- **Engine** — `sync.mode: mirror` differential delete (#340)
+- **Growth / README** — hero section redesign (#281) · Quickstart GIF/asciinema (#282) · Codespaces devcontainer (#283) · "Why OSS Reverse ETL" blog (#284) · production use case blog (#285) · Discord (#378) · X account link (#379) · PyPI keywords (#307) · Awesome lists (#290) · Reddit/HN launch (#289)
+- **Ecosystem** — GitHub Action (#292) · VS Code extension (#293)
+- **Dev tooling** — FakeSource (#364) · `drt_run_test` MCP tool (#368) · `/drt-troubleshoot` skill (#369) · `/drt-changelog` repo skill (#372) · connection test in `drt validate` (#367)
+
+**Out of scope:** Enterprise boundary (RBAC / audit log / plugin system → v0.9), Rust engine work (→ v1.x).
+
+**Target:** 2026-07 · **Progress:** [milestone/5](https://github.com/drt-hub/drt/milestone/5)
+
+---
+
+## v0.9 — Enterprise Foundation
+
+**Theme:** Open Core boundary design — interfaces for Enterprise features without implementing them in OSS.
+
+**Scope:**
+- **Interfaces** — RBAC interface spec (#298) · audit log hooks (#299) · plugin system for third-party connectors (#297)
+- **Protocol stability** — review and freeze preparation (#300) · config encryption for secrets at rest (#303) · `drt cloud push` stub (#302)
+- **Performance** — benchmark suite (#280) + I/O vs CPU profiling for Rust migration decision (#301)
+
+**Out of scope:** Implementing RBAC/audit log in OSS, actual Cloud service backend, Rust migration itself.
+
+**Target:** 2026-09 · **Progress:** [milestone/6](https://github.com/drt-hub/drt/milestone/6)
+
+---
+
+## v1.0 — Stable Release
+
+**Theme:** Protocol freeze, semver guarantee, public launch.
+
+**Scope:**
+- Protocol freeze — Source / Destination / StateManager interfaces (#304)
+- Migration guide v0.x → v1.0 (#305)
+- v1.0 launch campaign — blog, HN, Reddit, X (#306)
+
+**Target:** 2026-11 · **Progress:** [milestone/7](https://github.com/drt-hub/drt/milestone/7)
+
+---
+
+## v1.x — Rust Engine
+
+Rewrite `engine/sync.py` in Rust via PyO3. Decision gated on benchmark data from v0.9 (#301). Module boundaries are already drawn for this transition — `engine/sync.py` is kept pure (no I/O side effects beyond protocol calls).


### PR DESCRIPTION
## Summary

- Introduce `ROADMAP.md` as SSoT for upcoming releases. Each version carries explicit **Theme / Scope / Out of scope / Target / Progress link**.
- Strip duplicated roadmap content from `README.md` (keeps shipped-version table, links to ROADMAP.md for upcoming) and `CLAUDE.md` (now a pointer only).
- Refocus v0.7 scope to "Production Ready"; move Cloud destinations, Growth, DLQ, telemetry, benchmark to v0.8 / v0.9.

## Why

v0.7 milestone had 30 open issues spanning Production Ready + Cloud destinations + Growth — impossible to state "what's in v0.7" in one sentence. README and milestone descriptions had also drifted (README said "DWH destinations", milestone said "Production Ready + Cloud destinations"). Consolidating to ROADMAP.md keeps one place to edit; README and milestone descriptions become thin pointers.

## Scope decisions baked in

| Question | Decision | Reasoning |
|---|---|---|
| #338 zero-downtime vs #278 DLQ in v0.7? | #338 v0.7, #278 → v0.8 | Two research-label epics in one release is heavy; zero-downtime is concrete prod pain, DLQ is substitutable with orchestrator layer |
| #263 opt-in telemetry timing | → v0.8 | OSS telemetry is politically loaded (Homebrew, VS Code precedents); no reason to rush |
| #280 benchmark suite | → v0.9 | Primary purpose is Rust migration decision — colocate with #301 profiling |
| #276 sync history scope | v0.7 kept, **scope reduced** | JSON log + `drt status --history` tail only. No DB, no UI bloat. |

## v0.7 final list (9 issues)

- Reliability — #277 retry, #279 SIGTERM, #276 sync history (scope-reduced)
- Correctness — #316 json_columns (PR #382), #354 FK existence, #338 zero-downtime replace
- DX — #264 drt doctor (PR #329), #265 `--quiet`
- Tests — #365 retry/on_error tests

## Follow-up (after merge)

- [ ] Update GitHub milestone descriptions for v0.7 and v0.8 to match ROADMAP.md
- [ ] Move Cloud destinations (#164 #165 #167 #168 #169 #170) and Growth items from v0.7 milestone to v0.8
- [ ] Move #278 #263 #317 #340 to v0.8, #280 to v0.9

## Test plan

- [ ] ROADMAP.md renders correctly on GitHub (anchors, links)
- [ ] README.md "Next:" links resolve to ROADMAP.md sections
- [ ] CLAUDE.md still useful to agents as concise pointer

🤖 Generated with [Claude Code](https://claude.com/claude-code)