### PR TITLE
feat: zero-downtime replace via staging table swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Sync failure alerts** (#414): Configure `alerts.on_failure` in sync YAML to send Slack or generic HTTP webhook notifications when a sync ends with `failed > 0` or raises an exception. Two target types in v0.7: `slack` (Slack incoming webhook) and `webhook` (generic HTTP POST/PUT with optional `body_template`). Template variables: `sync_name`, `error`, `rows_processed`, `duration_s`, `started_at`. Dispatch is best-effort — alert failures are logged but never affect sync correctness or override the original exception.
 - **Snowflake destination** (#353): Write rows back to Snowflake tables. Supports `mode: insert` (append) and `mode: merge` (upsert via temp staging table + `MERGE` statement using `upsert_key`). Auth via `account_env` / `user_env` / `password_env`. Install: `pip install drt-core[snowflake]`. Contributed by @PFCAaron12.
+- **Zero-downtime replace via staging table swap** (#338): `sync.replace_strategy: swap` enables truly atomic table replacement — drt writes to a shadow table (`{table}__drt_swap`) per batch and atomically renames it to the original at the end of the sync. Supported on PostgreSQL (transactional `ALTER TABLE RENAME`), MySQL (atomic `RENAME TABLE`), and ClickHouse (atomic `EXCHANGE TABLES`, requires 21.8+). Default remains `truncate` (existing TRUNCATE → INSERT behavior). Follow-ups tracked in #433 (orphan auto-cleanup) and #434 (Snowflake support).
 
 ### Changed
 

--- a/docs/connectors/postgres.md
+++ b/docs/connectors/postgres.md
@@ -71,6 +71,23 @@ sync:
   mode: replace
 ```
 
+**Zero-downtime replace via staging swap:**
+```yaml
+sync:
+  mode: replace
+  replace_strategy: swap   # default: truncate
+```
+
+drt creates a shadow table `{table}__drt_swap`, populates it across batches, then atomically renames it to the original. Readers of the original table never see an empty state.
+
+Requirements: the destination user needs `CREATE TABLE`, `ALTER TABLE`, and `DROP TABLE` privileges.
+
+Caveats:
+- Tables with dependent views, materialized views, or triggers are **not recommended** for swap mode — the rename can break dependent objects.
+- If a sync is killed before completion, an orphan shadow may remain. Drop manually with `DROP TABLE {table}__drt_swap`. Auto-cleanup is tracked in [#433](https://github.com/drt-hub/drt/issues/433).
+
+Same `replace_strategy: swap` is supported on MySQL (atomic `RENAME TABLE`) and ClickHouse (atomic `EXCHANGE TABLES`, requires CH 21.8+).
+
 **FK resolution with destination_lookup:**
 ```yaml
 lookups:

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -639,6 +639,7 @@ class WatermarkConfig(BaseModel):
 
 class SyncOptions(BaseModel):
     mode: Literal["full", "incremental", "upsert", "replace"] = "full"
+    replace_strategy: Literal["truncate", "swap"] = "truncate"
     cursor_field: str | None = None  # required when mode=incremental
     watermark: WatermarkConfig | None = None
     batch_size: int = 100
@@ -650,6 +651,12 @@ class SyncOptions(BaseModel):
     def _check_incremental_cursor(self) -> "SyncOptions":
         if self.mode == "incremental" and not self.cursor_field:
             raise ValueError("cursor_field is required when mode is 'incremental'.")
+        return self
+
+    @model_validator(mode="after")
+    def _check_replace_strategy(self) -> "SyncOptions":
+        if self.replace_strategy == "swap" and self.mode != "replace":
+            raise ValueError("replace_strategy='swap' requires mode='replace'.")
         return self
 
 

--- a/drt/destinations/clickhouse.py
+++ b/drt/destinations/clickhouse.py
@@ -7,7 +7,10 @@ PostgreSQL and MySQL destination pattern).
 Deduplication is handled by ClickHouse's ReplacingMergeTree engine at merge
 time — the destination performs simple INSERTs.
 
-Supports ``sync.mode: replace`` (TRUNCATE TABLE → INSERT).
+Supports ``sync.mode: replace`` (TRUNCATE TABLE → INSERT) and
+``replace_strategy: swap`` (zero-downtime: build a shadow table via
+``CREATE TABLE ... AS ...``, INSERT into the shadow, then atomically
+``EXCHANGE TABLES`` in :meth:`finalize_sync`).
 
 Requires: pip install drt-core[clickhouse]
 
@@ -38,6 +41,8 @@ class ClickHouseDestination:
 
     def __init__(self) -> None:
         self._replace_truncated: bool = False
+        self._swap_shadow_created: bool = False
+        self._swap_table: str | None = None
 
     def load(
         self,
@@ -55,33 +60,119 @@ class ClickHouseDestination:
         try:
             columns = list(records[0].keys())
 
-            if sync_options.mode == "replace" and not self._replace_truncated:
-                client.command(f"TRUNCATE TABLE {config.table}")
-                self._replace_truncated = True
+            if (
+                sync_options.mode == "replace"
+                and sync_options.replace_strategy == "swap"
+            ):
+                result = self._load_replace_swap(
+                    client,
+                    records,
+                    columns,
+                    config.table,
+                    sync_options,
+                )
+            else:
+                if sync_options.mode == "replace" and not self._replace_truncated:
+                    client.command(f"TRUNCATE TABLE {config.table}")
+                    self._replace_truncated = True
 
-            # TODO: batch insert with fallback to row-by-row on error
-            for i, record in enumerate(records):
-                try:
-                    row = [[record.get(c) for c in columns]]
-                    client.insert(config.table, row, column_names=columns)
-                    result.success += 1
-                except Exception as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record, default=str)[:200],
-                            http_status=None,
-                            error_message=str(e),
+                # TODO: batch insert with fallback to row-by-row on error
+                for i, record in enumerate(records):
+                    try:
+                        row = [[record.get(c) for c in columns]]
+                        client.insert(config.table, row, column_names=columns)
+                        result.success += 1
+                    except Exception as e:
+                        result.failed += 1
+                        result.row_errors.append(
+                            RowError(
+                                batch_index=i,
+                                record_preview=json.dumps(record, default=str)[:200],
+                                http_status=None,
+                                error_message=str(e),
+                            )
                         )
-                    )
-                    if sync_options.on_error == "fail":
-                        return result
-                    continue
+                        if sync_options.on_error == "fail":
+                            return result
+                        continue
         finally:
             client.close()
 
         return result
+
+    def _load_replace_swap(
+        self,
+        client: Any,
+        records: list[dict[str, Any]],
+        columns: list[str],
+        table: str,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        """Build a shadow table per sync; atomic EXCHANGE happens in finalize_sync.
+
+        ClickHouse's ``CREATE TABLE shadow AS original`` clones the engine,
+        partitioning, ORDER BY, and column definitions. INSERTs go to the shadow
+        until :meth:`finalize_sync` runs ``EXCHANGE TABLES`` (atomic since 21.8).
+        """
+        result = SyncResult()
+        shadow = f"{table}__drt_swap"
+
+        if not self._swap_shadow_created:
+            client.command(f"DROP TABLE IF EXISTS {shadow}")
+            client.command(f"CREATE TABLE {shadow} AS {table}")
+            self._swap_shadow_created = True
+            self._swap_table = table
+
+        for i, record in enumerate(records):
+            try:
+                row = [[record.get(c) for c in columns]]
+                client.insert(shadow, row, column_names=columns)
+                result.success += 1
+            except Exception as e:
+                result.failed += 1
+                result.row_errors.append(
+                    RowError(
+                        batch_index=i,
+                        record_preview=json.dumps(record, default=str)[:200],
+                        http_status=None,
+                        error_message=str(e),
+                    )
+                )
+                if sync_options.on_error == "fail":
+                    return result
+                continue
+
+        return result
+
+    def finalize_sync(
+        self,
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult | None:
+        """Atomic EXCHANGE: shadow contents become live; old data dropped.
+
+        After ``EXCHANGE TABLES original AND shadow``, the shadow table now
+        holds the OLD data, so we drop it. ``EXCHANGE TABLES`` is atomic in
+        ClickHouse 21.8+.
+        """
+        if not self._swap_shadow_created or self._swap_table is None:
+            return None
+
+        assert isinstance(config, ClickHouseDestinationConfig)
+        table = self._swap_table
+        shadow = f"{table}__drt_swap"
+
+        client = self._connect(config)
+        try:
+            client.command(f"EXCHANGE TABLES {table} AND {shadow}")
+            # Shadow now contains the OLD data — drop it.
+            client.command(f"DROP TABLE {shadow}")
+        finally:
+            client.close()
+            self._swap_shadow_created = False
+            self._swap_table = None
+
+        return SyncResult()
 
     def get_row_count(self, config: DestinationConfig) -> int:
         """Get the current row count from the destination table.

--- a/drt/destinations/clickhouse.py
+++ b/drt/destinations/clickhouse.py
@@ -139,6 +139,15 @@ class ClickHouseDestination:
                     )
                 )
                 if sync_options.on_error == "fail":
+                    # Drop the partial shadow + reset state so finalize_sync()
+                    # cannot EXCHANGE partial data into the live table.
+                    # try/finally guarantees state reset even if DROP fails;
+                    # at worst we leave an orphan shadow (tracked by #433).
+                    try:
+                        client.command(f"DROP TABLE IF EXISTS {shadow}")
+                    finally:
+                        self._swap_shadow_created = False
+                        self._swap_table = None
                     return result
                 continue
 

--- a/drt/destinations/mysql.py
+++ b/drt/destinations/mysql.py
@@ -66,6 +66,8 @@ class MySQLDestination:
 
     def __init__(self) -> None:
         self._replace_truncated: bool = False
+        self._swap_shadow_created: bool = False
+        self._swap_table: str | None = None
 
     def load(
         self,
@@ -85,15 +87,25 @@ class MySQLDestination:
             columns = list(records[0].keys())
 
             if sync_options.mode == "replace":
-                result = self._load_replace(
-                    conn,
-                    cur,
-                    records,
-                    columns,
-                    config.table,
-                    sync_options,
-                    config,
-                )
+                if sync_options.replace_strategy == "swap":
+                    result = self._load_replace_swap(
+                        conn,
+                        cur,
+                        records,
+                        columns,
+                        config.table,
+                        sync_options,
+                    )
+                else:
+                    result = self._load_replace(
+                        conn,
+                        cur,
+                        records,
+                        columns,
+                        config.table,
+                        sync_options,
+                        config,
+                    )
             else:
                 result = self._load_upsert(
                     conn,
@@ -135,6 +147,17 @@ class MySQLDestination:
             return row[0] if row else 0
         finally:
             conn.close()
+
+    @staticmethod
+    def _quote_ident(table: str) -> str:
+        """Backtick-quote a (possibly schema-qualified) identifier.
+
+        ``mydb.scores`` -> ``\\`mydb\\`.\\`scores\\```
+        ``scores``      -> ``\\`scores\\```
+        """
+        if "." in table:
+            return "`" + "`.`".join(table.split(".")) + "`"
+        return f"`{table}`"
 
     def _load_replace(
         self,
@@ -179,6 +202,95 @@ class MySQLDestination:
 
         conn.commit()
         return result
+
+    def _load_replace_swap(
+        self,
+        conn: Any,
+        cur: Any,
+        records: list[dict[str, Any]],
+        columns: list[str],
+        table: str,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        """Build a shadow table per sync; atomic rename happens in finalize_sync."""
+        result = SyncResult()
+        shadow = f"{table}__drt_swap"
+        shadow_q = self._quote_ident(shadow)
+        table_q = self._quote_ident(table)
+
+        if not self._swap_shadow_created:
+            cur.execute(f"DROP TABLE IF EXISTS {shadow_q}")
+            # MySQL: CREATE TABLE ... LIKE ... copies columns + indexes
+            # + AUTO_INCREMENT default — no extra clause needed.
+            cur.execute(f"CREATE TABLE {shadow_q} LIKE {table_q}")
+            self._swap_shadow_created = True
+            self._swap_table = table
+
+        sql = self._build_insert_sql(shadow, columns)
+
+        for i, record in enumerate(records):
+            try:
+                values = [_serialize_value(record.get(c)) for c in columns]
+                cur.execute(sql, values)
+                result.success += 1
+            except Exception as e:
+                result.failed += 1
+                result.row_errors.append(
+                    RowError(
+                        batch_index=i,
+                        record_preview=json.dumps(record, default=str)[:200],
+                        http_status=None,
+                        error_message=str(e),
+                    )
+                )
+                if sync_options.on_error == "fail":
+                    conn.rollback()
+                    # Cleanup shadow on hard fail
+                    cur = conn.cursor()
+                    cur.execute(f"DROP TABLE IF EXISTS {shadow_q}")
+                    conn.commit()
+                    self._swap_shadow_created = False
+                    self._swap_table = None
+                    return result
+                # on_error=skip: keep going
+
+        conn.commit()
+        return result
+
+    def finalize_sync(
+        self,
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult | None:
+        """Atomic single-statement RENAME: original->old, shadow->original; drop old."""
+        if not self._swap_shadow_created or self._swap_table is None:
+            return None
+
+        assert isinstance(config, MySQLDestinationConfig)
+        table = self._swap_table
+        shadow = f"{table}__drt_swap"
+        old = f"{table}__drt_old"
+        table_q = self._quote_ident(table)
+        shadow_q = self._quote_ident(shadow)
+        old_q = self._quote_ident(old)
+
+        conn = self._connect(config)
+        try:
+            cur = conn.cursor()
+            # MySQL's multi-table RENAME is atomic in a single statement.
+            cur.execute(
+                f"RENAME TABLE {table_q} TO {old_q}, {shadow_q} TO {table_q}"
+            )
+            conn.commit()
+            # DROP old in separate tx (failure here doesn't break the swap).
+            cur.execute(f"DROP TABLE {old_q}")
+            conn.commit()
+        finally:
+            conn.close()
+            self._swap_shadow_created = False
+            self._swap_table = None
+
+        return SyncResult()
 
     @staticmethod
     def _load_upsert(

--- a/drt/destinations/postgres.py
+++ b/drt/destinations/postgres.py
@@ -92,6 +92,8 @@ class PostgresDestination:
 
     def __init__(self) -> None:
         self._replace_truncated: bool = False
+        self._swap_shadow_created: bool = False
+        self._swap_table: str | None = None
 
     def load(
         self,
@@ -111,15 +113,25 @@ class PostgresDestination:
             columns = list(records[0].keys())
 
             if sync_options.mode == "replace":
-                result = self._load_replace(
-                    conn,
-                    cur,
-                    records,
-                    columns,
-                    config.table,
-                    sync_options,
-                    config,
-                )
+                if sync_options.replace_strategy == "swap":
+                    result = self._load_replace_swap(
+                        conn,
+                        cur,
+                        records,
+                        columns,
+                        config.table,
+                        sync_options,
+                    )
+                else:
+                    result = self._load_replace(
+                        conn,
+                        cur,
+                        records,
+                        columns,
+                        config.table,
+                        sync_options,
+                        config,
+                    )
             else:
                 result = self._load_upsert(
                     conn,
@@ -207,6 +219,89 @@ class PostgresDestination:
 
         conn.commit()
         return result
+
+    def _load_replace_swap(
+        self,
+        conn: Any,
+        cur: Any,
+        records: list[dict[str, Any]],
+        columns: list[str],
+        table: str,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        """Build a shadow table per sync; atomic rename happens in finalize_sync."""
+        result = SyncResult()
+        shadow = f"{table}__drt_swap"
+
+        if not self._swap_shadow_created:
+            cur.execute(f"DROP TABLE IF EXISTS {shadow}")
+            cur.execute(f"CREATE TABLE {shadow} (LIKE {table} INCLUDING ALL)")
+            self._swap_shadow_created = True
+            self._swap_table = table
+
+        sql = self._build_insert_sql(shadow, columns)
+
+        for i, record in enumerate(records):
+            try:
+                values = [_serialize_value(record.get(c)) for c in columns]
+                cur.execute(sql, values)
+                result.success += 1
+            except Exception as e:
+                result.failed += 1
+                result.row_errors.append(
+                    RowError(
+                        batch_index=i,
+                        record_preview=json.dumps(record, default=str)[:200],
+                        http_status=None,
+                        error_message=str(e),
+                    )
+                )
+                if sync_options.on_error == "fail":
+                    conn.rollback()
+                    # Cleanup shadow on hard fail
+                    cur = conn.cursor()
+                    cur.execute(f"DROP TABLE IF EXISTS {shadow}")
+                    conn.commit()
+                    self._swap_shadow_created = False
+                    self._swap_table = None
+                    return result
+                # on_error=skip: keep going
+
+        conn.commit()
+        return result
+
+    def finalize_sync(
+        self,
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult | None:
+        """Atomic rename: original->old, shadow->original, drop old."""
+        if not self._swap_shadow_created or self._swap_table is None:
+            return None
+
+        assert isinstance(config, PostgresDestinationConfig)
+        table = self._swap_table
+        shadow = f"{table}__drt_swap"
+        old = f"{table}__drt_old"
+
+        conn = self._connect(config)
+        try:
+            cur = conn.cursor()
+            # Single transaction: original->old, shadow->original.
+            # ALTER TABLE ... RENAME TO takes a bare relation name on the RHS;
+            # the schema is preserved automatically.
+            cur.execute(f"ALTER TABLE {table} RENAME TO {old.split('.')[-1]}")
+            cur.execute(f"ALTER TABLE {shadow} RENAME TO {table.split('.')[-1]}")
+            conn.commit()
+            # DROP old in separate tx (failure here doesn't break the swap).
+            cur.execute(f"DROP TABLE {old}")
+            conn.commit()
+        finally:
+            conn.close()
+            self._swap_shadow_created = False
+            self._swap_table = None
+
+        return SyncResult()
 
     @staticmethod
     def _load_upsert(

--- a/drt/engine/sync.py
+++ b/drt/engine/sync.py
@@ -252,6 +252,22 @@ def _run_sync_body(
         total_result.errors.extend(finalize_result.errors)
         total_result.row_errors.extend(getattr(finalize_result, "row_errors", []))
 
+    # Duck-typed end-of-sync hook for non-staged destinations
+    # (e.g. swap-finalize for replace_strategy=swap on Postgres/MySQL/ClickHouse).
+    # The hook is intentionally NOT a Protocol — destinations opt in by simply
+    # defining a finalize_sync() method.
+    if not is_staged and not dry_run:
+        finalizer = getattr(destination, "finalize_sync", None)
+        if callable(finalizer):
+            finalize_result = finalizer(sync.destination, sync.sync)
+            if finalize_result is not None:
+                total_result.success += finalize_result.success
+                total_result.failed += finalize_result.failed
+                total_result.errors.extend(finalize_result.errors)
+                total_result.row_errors.extend(
+                    getattr(finalize_result, "row_errors", [])
+                )
+
     total_result.duration_seconds = round(time.perf_counter() - t0, 3)
     total_result.watermark_source = watermark_source
     total_result.cursor_value_used = last_cursor_value

--- a/tests/unit/test_clickhouse_destination.py
+++ b/tests/unit/test_clickhouse_destination.py
@@ -243,3 +243,105 @@ class TestClickHouseReplaceMode:
         dest.load([{"id": 1, "score": 0.5}], _config(), _options(mode="full"))
 
         client.command.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Replace mode — swap strategy
+# ---------------------------------------------------------------------------
+
+
+class TestClickHouseReplaceSwap:
+    @patch("drt.destinations.clickhouse.ClickHouseDestination._connect")
+    def test_swap_creates_shadow_via_create_table_as(
+        self, mock_connect: MagicMock
+    ) -> None:
+        client = _fake_client()
+        mock_connect.return_value = client
+        records = [{"id": 1, "score": 0.95}]
+
+        dest = ClickHouseDestination()
+        dest.load(records, _config(), _options(mode="replace", replace_strategy="swap"))
+
+        commands = [c[0][0] for c in client.command.call_args_list]
+        assert any(
+            "DROP TABLE IF EXISTS" in s and "__drt_swap" in s for s in commands
+        )
+        assert any(
+            "CREATE TABLE" in s and "__drt_swap" in s and " AS " in s
+            for s in commands
+        )
+        # Insert goes to shadow, not the original table
+        assert client.insert.call_count == 1
+        assert client.insert.call_args[0][0].endswith("__drt_swap")
+        assert client.insert.call_args[1]["column_names"] == ["id", "score"]
+        # No EXCHANGE TABLES yet — that happens in finalize_sync
+        assert not any("EXCHANGE TABLES" in s for s in commands)
+
+    @patch("drt.destinations.clickhouse.ClickHouseDestination._connect")
+    def test_swap_finalize_uses_exchange_tables(
+        self, mock_connect: MagicMock
+    ) -> None:
+        client = _fake_client()
+        mock_connect.return_value = client
+
+        dest = ClickHouseDestination()
+        dest.load(
+            [{"id": 1, "score": 0.95}],
+            _config(),
+            _options(mode="replace", replace_strategy="swap"),
+        )
+        dest.finalize_sync(
+            _config(), _options(mode="replace", replace_strategy="swap")
+        )
+
+        commands = [c[0][0] for c in client.command.call_args_list]
+        # EXCHANGE TABLES original AND shadow
+        exchange_sqls = [
+            s
+            for s in commands
+            if "EXCHANGE TABLES" in s and "__drt_swap" in s
+        ]
+        assert len(exchange_sqls) >= 1
+        # Drop the (now-old) shadow table after exchange
+        drop_after_exchange = [
+            s
+            for s in commands
+            if s.startswith("DROP TABLE") and "IF EXISTS" not in s and "__drt_swap" in s
+        ]
+        assert len(drop_after_exchange) >= 1
+
+    @patch("drt.destinations.clickhouse.ClickHouseDestination._connect")
+    def test_swap_finalize_noop_when_no_swap_in_progress(
+        self, mock_connect: MagicMock
+    ) -> None:
+        dest = ClickHouseDestination()
+        result = dest.finalize_sync(_config(), _options(mode="full"))
+        assert result is None
+        mock_connect.assert_not_called()
+
+    @patch("drt.destinations.clickhouse.ClickHouseDestination._connect")
+    def test_swap_creates_shadow_only_once_across_batches(
+        self, mock_connect: MagicMock
+    ) -> None:
+        client = _fake_client()
+        mock_connect.return_value = client
+
+        dest = ClickHouseDestination()
+        dest.load(
+            [{"id": 1, "score": 0.5}],
+            _config(),
+            _options(mode="replace", replace_strategy="swap"),
+        )
+        dest.load(
+            [{"id": 2, "score": 0.9}],
+            _config(),
+            _options(mode="replace", replace_strategy="swap"),
+        )
+
+        commands = [c[0][0] for c in client.command.call_args_list]
+        create_count = sum(
+            1
+            for s in commands
+            if s.startswith("CREATE TABLE") and "__drt_swap" in s
+        )
+        assert create_count == 1

--- a/tests/unit/test_clickhouse_destination.py
+++ b/tests/unit/test_clickhouse_destination.py
@@ -345,3 +345,77 @@ class TestClickHouseReplaceSwap:
             if s.startswith("CREATE TABLE") and "__drt_swap" in s
         )
         assert create_count == 1
+
+    @patch("drt.destinations.clickhouse.ClickHouseDestination._connect")
+    def test_swap_on_error_fail_drops_shadow_and_resets_state(
+        self, mock_connect: MagicMock
+    ) -> None:
+        """Mid-batch failure with on_error=fail must drop shadow + reset state
+        so finalize_sync cannot EXCHANGE partial data into the live table.
+        """
+        client = _fake_client()
+        # Succeed on first row, then fail.
+        client.insert.side_effect = [None, Exception("type mismatch in batch 2")]
+        mock_connect.return_value = client
+
+        dest = ClickHouseDestination()
+        result = dest.load(
+            [{"id": 1, "score": 0.5}, {"id": 2, "score": "NaN"}],
+            _config(),
+            _options(mode="replace", replace_strategy="swap", on_error="fail"),
+        )
+
+        # Failure tracked
+        assert result.failed == 1
+        # Shadow was dropped on hard fail (DROP IF EXISTS issued AFTER the create)
+        commands = [c[0][0] for c in client.command.call_args_list]
+        drop_after_create = [
+            s for s in commands if "DROP TABLE IF EXISTS" in s and "__drt_swap" in s
+        ]
+        assert len(drop_after_create) >= 2  # one before CREATE, one on failure
+        # State reset → finalize_sync must be a no-op
+        finalize_result = dest.finalize_sync(
+            _config(), _options(mode="replace", replace_strategy="swap")
+        )
+        assert finalize_result is None
+        # Critically: no EXCHANGE TABLES was issued
+        assert not any("EXCHANGE TABLES" in s for s in commands)
+
+    @patch("drt.destinations.clickhouse.ClickHouseDestination._connect")
+    def test_swap_on_error_fail_resets_state_even_if_drop_fails(
+        self, mock_connect: MagicMock
+    ) -> None:
+        """If the cleanup DROP itself fails, state must still be reset
+        (orphan shadow is acceptable and tracked by #433; partial-data
+        EXCHANGE is not).
+        """
+        client = _fake_client()
+        client.insert.side_effect = Exception("insert failed")
+
+        # Make the cleanup DROP itself raise — the initial DROP IF EXISTS at
+        # shadow setup must succeed; only the cleanup one fails.
+        drop_call_count = {"n": 0}
+
+        def command_side_effect(sql: str) -> None:
+            if "DROP TABLE IF EXISTS" in sql:
+                drop_call_count["n"] += 1
+                if drop_call_count["n"] >= 2:
+                    raise Exception("cluster busy")
+            return None
+
+        client.command.side_effect = command_side_effect
+        mock_connect.return_value = client
+
+        dest = ClickHouseDestination()
+        with pytest.raises(Exception, match="cluster busy"):
+            dest.load(
+                [{"id": 1, "score": 0.5}],
+                _config(),
+                _options(mode="replace", replace_strategy="swap", on_error="fail"),
+            )
+
+        # Even though DROP raised, state must be reset (try/finally)
+        finalize_result = dest.finalize_sync(
+            _config(), _options(mode="replace", replace_strategy="swap")
+        )
+        assert finalize_result is None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -639,3 +639,26 @@ class TestAlertsConfig:
         from drt.config.models import WebhookAlertConfig
         with pytest.raises(ValueError, match="url"):
             WebhookAlertConfig(type="webhook")
+
+
+# ---------------------------------------------------------------------------
+# Replace strategy (zero-downtime swap — #338)
+# ---------------------------------------------------------------------------
+
+
+class TestReplaceStrategy:
+    def test_default_replace_strategy_is_truncate(self) -> None:
+        opts = SyncOptions(mode="replace")
+        assert opts.replace_strategy == "truncate"
+
+    def test_replace_strategy_swap_accepted(self) -> None:
+        opts = SyncOptions(mode="replace", replace_strategy="swap")
+        assert opts.replace_strategy == "swap"
+
+    def test_replace_strategy_invalid_value_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SyncOptions(mode="replace", replace_strategy="hotswap")  # type: ignore[arg-type]
+
+    def test_replace_strategy_swap_requires_replace_mode(self) -> None:
+        with pytest.raises(ValueError, match="replace_strategy"):
+            SyncOptions(mode="full", replace_strategy="swap")

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -726,3 +726,93 @@ class TestEngineAlertDispatch:
         run_sync(sync, source, dest, _make_profile(), tmp_path, dry_run=True)
 
         assert not mock_dispatch.called
+
+
+# ---------------------------------------------------------------------------
+# finalize_sync() duck-typed hook (#338)
+# ---------------------------------------------------------------------------
+
+
+class FakeDestinationWithFinalize:
+    """Non-staged destination that also implements duck-typed finalize_sync()."""
+
+    def __init__(self, finalize_result: SyncResult | None = None) -> None:
+        self.calls: list[list[dict]] = []
+        self.finalize_called = False
+        self.finalize_args: tuple[DestinationConfig, SyncOptions] | None = None
+        self._finalize_result = finalize_result if finalize_result is not None else SyncResult()
+
+    def load(
+        self,
+        records: list[dict],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        self.calls.append(records)
+        result = SyncResult()
+        result.success = len(records)
+        return result
+
+    def finalize_sync(
+        self,
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        self.finalize_called = True
+        self.finalize_args = (config, sync_options)
+        return self._finalize_result
+
+
+def test_finalize_sync_called_when_destination_has_it(tmp_path: Path) -> None:
+    """Engine should call finalize_sync() if the destination implements it."""
+    rows = [{"id": i} for i in range(3)]
+    source = FakeSource(rows)
+    dest = FakeDestinationWithFinalize()
+    sync = _make_sync(batch_size=10)
+
+    run_sync(sync, source, dest, _make_profile(), tmp_path)
+
+    assert dest.finalize_called is True
+    assert dest.finalize_args is not None
+
+
+def test_finalize_sync_absent_does_not_crash(tmp_path: Path) -> None:
+    """Engine should not crash when destination has no finalize_sync attr."""
+    rows = [{"id": i} for i in range(3)]
+    source = FakeSource(rows)
+    dest = FakeDestination()  # has only load(), no finalize_sync
+    sync = _make_sync(batch_size=10)
+
+    # Must not raise AttributeError
+    result = run_sync(sync, source, dest, _make_profile(), tmp_path)
+
+    assert result.success == 3
+    assert not hasattr(dest, "finalize_called")
+
+
+def test_finalize_sync_result_accumulated_into_total(tmp_path: Path) -> None:
+    """finalize_sync's SyncResult should be merged into total_result."""
+    rows = [{"id": i} for i in range(2)]
+    source = FakeSource(rows)
+    finalize_result = SyncResult(success=5, failed=1, errors=["finalize warn"])
+    dest = FakeDestinationWithFinalize(finalize_result=finalize_result)
+    sync = _make_sync(batch_size=10)
+
+    result = run_sync(sync, source, dest, _make_profile(), tmp_path)
+
+    # load() reported 2 success; finalize_sync adds 5 success + 1 failed.
+    assert result.success == 2 + 5
+    assert result.failed == 1
+    assert "finalize warn" in result.errors
+
+
+def test_finalize_sync_skipped_on_dry_run(tmp_path: Path) -> None:
+    """finalize_sync must NOT be called during dry_run (no side effects)."""
+    rows = [{"id": i} for i in range(2)]
+    source = FakeSource(rows)
+    dest = FakeDestinationWithFinalize()
+    sync = _make_sync(batch_size=10)
+
+    run_sync(sync, source, dest, _make_profile(), tmp_path, dry_run=True)
+
+    assert dest.finalize_called is False

--- a/tests/unit/test_mysql_destination.py
+++ b/tests/unit/test_mysql_destination.py
@@ -440,3 +440,50 @@ class TestMySQLReplaceSwap:
             1 for s in sqls if "CREATE TABLE" in s and " LIKE " in s
         )
         assert create_count == 1
+
+    @patch("drt.destinations.mysql.MySQLDestination._connect")
+    def test_swap_on_error_fail_drops_shadow_and_resets_state(
+        self, mock_connect: MagicMock
+    ) -> None:
+        """Mid-batch failure with on_error=fail must rollback, drop shadow,
+        and reset state so finalize_sync cannot RENAME a partial shadow into
+        the live table.
+        """
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        insert_call_count = {"n": 0}
+
+        def execute_side_effect(sql: str, *args: Any) -> None:
+            if sql.startswith("INSERT INTO"):
+                insert_call_count["n"] += 1
+                if insert_call_count["n"] == 2:
+                    raise Exception("data too long for column")
+            return None
+
+        cur.execute.side_effect = execute_side_effect
+
+        dest = MySQLDestination()
+        result = dest.load(
+            [
+                {"user_id": 1, "company_id": 5, "score": 0.5},
+                {"user_id": 2, "company_id": 5, "score": 0.9},
+            ],
+            _config(),
+            _options(mode="replace", replace_strategy="swap", on_error="fail"),
+        )
+
+        assert result.failed == 1
+        assert result.success == 1
+        conn.rollback.assert_called()
+        sqls = [c[0][0] for c in cur.execute.call_args_list]
+        drops = [s for s in sqls if "DROP TABLE IF EXISTS" in s and "__drt_swap" in s]
+        assert len(drops) >= 2
+        # State reset → finalize_sync must be a no-op
+        finalize_result = dest.finalize_sync(
+            _config(), _options(mode="replace", replace_strategy="swap")
+        )
+        assert finalize_result is None
+        sqls_after = [c[0][0] for c in cur.execute.call_args_list]
+        assert not any("RENAME TABLE" in s for s in sqls_after)

--- a/tests/unit/test_mysql_destination.py
+++ b/tests/unit/test_mysql_destination.py
@@ -350,3 +350,93 @@ class TestJsonColumns:
         assert _serialize_value(None, "col", ["col"]) is None
 
 
+# ---------------------------------------------------------------------------
+# Replace mode — swap strategy
+# ---------------------------------------------------------------------------
+
+
+class TestMySQLReplaceSwap:
+    @patch("drt.destinations.mysql.MySQLDestination._connect")
+    def test_swap_creates_shadow_then_inserts(self, mock_connect: MagicMock) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+        records = [{"user_id": 1, "company_id": 5, "score": 0.95}]
+
+        dest = MySQLDestination()
+        dest.load(records, _config(), _options(mode="replace", replace_strategy="swap"))
+
+        sqls = [c[0][0] for c in cur.execute.call_args_list]
+        assert any("DROP TABLE IF EXISTS" in s and "__drt_swap" in s for s in sqls)
+        # MySQL: CREATE TABLE ... LIKE ... (NOT "INCLUDING ALL")
+        assert any(
+            "CREATE TABLE" in s and " LIKE " in s and "__drt_swap" in s for s in sqls
+        )
+        assert any("INSERT INTO" in s and "__drt_swap" in s for s in sqls)
+        # No RENAME yet — happens in finalize_sync
+        assert not any("RENAME TABLE" in s for s in sqls)
+
+    @patch("drt.destinations.mysql.MySQLDestination._connect")
+    def test_swap_finalize_atomic_rename(self, mock_connect: MagicMock) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        dest = MySQLDestination()
+        dest.load(
+            [{"user_id": 1, "company_id": 5, "score": 0.95}],
+            _config(),
+            _options(mode="replace", replace_strategy="swap"),
+        )
+        dest.finalize_sync(
+            _config(), _options(mode="replace", replace_strategy="swap")
+        )
+
+        sqls = [c[0][0] for c in cur.execute.call_args_list]
+        # MySQL: a SINGLE atomic multi-table RENAME statement
+        rename_sqls = [s for s in sqls if "RENAME TABLE" in s]
+        assert len(rename_sqls) == 1
+        rename_sql = rename_sqls[0]
+        # Both pairs in one statement, comma-separated
+        assert "__drt_old" in rename_sql
+        assert "__drt_swap" in rename_sql
+        assert "," in rename_sql
+        # Final DROP of old table
+        assert any("DROP TABLE" in s and "__drt_old" in s for s in sqls)
+
+    @patch("drt.destinations.mysql.MySQLDestination._connect")
+    def test_swap_finalize_noop_when_no_swap_in_progress(
+        self, mock_connect: MagicMock
+    ) -> None:
+        dest = MySQLDestination()
+        # finalize_sync without prior swap-mode load is a safe no-op
+        result = dest.finalize_sync(_config(), _options(mode="full"))
+        assert result is None or result.success == 0
+        # Should not have connected
+        mock_connect.assert_not_called()
+
+    @patch("drt.destinations.mysql.MySQLDestination._connect")
+    def test_swap_creates_shadow_only_once_across_batches(
+        self, mock_connect: MagicMock
+    ) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        dest = MySQLDestination()
+        dest.load(
+            [{"user_id": 1, "company_id": 5, "score": 0.5}],
+            _config(),
+            _options(mode="replace", replace_strategy="swap"),
+        )
+        dest.load(
+            [{"user_id": 2, "company_id": 5, "score": 0.9}],
+            _config(),
+            _options(mode="replace", replace_strategy="swap"),
+        )
+
+        sqls = [c[0][0] for c in cur.execute.call_args_list]
+        create_count = sum(
+            1 for s in sqls if "CREATE TABLE" in s and " LIKE " in s
+        )
+        assert create_count == 1

--- a/tests/unit/test_postgres_destination.py
+++ b/tests/unit/test_postgres_destination.py
@@ -423,4 +423,50 @@ class TestPostgresReplaceSwap:
             1 for s in sqls if "CREATE TABLE" in s and "INCLUDING ALL" in s
         )
         assert create_count == 1
->>>>>>> 67c8fa4 (feat(destinations/postgres): add replace_strategy=swap)
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_swap_on_error_fail_drops_shadow_and_resets_state(
+        self, mock_connect: MagicMock
+    ) -> None:
+        """Mid-batch failure with on_error=fail must rollback, drop shadow,
+        and reset state so finalize_sync cannot RENAME a partial shadow into
+        the live table.
+        """
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        # Fail only on INSERT — DROP/CREATE/cleanup succeed.
+        insert_call_count = {"n": 0}
+
+        def execute_side_effect(sql: str, *args: Any) -> None:
+            if sql.startswith("INSERT INTO"):
+                insert_call_count["n"] += 1
+                if insert_call_count["n"] == 2:
+                    raise Exception("constraint violation on row 2")
+            return None
+
+        cur.execute.side_effect = execute_side_effect
+
+        dest = PostgresDestination()
+        result = dest.load(
+            [{"id": 1, "score": 0.5}, {"id": 2, "score": 0.9}],
+            _config(),
+            _options(mode="replace", replace_strategy="swap", on_error="fail"),
+        )
+
+        assert result.failed == 1
+        assert result.success == 1
+        # Rollback called on hard fail
+        conn.rollback.assert_called()
+        # Cleanup DROP IF EXISTS issued after rollback
+        sqls = [c[0][0] for c in cur.execute.call_args_list]
+        drops = [s for s in sqls if "DROP TABLE IF EXISTS" in s and "__drt_swap" in s]
+        assert len(drops) >= 2  # initial + cleanup
+        # State reset → finalize_sync must be a no-op (no RENAME issued)
+        finalize_result = dest.finalize_sync(
+            _config(), _options(mode="replace", replace_strategy="swap")
+        )
+        assert finalize_result is None
+        sqls_after = [c[0][0] for c in cur.execute.call_args_list]
+        assert not any("RENAME TO" in s for s in sqls_after)

--- a/tests/unit/test_postgres_destination.py
+++ b/tests/unit/test_postgres_destination.py
@@ -336,3 +336,91 @@ class TestPostgresJsonColumns:
 
         with pytest.raises(ValueError, match="'my_settings'"):
             _serialize_value({"a": 1}, column="my_settings", json_columns=["profile"])
+
+
+# ---------------------------------------------------------------------------
+# Replace mode — swap strategy
+# ---------------------------------------------------------------------------
+
+
+class TestPostgresReplaceSwap:
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_swap_creates_shadow_then_inserts(self, mock_connect: MagicMock) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+        records = [{"id": 1, "score": 0.95}]
+
+        dest = PostgresDestination()
+        dest.load(records, _config(), _options(mode="replace", replace_strategy="swap"))
+
+        sqls = [c[0][0] for c in cur.execute.call_args_list]
+        assert any("DROP TABLE IF EXISTS" in s and "__drt_swap" in s for s in sqls)
+        assert any(
+            "CREATE TABLE" in s and "(LIKE " in s and "INCLUDING ALL" in s for s in sqls
+        )
+        assert any("INSERT INTO" in s and "__drt_swap" in s for s in sqls)
+        # No swap yet — happens in finalize_sync
+        assert not any("RENAME TO" in s for s in sqls)
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_swap_finalize_renames_atomically(self, mock_connect: MagicMock) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        dest = PostgresDestination()
+        dest.load(
+            [{"id": 1, "score": 0.95}],
+            _config(),
+            _options(mode="replace", replace_strategy="swap"),
+        )
+        dest.finalize_sync(
+            _config(), _options(mode="replace", replace_strategy="swap")
+        )
+
+        sqls = [c[0][0] for c in cur.execute.call_args_list]
+        # Two RENAME steps wrapped in a transaction
+        rename_sqls = [s for s in sqls if "RENAME TO" in s]
+        assert len(rename_sqls) >= 2
+        # Final DROP of old table
+        assert any("DROP TABLE" in s and "__drt_old" in s for s in sqls)
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_swap_finalize_noop_when_no_swap_in_progress(
+        self, mock_connect: MagicMock
+    ) -> None:
+        conn = _fake_connection()
+        mock_connect.return_value = conn
+
+        dest = PostgresDestination()
+        # finalize_sync without prior swap-mode load is a safe no-op
+        result = dest.finalize_sync(_config(), _options(mode="full"))
+        assert result is None or result.success == 0
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_swap_creates_shadow_only_once_across_batches(
+        self, mock_connect: MagicMock
+    ) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        dest = PostgresDestination()
+        dest.load(
+            [{"id": 1, "score": 0.5}],
+            _config(),
+            _options(mode="replace", replace_strategy="swap"),
+        )
+        dest.load(
+            [{"id": 2, "score": 0.9}],
+            _config(),
+            _options(mode="replace", replace_strategy="swap"),
+        )
+
+        sqls = [c[0][0] for c in cur.execute.call_args_list]
+        create_count = sum(
+            1 for s in sqls if "CREATE TABLE" in s and "INCLUDING ALL" in s
+        )
+        assert create_count == 1
+>>>>>>> 67c8fa4 (feat(destinations/postgres): add replace_strategy=swap)


### PR DESCRIPTION
## Summary

Implements `sync.replace_strategy: swap` for atomic table replacement, closing #338.

- Adds `replace_strategy: Literal["truncate", "swap"] = "truncate"` to `SyncOptions`, with a validator ensuring `swap` is only valid with `mode=replace`. Default behavior unchanged → fully backwards compatible.
- Engine gains a duck-typed `finalize_sync()` hook (no Protocol break) called once after the load loop for non-staged destinations.
- **PostgreSQL**: `CREATE TABLE shadow (LIKE original INCLUDING ALL)` → batch INSERT → transactional `ALTER TABLE RENAME` swap → `DROP` old.
- **MySQL**: `CREATE TABLE shadow LIKE original` → batch INSERT → atomic single-statement multi-table `RENAME TABLE` → `DROP` old.
- **ClickHouse**: `CREATE TABLE shadow AS original` → batch INSERT → atomic `EXCHANGE TABLES` (21.8+) → `DROP` shadow.

## Architecture note

The Protocol `Destination` does not have an end-of-sync hook (only `StagedDestination` does, via `finalize()`). Rather than introducing a Protocol-breaking change, the engine uses a duck-typed `getattr(destination, "finalize_sync", None)` call — destinations that don't need it are unaffected.

## Out of Scope (split into follow-ups)

- Orphan shadow auto-cleanup → #433 (v0.8)
- Snowflake support → #434 (v0.8, depends on #353)
- Dependent-object handling (views / mviews / triggers) → docs caveat only, future v0.9

## Test plan

- [x] `make lint` — ruff + mypy clean
- [x] `make test` — 735 passed, 2 skipped (was 715 before this PR; 20 new tests across config, engine, and 3 destinations)
- [x] `make check-i18n` — clean
- [x] New TDD coverage:
  - Config: `replace_strategy` field + cross-field validator (4 tests)
  - Engine: duck-typed `finalize_sync` hook — called when present, skipped when absent, dry-run guard, result accumulation (4 tests)
  - Postgres: shadow create, multi-batch insert, atomic rename, finalize-noop (4 tests)
  - MySQL: same coverage with atomic multi-table `RENAME TABLE` (4 tests)
  - ClickHouse: same coverage with `EXCHANGE TABLES` (4 tests)

## Governance

Per [GOVERNANCE.md](https://github.com/drt-hub/drt/blob/main/GOVERNANCE.md): **Medium change** (config schema addition + engine internal hook, no Protocol break) — 1 Owner approval + 24h objection window.

Reviewer: @yodakanohoshi

Closes #338