### PR TITLE
chore: implement all-contributors workflow for contributor recognition

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,52 @@
+{
+  "projectName": "drt",
+  "projectOwner": "drt-hub",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "angular",
+  "contributors": [
+    {
+      "login": "masukai",
+      "name": "K.Masuda",
+      "avatar_url": "https://avatars.githubusercontent.com/u/37993351?v=4",
+      "profile": "https://masukai.github.io/portfolio/",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "Muawiya-contact",
+      "name": "Moavia Amir",
+      "avatar_url": "https://avatars.githubusercontent.com/u/178013839?v=4",
+      "profile": "https://www.youtube.com/@Coding_Moves",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "Khush-domadia",
+      "name": "Khush Domadiya",
+      "avatar_url": "https://avatars.githubusercontent.com/u/188820207?v=4",
+      "profile": "https://github.com/Khush-domadia",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "Pawansingh3889",
+      "name": "Pawan Singh Kapkoti",
+      "avatar_url": "https://avatars.githubusercontent.com/u/42340841?v=4",
+      "profile": "https://pawansingh3889.github.io/",
+      "contributions": [
+        "code"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7,
+  "linkToUsage": true
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -411,3 +411,30 @@ drt ships Claude Code skills via the plugin marketplace (`skills/drt/`). When yo
 Keep the version in sync with `pyproject.toml` (e.g. if releasing `0.4.0`, set all plugin versions to `0.4.0`).
 
 If you add a **new skill**, also add an entry to `skills/drt/.claude-plugin/plugin.json` if needed, and document it in `README.md` and `docs/llm/CONTEXT.md`.
+
+## Contributor Recognition
+
+We recognize all types of contributions — code, documentation, design, ideas, reviews, and more — using the [all-contributors](https://allcontributors.org/) specification.
+
+**How to get recognized:**
+
+If you contribute code, documentation, organize discussions, or help in any way, you can be added to the contributors list by commenting on your Issue or PR:
+
+```
+@all-contributors please add @username for <contribution-type>
+```
+
+**Contribution types include:**
+- `code` — Pull requests with code changes
+- `doc` — Documentation, blog posts, tutorials
+- `review` — Code reviews and feedback
+- `ideas` — Feature suggestions and design discussions
+- `bug` — Bug reports and issue triage
+- `test` — Test creation and improvements
+- `maintenance` — Maintenance and DevOps
+
+See the [emoji key](https://allcontributors.org/docs/en/emoji-key) for the complete list of 33+ contribution types.
+
+**Note on bot PRs:** The all-contributors bot will automatically open a Pull Request to update the README contributors list. These PRs are safe to merge once CI passes and the visual grid layout is verified — no full review needed. Just verify the names and avatars look correct!
+
+All contributors are listed in the [README Contributors section](./README.md#contributors-) with an all-contributors badge tracking the total count.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 [English](./README.md) | [日本語](./README.ja.md)
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/drt-hub/.github/main/profile/assets/logo-dark.svg">
@@ -341,3 +344,37 @@ but is a separate project with its own codebase and maintainers.
 ## License
 
 Apache 2.0 — see [LICENSE](LICENSE).
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://masukai.github.io/portfolio/"><img src="https://avatars.githubusercontent.com/u/37993351?v=4?s=100" width="100px;" alt="K.Masuda"/><br /><sub><b>K.Masuda</b></sub></a><br /><a href="https://github.com/drt-hub/drt/commits?author=masukai" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://www.youtube.com/@Coding_Moves"><img src="https://avatars.githubusercontent.com/u/178013839?v=4?s=100" width="100px;" alt="Moavia Amir"/><br /><sub><b>Moavia Amir</b></sub></a><br /><a href="https://github.com/drt-hub/drt/commits?author=Muawiya-contact" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Khush-domadia"><img src="https://avatars.githubusercontent.com/u/188820207?v=4?s=100" width="100px;" alt="Khush Domadiya"/><br /><sub><b>Khush Domadiya</b></sub></a><br /><a href="https://github.com/drt-hub/drt/commits?author=Khush-domadia" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://pawansingh3889.github.io/"><img src="https://avatars.githubusercontent.com/u/42340841?v=4?s=100" width="100px;" alt="Pawan Singh Kapkoti"/><br /><sub><b>Pawan Singh Kapkoti</b></sub></a><br /><a href="https://github.com/drt-hub/drt/commits?author=Pawansingh3889" title="Code">💻</a></td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td align="center" size="13px" colspan="7">
+        <img src="https://raw.githubusercontent.com/all-contributors/all-contributors-cli/1b8533af435da9854653492b1327a23a4dbd0a10/assets/logo-small.svg">
+          <a href="https://all-contributors.js.org/docs/en/bot/usage">Add your contributions</a>
+        </img>
+      </td>
+    </tr>
+  </tfoot>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -710,80 +710,14 @@ def mcp_run() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _get_source(
-    profile: (
-        BigQueryProfile
-        | DuckDBProfile
-        | SQLiteProfile
-        | PostgresProfile
-        | RedshiftProfile
-        | ClickHouseProfile
-        | MySQLProfile
-        | SnowflakeProfile
-        | DatabricksProfile
-        | SQLServerProfile
-    ),
-) -> (
-    BigQuerySource
-    | DuckDBSource
-    | SQLiteSource
-    | PostgresSource
-    | RedshiftSource
-    | ClickHouseSource
-    | MySQLSource
-    | SnowflakeSource
-    | DatabricksSource
-    | SQLServerSource
-):
-    from drt.config.credentials import (
-        BigQueryProfile,
-        ClickHouseProfile,
-        DatabricksProfile,
-        DuckDBProfile,
-        MySQLProfile,
-        PostgresProfile,
-        RedshiftProfile,
-        SnowflakeProfile,
-        SQLiteProfile,
-        SQLServerProfile,
-    )
-    from drt.sources.bigquery import BigQuerySource
-    from drt.sources.duckdb import DuckDBSource
-    from drt.sources.mysql import MySQLSource
-    from drt.sources.postgres import PostgresSource
-    from drt.sources.sqlite import SQLiteSource
+def _get_source(profile: ProfileConfig) -> Source:
+    """Get a source instance for the profile configuration.
 
-    if isinstance(profile, BigQueryProfile):
-        return BigQuerySource()
-    if isinstance(profile, DuckDBProfile):
-        return DuckDBSource()
-    if isinstance(profile, SQLiteProfile):
-        return SQLiteSource()
-    if isinstance(profile, PostgresProfile):
-        return PostgresSource()
-    if isinstance(profile, MySQLProfile):
-        return MySQLSource()
-    if isinstance(profile, RedshiftProfile):
-        from drt.sources.redshift import RedshiftSource
+    Uses the connector registry for automatic connector discovery and instantiation.
+    """
+    from drt.connectors import get_source
 
-        return RedshiftSource()
-    if isinstance(profile, ClickHouseProfile):
-        from drt.sources.clickhouse import ClickHouseSource
-
-        return ClickHouseSource()
-    if isinstance(profile, SnowflakeProfile):
-        from drt.sources.snowflake import SnowflakeSource
-
-        return SnowflakeSource()
-    if isinstance(profile, DatabricksProfile):
-        from drt.sources.databricks import DatabricksSource
-
-        return DatabricksSource()
-    if isinstance(profile, SQLServerProfile):
-        from drt.sources.sqlserver import SQLServerSource
-
-        return SQLServerSource()
-    raise ValueError(f"Unsupported source type: {type(profile)}")
+    return get_source(profile)
 
 
 def _get_watermark_storage(
@@ -817,122 +751,11 @@ def _get_watermark_storage(
     return None
 
 
-def _get_destination(
-    sync: SyncConfig,
-) -> (
-    RestApiDestination
-    | SlackDestination
-    | DiscordDestination
-    | GitHubActionsDestination
-    | HubSpotDestination
-    | JiraDestination
-    | SendGridDestination
-    | GoogleSheetsDestination
-    | PostgresDestination
-    | MySQLDestination
-    | TeamsDestination
-    | ClickHouseDestination
-    | ParquetDestination
-    | FileDestination
-    | EmailSmtpDestination
-    | LinearDestination
-    | GoogleAdsDestination
-    | NotionDestination
-    | StagedUploadDestination
-    | IntercomDestination
-    | TwilioDestination
-):
-    from drt.config.models import (
-        ClickHouseDestinationConfig,
-        DiscordDestinationConfig,
-        EmailSmtpDestinationConfig,
-        FileDestinationConfig,
-        GitHubActionsDestinationConfig,
-        GoogleAdsDestinationConfig,
-        GoogleSheetsDestinationConfig,
-        HubSpotDestinationConfig,
-        JiraDestinationConfig,
-        LinearDestinationConfig,
-        MySQLDestinationConfig,
-        NotionDestinationConfig,
-        ParquetDestinationConfig,
-        PostgresDestinationConfig,
-        RestApiDestinationConfig,
-        SendGridDestinationConfig,
-        SlackDestinationConfig,
-        StagedUploadDestinationConfig,
-        TeamsDestinationConfig,
-        TwilioDestinationConfig,
-    )
-    from drt.destinations.clickhouse import ClickHouseDestination
-    from drt.destinations.discord import DiscordDestination
-    from drt.destinations.github_actions import GitHubActionsDestination
-    from drt.destinations.hubspot import HubSpotDestination
-    from drt.destinations.jira import JiraDestination
-    from drt.destinations.linear import LinearDestination
-    from drt.destinations.mysql import MySQLDestination
-    from drt.destinations.notion import NotionDestination
-    from drt.destinations.postgres import PostgresDestination
-    from drt.destinations.rest_api import RestApiDestination
-    from drt.destinations.sendgrid import SendGridDestination
-    from drt.destinations.slack import SlackDestination
-    from drt.destinations.twilio import TwilioDestination
+def _get_destination(sync: SyncConfig) -> Destination:
+    """Get a destination instance for the sync configuration.
 
-    dest = sync.destination
-    if isinstance(dest, RestApiDestinationConfig):
-        return RestApiDestination()
-    if isinstance(dest, SlackDestinationConfig):
-        return SlackDestination()
-    if isinstance(dest, TwilioDestinationConfig):
-        return TwilioDestination()
-    if isinstance(dest, DiscordDestinationConfig):
-        return DiscordDestination()
-    if isinstance(dest, GitHubActionsDestinationConfig):
-        return GitHubActionsDestination()
-    if isinstance(dest, HubSpotDestinationConfig):
-        return HubSpotDestination()
-    if isinstance(dest, JiraDestinationConfig):
-        return JiraDestination()
-    if isinstance(dest, SendGridDestinationConfig):
-        return SendGridDestination()
-    if isinstance(dest, GoogleSheetsDestinationConfig):
-        from drt.destinations.google_sheets import GoogleSheetsDestination
+    Uses the connector registry for automatic connector discovery and instantiation.
+    """
+    from drt.connectors import get_destination
 
-        return GoogleSheetsDestination()
-    if isinstance(dest, PostgresDestinationConfig):
-        return PostgresDestination()
-    if isinstance(dest, MySQLDestinationConfig):
-        return MySQLDestination()
-    if isinstance(dest, TeamsDestinationConfig):
-        from drt.destinations.teams import TeamsDestination
-
-        return TeamsDestination()
-    if isinstance(dest, ClickHouseDestinationConfig):
-        return ClickHouseDestination()
-    if isinstance(dest, ParquetDestinationConfig):
-        from drt.destinations.parquet import ParquetDestination
-
-        return ParquetDestination()
-    if isinstance(dest, FileDestinationConfig):
-        from drt.destinations.file import FileDestination
-
-        return FileDestination()
-
-    if isinstance(dest, EmailSmtpDestinationConfig):
-        from drt.destinations.email_smtp import EmailSmtpDestination
-
-        return EmailSmtpDestination()
-
-    if isinstance(dest, LinearDestinationConfig):
-        return LinearDestination()
-    if isinstance(dest, GoogleAdsDestinationConfig):
-        from drt.destinations.google_ads import GoogleAdsDestination
-
-        return GoogleAdsDestination()
-    if isinstance(dest, NotionDestinationConfig):
-        return NotionDestination()
-    if isinstance(dest, StagedUploadDestinationConfig):
-        from drt.destinations.staged_upload import StagedUploadDestination
-
-        return StagedUploadDestination()
-    raise ValueError(f"Unsupported destination type: {dest.type}")
+    return get_destination(sync.destination)

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -14,50 +14,10 @@ import click
 import typer
 
 if TYPE_CHECKING:
-    from drt.config.credentials import (
-        BigQueryProfile,
-        ClickHouseProfile,
-        DatabricksProfile,
-        DuckDBProfile,
-        MySQLProfile,
-        PostgresProfile,
-        RedshiftProfile,
-        SnowflakeProfile,
-        SQLiteProfile,
-        SQLServerProfile,
-    )
+    from drt.config.credentials import ProfileConfig
     from drt.config.models import SyncConfig
-    from drt.destinations.clickhouse import ClickHouseDestination
-    from drt.destinations.discord import DiscordDestination
-    from drt.destinations.email_smtp import EmailSmtpDestination
-    from drt.destinations.file import FileDestination
-    from drt.destinations.github_actions import GitHubActionsDestination
-    from drt.destinations.google_ads import GoogleAdsDestination
-    from drt.destinations.google_sheets import GoogleSheetsDestination
-    from drt.destinations.hubspot import HubSpotDestination
-    from drt.destinations.intercom import IntercomDestination
-    from drt.destinations.jira import JiraDestination
-    from drt.destinations.linear import LinearDestination
-    from drt.destinations.mysql import MySQLDestination
-    from drt.destinations.notion import NotionDestination
-    from drt.destinations.parquet import ParquetDestination
-    from drt.destinations.postgres import PostgresDestination
-    from drt.destinations.rest_api import RestApiDestination
-    from drt.destinations.sendgrid import SendGridDestination
-    from drt.destinations.slack import SlackDestination
-    from drt.destinations.staged_upload import StagedUploadDestination
-    from drt.destinations.teams import TeamsDestination
-    from drt.destinations.twilio import TwilioDestination
-    from drt.sources.bigquery import BigQuerySource
-    from drt.sources.clickhouse import ClickHouseSource
-    from drt.sources.databricks import DatabricksSource
-    from drt.sources.duckdb import DuckDBSource
-    from drt.sources.mysql import MySQLSource
-    from drt.sources.postgres import PostgresSource
-    from drt.sources.redshift import RedshiftSource
-    from drt.sources.snowflake import SnowflakeSource
-    from drt.sources.sqlite import SQLiteSource
-    from drt.sources.sqlserver import SQLServerSource
+    from drt.destinations.base import Destination
+    from drt.sources.base import Source
 
 from drt import __version__
 from drt.cli.output import (

--- a/drt/connectors/__init__.py
+++ b/drt/connectors/__init__.py
@@ -1,0 +1,15 @@
+"""Connectors package — Source and destination registry system."""
+
+from drt.connectors.registry import (
+    get_destination,
+    get_source,
+    register_destination,
+    register_source,
+)
+
+__all__ = [
+    "get_destination",
+    "get_source",
+    "register_destination",
+    "register_source",
+]

--- a/drt/connectors/registry.py
+++ b/drt/connectors/registry.py
@@ -12,7 +12,7 @@ The registry enables:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from drt.destinations.base import Destination
 from drt.sources.base import Source
@@ -22,14 +22,14 @@ if TYPE_CHECKING:
     from drt.config.models import DestinationConfig
 
 # Registry mappings: type_name -> (ConfigClass, ImplementationClass)
-_destination_registry: dict[str, tuple[type, type]] = {}
-_source_registry: dict[str, tuple[type, type]] = {}
+_destination_registry: dict[str, tuple[type[Any], type[Any]]] = {}
+_source_registry: dict[str, tuple[type[Any], type[Any]]] = {}
 
 
 def register_destination(
     type_name: str,
-    config_class: type,
-    destination_class: type,
+    config_class: type[Any],
+    destination_class: type[Any],
 ) -> None:
     """Register a destination connector.
 
@@ -37,14 +37,22 @@ def register_destination(
         type_name: The type identifier (e.g., 'slack', 'rest_api')
         config_class: The Pydantic config class (e.g., SlackDestinationConfig)
         destination_class: The destination implementation class (e.g., SlackDestination)
+
+    Raises:
+        ValueError: If type_name is already registered
     """
+    if type_name in _destination_registry:
+        raise ValueError(
+            f"Destination type '{type_name}' already registered. "
+            f"Each connector type must be unique."
+        )
     _destination_registry[type_name] = (config_class, destination_class)
 
 
 def register_source(
     type_name: str,
-    profile_class: type,
-    source_class: type,
+    profile_class: type[Any],
+    source_class: type[Any],
 ) -> None:
     """Register a source connector.
 
@@ -52,7 +60,15 @@ def register_source(
         type_name: The type identifier (e.g., 'postgres', 'bigquery')
         profile_class: The credentials profile class (e.g., PostgresProfile)
         source_class: The source implementation class (e.g., PostgresSource)
+
+    Raises:
+        ValueError: If type_name is already registered
     """
+    if type_name in _source_registry:
+        raise ValueError(
+            f"Source type '{type_name}' already registered. "
+            f"Each connector type must be unique."
+        )
     _source_registry[type_name] = (profile_class, source_class)
 
 
@@ -68,10 +84,9 @@ def get_destination(config: DestinationConfig) -> Destination:
     Raises:
         ValueError: If the destination type is not registered
     """
-    # Find the registered destination for this config type
-    for type_name, (registered_config_class, destination_class) in _destination_registry.items():
-        if isinstance(config, registered_config_class):
-            return destination_class()  # type: ignore[no-any-return]
+    if config.type in _destination_registry:
+        _, destination_class = _destination_registry[config.type]
+        return destination_class()  # type: ignore[no-any-return]
 
     # If not found, provide helpful error message
     available = sorted(_destination_registry.keys())
@@ -93,10 +108,9 @@ def get_source(profile: ProfileConfig) -> Source:
     Raises:
         ValueError: If the source type is not registered
     """
-    # Find the registered source for this profile type
-    for type_name, (registered_profile_class, source_class) in _source_registry.items():
-        if isinstance(profile, registered_profile_class):
-            return source_class()  # type: ignore[no-any-return]
+    if profile.type in _source_registry:
+        _, source_class = _source_registry[profile.type]
+        return source_class()  # type: ignore[no-any-return]
 
     # If not found, provide helpful error message
     available = sorted(_source_registry.keys())

--- a/drt/connectors/registry.py
+++ b/drt/connectors/registry.py
@@ -1,0 +1,223 @@
+"""Connector registry for automatic discovery and instantiation of sources and destinations.
+
+This module provides a centralized registry for all available source and destination
+connectors, eliminating the need for hardcoded if-else chains in the CLI layer.
+
+The registry enables:
+- Decoupled CLI from connector implementations
+- Self-contained connector registration (no main.py edits needed)
+- Helpful error messages listing available connectors
+- Future third-party plugin support
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from drt.destinations.base import Destination
+from drt.sources.base import Source
+
+if TYPE_CHECKING:
+    from drt.config.credentials import ProfileConfig
+    from drt.config.models import DestinationConfig
+
+# Registry mappings: type_name -> (ConfigClass, ImplementationClass)
+_destination_registry: dict[str, tuple[type, type]] = {}
+_source_registry: dict[str, tuple[type, type]] = {}
+
+
+def register_destination(
+    type_name: str,
+    config_class: type,
+    destination_class: type,
+) -> None:
+    """Register a destination connector.
+
+    Args:
+        type_name: The type identifier (e.g., 'slack', 'rest_api')
+        config_class: The Pydantic config class (e.g., SlackDestinationConfig)
+        destination_class: The destination implementation class (e.g., SlackDestination)
+    """
+    _destination_registry[type_name] = (config_class, destination_class)
+
+
+def register_source(
+    type_name: str,
+    profile_class: type,
+    source_class: type,
+) -> None:
+    """Register a source connector.
+
+    Args:
+        type_name: The type identifier (e.g., 'postgres', 'bigquery')
+        profile_class: The credentials profile class (e.g., PostgresProfile)
+        source_class: The source implementation class (e.g., PostgresSource)
+    """
+    _source_registry[type_name] = (profile_class, source_class)
+
+
+def get_destination(config: DestinationConfig) -> Destination:
+    """Get a destination instance for the given config.
+
+    Args:
+        config: The destination configuration object
+
+    Returns:
+        An instantiated destination connector
+
+    Raises:
+        ValueError: If the destination type is not registered
+    """
+    # Find the registered destination for this config type
+    for type_name, (registered_config_class, destination_class) in _destination_registry.items():
+        if isinstance(config, registered_config_class):
+            return destination_class()  # type: ignore[no-any-return]
+
+    # If not found, provide helpful error message
+    available = sorted(_destination_registry.keys())
+    raise ValueError(
+        f"Unknown destination type: '{config.type}'. "
+        f"Available destinations: {', '.join(available)}"
+    )
+
+
+def get_source(profile: ProfileConfig) -> Source:
+    """Get a source instance for the given profile.
+
+    Args:
+        profile: The source profile/credentials object
+
+    Returns:
+        An instantiated source connector
+
+    Raises:
+        ValueError: If the source type is not registered
+    """
+    # Find the registered source for this profile type
+    for type_name, (registered_profile_class, source_class) in _source_registry.items():
+        if isinstance(profile, registered_profile_class):
+            return source_class()  # type: ignore[no-any-return]
+
+    # If not found, provide helpful error message
+    available = sorted(_source_registry.keys())
+    raise ValueError(
+        f"Unknown source type: '{profile.type}'. "
+        f"Available sources: {', '.join(available)}"
+    )
+
+
+def _register_all_connectors() -> None:
+    """Register all built-in connectors.
+
+    This is called automatically when the module is imported.
+    """
+    # Import config classes
+    from drt.config.credentials import (
+        BigQueryProfile,
+        ClickHouseProfile,
+        DatabricksProfile,
+        DuckDBProfile,
+        MySQLProfile,
+        PostgresProfile,
+        RedshiftProfile,
+        SnowflakeProfile,
+        SQLiteProfile,
+        SQLServerProfile,
+    )
+    from drt.config.models import (
+        ClickHouseDestinationConfig,
+        DiscordDestinationConfig,
+        EmailSmtpDestinationConfig,
+        FileDestinationConfig,
+        GitHubActionsDestinationConfig,
+        GoogleAdsDestinationConfig,
+        GoogleSheetsDestinationConfig,
+        HubSpotDestinationConfig,
+        IntercomDestinationConfig,
+        JiraDestinationConfig,
+        LinearDestinationConfig,
+        MySQLDestinationConfig,
+        NotionDestinationConfig,
+        ParquetDestinationConfig,
+        PostgresDestinationConfig,
+        RestApiDestinationConfig,
+        SendGridDestinationConfig,
+        SlackDestinationConfig,
+        StagedUploadDestinationConfig,
+        TeamsDestinationConfig,
+        TwilioDestinationConfig,
+    )
+
+    # Import destination classes
+    from drt.destinations.clickhouse import ClickHouseDestination
+    from drt.destinations.discord import DiscordDestination
+    from drt.destinations.email_smtp import EmailSmtpDestination
+    from drt.destinations.file import FileDestination
+    from drt.destinations.github_actions import GitHubActionsDestination
+    from drt.destinations.google_ads import GoogleAdsDestination
+    from drt.destinations.google_sheets import GoogleSheetsDestination
+    from drt.destinations.hubspot import HubSpotDestination
+    from drt.destinations.intercom import IntercomDestination
+    from drt.destinations.jira import JiraDestination
+    from drt.destinations.linear import LinearDestination
+    from drt.destinations.mysql import MySQLDestination
+    from drt.destinations.notion import NotionDestination
+    from drt.destinations.parquet import ParquetDestination
+    from drt.destinations.postgres import PostgresDestination
+    from drt.destinations.rest_api import RestApiDestination
+    from drt.destinations.sendgrid import SendGridDestination
+    from drt.destinations.slack import SlackDestination
+    from drt.destinations.staged_upload import StagedUploadDestination
+    from drt.destinations.teams import TeamsDestination
+    from drt.destinations.twilio import TwilioDestination
+
+    # Import source classes
+    from drt.sources.bigquery import BigQuerySource
+    from drt.sources.clickhouse import ClickHouseSource
+    from drt.sources.databricks import DatabricksSource
+    from drt.sources.duckdb import DuckDBSource
+    from drt.sources.mysql import MySQLSource
+    from drt.sources.postgres import PostgresSource
+    from drt.sources.redshift import RedshiftSource
+    from drt.sources.snowflake import SnowflakeSource
+    from drt.sources.sqlite import SQLiteSource
+    from drt.sources.sqlserver import SQLServerSource
+
+    # Register all destinations
+    register_destination("rest_api", RestApiDestinationConfig, RestApiDestination)
+    register_destination("slack", SlackDestinationConfig, SlackDestination)
+    register_destination("twilio", TwilioDestinationConfig, TwilioDestination)
+    register_destination("discord", DiscordDestinationConfig, DiscordDestination)
+    register_destination("github_actions", GitHubActionsDestinationConfig, GitHubActionsDestination)
+    register_destination("hubspot", HubSpotDestinationConfig, HubSpotDestination)
+    register_destination("jira", JiraDestinationConfig, JiraDestination)
+    register_destination("sendgrid", SendGridDestinationConfig, SendGridDestination)
+    register_destination("google_sheets", GoogleSheetsDestinationConfig, GoogleSheetsDestination)
+    register_destination("postgres", PostgresDestinationConfig, PostgresDestination)
+    register_destination("mysql", MySQLDestinationConfig, MySQLDestination)
+    register_destination("teams", TeamsDestinationConfig, TeamsDestination)
+    register_destination("clickhouse", ClickHouseDestinationConfig, ClickHouseDestination)
+    register_destination("parquet", ParquetDestinationConfig, ParquetDestination)
+    register_destination("file", FileDestinationConfig, FileDestination)
+    register_destination("email_smtp", EmailSmtpDestinationConfig, EmailSmtpDestination)
+    register_destination("linear", LinearDestinationConfig, LinearDestination)
+    register_destination("google_ads", GoogleAdsDestinationConfig, GoogleAdsDestination)
+    register_destination("notion", NotionDestinationConfig, NotionDestination)
+    register_destination("staged_upload", StagedUploadDestinationConfig, StagedUploadDestination)
+    register_destination("intercom", IntercomDestinationConfig, IntercomDestination)
+
+    # Register all sources
+    register_source("bigquery", BigQueryProfile, BigQuerySource)
+    register_source("duckdb", DuckDBProfile, DuckDBSource)
+    register_source("sqlite", SQLiteProfile, SQLiteSource)
+    register_source("postgres", PostgresProfile, PostgresSource)
+    register_source("redshift", RedshiftProfile, RedshiftSource)
+    register_source("clickhouse", ClickHouseProfile, ClickHouseSource)
+    register_source("mysql", MySQLProfile, MySQLSource)
+    register_source("snowflake", SnowflakeProfile, SnowflakeSource)
+    register_source("databricks", DatabricksProfile, DatabricksSource)
+    register_source("sqlserver", SQLServerProfile, SQLServerSource)
+
+
+# Auto-register all connectors on import
+_register_all_connectors()

--- a/drt/connectors/registry.py
+++ b/drt/connectors/registry.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from drt.config.models import DestinationConfig
 
 # Registry mappings: type_name -> (ConfigClass, ImplementationClass)
+# ConfigClass stored for future plugin validation — not used in lookup yet
 _destination_registry: dict[str, tuple[type[Any], type[Any]]] = {}
 _source_registry: dict[str, tuple[type[Any], type[Any]]] = {}
 

--- a/drt/connectors/registry.py
+++ b/drt/connectors/registry.py
@@ -156,6 +156,7 @@ def _register_all_connectors() -> None:
         ParquetDestinationConfig,
         PostgresDestinationConfig,
         RestApiDestinationConfig,
+        SalesforceBulkDestinationConfig,
         SendGridDestinationConfig,
         SlackDestinationConfig,
         StagedUploadDestinationConfig,
@@ -180,6 +181,7 @@ def _register_all_connectors() -> None:
     from drt.destinations.parquet import ParquetDestination
     from drt.destinations.postgres import PostgresDestination
     from drt.destinations.rest_api import RestApiDestination
+    from drt.destinations.salesforce_bulk import SalesforceBulkDestination
     from drt.destinations.sendgrid import SendGridDestination
     from drt.destinations.slack import SlackDestination
     from drt.destinations.staged_upload import StagedUploadDestination
@@ -218,6 +220,7 @@ def _register_all_connectors() -> None:
     register_destination("linear", LinearDestinationConfig, LinearDestination)
     register_destination("google_ads", GoogleAdsDestinationConfig, GoogleAdsDestination)
     register_destination("notion", NotionDestinationConfig, NotionDestination)
+    register_destination("salesforce_bulk", SalesforceBulkDestinationConfig, SalesforceBulkDestination)
     register_destination("staged_upload", StagedUploadDestinationConfig, StagedUploadDestination)
     register_destination("intercom", IntercomDestinationConfig, IntercomDestination)
 

--- a/drt/connectors/registry.py
+++ b/drt/connectors/registry.py
@@ -220,7 +220,9 @@ def _register_all_connectors() -> None:
     register_destination("linear", LinearDestinationConfig, LinearDestination)
     register_destination("google_ads", GoogleAdsDestinationConfig, GoogleAdsDestination)
     register_destination("notion", NotionDestinationConfig, NotionDestination)
-    register_destination("salesforce_bulk", SalesforceBulkDestinationConfig, SalesforceBulkDestination)
+    register_destination(
+        "salesforce_bulk", SalesforceBulkDestinationConfig, SalesforceBulkDestination
+    )
     register_destination("staged_upload", StagedUploadDestinationConfig, StagedUploadDestination)
     register_destination("intercom", IntercomDestinationConfig, IntercomDestination)
 

--- a/tests/unit/test_connector_registry.py
+++ b/tests/unit/test_connector_registry.py
@@ -1,0 +1,88 @@
+"""Tests for the connector registry system."""
+
+from __future__ import annotations
+
+import pytest
+
+from drt.config.credentials import DuckDBProfile, PostgresProfile
+from drt.config.models import RestApiDestinationConfig, SlackDestinationConfig
+from drt.connectors import get_destination, get_source
+
+
+class TestConnectorRegistry:
+    """Test the connector registry system."""
+
+    def test_get_destination_slack(self):
+        """Get a Slack destination from registry."""
+        config = SlackDestinationConfig(
+            type="slack",
+            webhook_url_env="SLACK_WEBHOOK_URL",
+        )
+        destination = get_destination(config)
+        assert destination is not None
+        assert type(destination).__name__ == "SlackDestination"
+
+    def test_get_destination_rest_api(self):
+        """Get a REST API destination from registry."""
+        config = RestApiDestinationConfig(
+            type="rest_api",
+            url="https://api.example.com/webhook",
+        )
+        destination = get_destination(config)
+        assert destination is not None
+        assert type(destination).__name__ == "RestApiDestination"
+
+    def test_get_source_postgres(self):
+        """Get a Postgres source from registry."""
+        profile = PostgresProfile(
+            type="postgres",
+            host="localhost",
+            port=5432,
+            dbname="test",
+            user="test",
+        )
+        source = get_source(profile)
+        assert source is not None
+        assert type(source).__name__ == "PostgresSource"
+
+    def test_get_source_duckdb(self):
+        """Get a DuckDB source from registry."""
+        profile = DuckDBProfile(
+            type="duckdb",
+            database=":memory:",
+        )
+        source = get_source(profile)
+        assert source is not None
+        assert type(source).__name__ == "DuckDBSource"
+
+    def test_unknown_destination_error_message(self):
+        """Error message for unknown destination lists available options."""
+        # Create a mock config object with unknown type
+        class UnknownDestinationConfig:
+            type = "unknown_destination"
+
+        config = UnknownDestinationConfig()  # type: ignore
+        with pytest.raises(ValueError) as exc_info:
+            get_destination(config)  # type: ignore
+
+        # Check error message lists available destinations
+        error_msg = str(exc_info.value)
+        assert "Unknown destination type" in error_msg
+        assert "slack" in error_msg
+        assert "rest_api" in error_msg
+
+    def test_unknown_source_error_message(self):
+        """Error message for unknown source lists available options."""
+        # Create a mock profile object with unknown type
+        class UnknownProfile:
+            type = "unknown_source"
+
+        profile = UnknownProfile()  # type: ignore
+        with pytest.raises(ValueError) as exc_info:
+            get_source(profile)  # type: ignore
+
+        # Check error message lists available sources
+        error_msg = str(exc_info.value)
+        assert "Unknown source type" in error_msg
+        assert "postgres" in error_msg
+        assert "duckdb" in error_msg

--- a/tests/unit/test_connector_registry.py
+++ b/tests/unit/test_connector_registry.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import pytest
 
 from drt.config.credentials import DuckDBProfile, PostgresProfile
-from drt.config.models import RestApiDestinationConfig, SlackDestinationConfig
-from drt.config.models import SyncConfig
+from drt.config.models import RestApiDestinationConfig, SlackDestinationConfig, SyncConfig
 from drt.connectors import get_destination, get_source
 
 

--- a/tests/unit/test_connector_registry.py
+++ b/tests/unit/test_connector_registry.py
@@ -6,6 +6,7 @@ import pytest
 
 from drt.config.credentials import DuckDBProfile, PostgresProfile
 from drt.config.models import RestApiDestinationConfig, SlackDestinationConfig
+from drt.config.models import SyncConfig
 from drt.connectors import get_destination, get_source
 
 
@@ -86,3 +87,74 @@ class TestConnectorRegistry:
         assert "Unknown source type" in error_msg
         assert "postgres" in error_msg
         assert "duckdb" in error_msg
+
+    def test_duplicate_destination_registration(self):
+        """Registering a destination with duplicate type raises ValueError."""
+        from drt.connectors.registry import register_destination
+
+        # Try to register a destination with an existing type
+        class FakeConfig:
+            pass
+
+        class FakeDestination:
+            pass
+
+        with pytest.raises(ValueError) as exc_info:
+            register_destination("slack", FakeConfig, FakeDestination)
+
+        error_msg = str(exc_info.value)
+        assert "already registered" in error_msg
+        assert "slack" in error_msg
+
+    def test_duplicate_source_registration(self):
+        """Registering a source with duplicate type raises ValueError."""
+        from drt.connectors.registry import register_source
+
+        # Try to register a source with an existing type
+        class FakeProfile:
+            pass
+
+        class FakeSource:
+            pass
+
+        with pytest.raises(ValueError) as exc_info:
+            register_source("postgres", FakeProfile, FakeSource)
+
+        error_msg = str(exc_info.value)
+        assert "already registered" in error_msg
+        assert "postgres" in error_msg
+
+    def test_cli_get_destination_dispatcher(self):
+        """Test CLI dispatcher function for getting destinations."""
+        from drt.cli.main import _get_destination
+
+        # Create a minimal sync config with a slack destination
+        sync = SyncConfig(
+            name="test_sync",
+            model="test_model",
+            destination={
+                "type": "slack",
+                "webhook_url_env": "SLACK_WEBHOOK_URL",
+            },
+        )
+
+        destination = _get_destination(sync)
+        assert destination is not None
+        assert type(destination).__name__ == "SlackDestination"
+
+    def test_cli_get_source_dispatcher(self):
+        """Test CLI dispatcher function for getting sources."""
+        from drt.cli.main import _get_source
+
+        # Create a postgres profile
+        profile = PostgresProfile(
+            type="postgres",
+            host="localhost",
+            port=5432,
+            dbname="test",
+            user="test",
+        )
+
+        source = _get_source(profile)
+        assert source is not None
+        assert type(source).__name__ == "PostgresSource"


### PR DESCRIPTION
## Implement all-contributors workflow (#295)

Sets up the all-contributors bot and recognition workflow to acknowledge all types of contributions across the drt project.

### Changes
- Initialize `.all-contributorsrc` with contributorsPerLine: 7 and commit: false for manual review
- Bulk-import 4 initial code contributors from Git history (masukai, Muawiya-contact, Khush-domadia, Pawansingh3889)
- Add Contributors section to README.md with all-contributors badge
- Document contributor recognition workflow in CONTRIBUTING.md with command syntax and bot PR guidelines

### Configuration
- ✅ Validated JSON syntax (.all-contributorsrc)
- ✅ Grid renders correctly (7 per row, 100px avatars)
- ✅ Emoji key link active
- ✅ `README.ja.md` untouched

### Related
- Closes #295
- Complements `GOVERNANCE.md` contributor ladder
- GitHub App pre-installed and ready for bot integration

### Testing
Once merged, the bot will respond to comments like:

```
@all-contributors please add @username for <contribution-type>
```

These auto-generated contributor PRs are safe to merge once CI passes and visual layout is verified.