### PR TITLE
chore: expand PyPI keywords/classifiers and add drt cloud push stub

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -893,6 +893,23 @@ def serve(
 
 
 # ---------------------------------------------------------------------------
+# cloud (stub for future drt Cloud service)
+# ---------------------------------------------------------------------------
+
+cloud_app = typer.Typer(name="cloud", help="drt Cloud commands (stub).", no_args_is_help=True)
+app.add_typer(cloud_app)
+
+
+@cloud_app.command(name="push")
+def cloud_push() -> None:
+    """Push local project configuration to drt Cloud (stub)."""
+    console.print("\n[bold blue]🚀 drt Cloud[/bold blue]")
+    console.print("This is a stub for the future drt Cloud service.")
+    console.print("Project state would be pushed to your cloud dashboard here.")
+    console.print("\n[dim]Coming soon...[/dim]\n")
+
+
+# ---------------------------------------------------------------------------
 # mcp
 # ---------------------------------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,18 +9,38 @@ description = "Reverse ETL for the code-first data stack"
 readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "drt-hub", email = "masukai9612kf@gmail.com" }]
-keywords = ["reverse-etl", "data-engineering", "dbt", "bigquery", "cli"]
+keywords = [
+    "reverse-etl",
+    "data-engineering",
+    "data-activation",
+    "data-pipeline",
+    "data-stack",
+    "etl",
+    "dbt",
+    "bigquery",
+    "cli",
+    "automation",
+    "data-warehouse",
+    "sql",
+    "python-cli",
+    "open-source",
+    "mcp",
+    "llm-data",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
     "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
     "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Database",
+    "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

Re-lands two contributions originally from @Deepak8858 (#307, #308) under maintainer authorship after 12+ days of CLA-signing inactivity (gentle pings on both PRs unanswered). Original PRs will be closed with attribution + open invite to return once CLA is signed.

- **pyproject.toml**: expand `keywords` from 5 → 16 and add three classifiers (Information Technology audience, OS Independent, Python Modules topic). Improves PyPI discoverability for the AI/MCP audience and broader data-tooling search.
- **drt/cli/main.py**: add `drt cloud` Typer subcommand with a `push` stub that prints "Coming soon". Reserves the CLI namespace for the future drt Cloud service tracked in #302 (v0.9 milestone).

The stub is a no-op and ships no functional change. The keyword update takes effect on the next PyPI release.

## Why bundle

Both changes are tiny (4 + 17 lines), come from the same source, and are mechanical. Single review cycle vs two.

## Test plan

- [x] `make lint` — green (ruff + mypy)
- [x] `make test` — 713 passed, 2 skipped
- [x] Smoke: `drt cloud push` runs and prints the expected stub message
- [ ] CI confirms all of the above on Python 3.10 / 3.11 / 3.12 / 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)