### PR TITLE
feat: sync failure alerts (Slack / webhook)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Sync failure alerts** (#414): Configure `alerts.on_failure` in sync YAML to send Slack or generic HTTP webhook notifications when a sync ends with `failed > 0` or raises an exception. Two target types in v0.7: `slack` (Slack incoming webhook) and `webhook` (generic HTTP POST/PUT with optional `body_template`). Template variables: `sync_name`, `error`, `rows_processed`, `duration_s`, `started_at`. Dispatch is best-effort — alert failures are logged but never affect sync correctness or override the original exception.
+
 ### Changed
 
 - **Connector registry** (#381): Replaced hardcoded `isinstance` chains in `_get_destination()` / `_get_source()` with a centralized registry (`drt/connectors/registry.py`). Adding a new connector no longer requires editing `main.py`. Error messages now list available connectors on typo. Contributed by @Muawiya-contact.

--- a/docs/guides/alerts.md
+++ b/docs/guides/alerts.md
@@ -1,0 +1,145 @@
+# Sync Failure Alerts
+
+Configure push notifications so operators learn about sync failures immediately, without polling `drt status`.
+
+## Quick start
+
+Add an `alerts:` block to a sync YAML. The block is optional — syncs without `alerts:` behave exactly as before.
+
+```yaml
+name: profile_sync
+model: |
+  SELECT id, email FROM profiles WHERE updated_at >= '{{ cursor_value }}'
+destination:
+  type: postgres
+  host: db.example.com
+  table: app.profiles
+  upsert_key: [id]
+sync:
+  mode: upsert
+alerts:
+  on_failure:
+    - type: slack
+      webhook_url_env: SLACK_ALERT_WEBHOOK
+    - type: webhook
+      url_env: ALERT_WEBHOOK_URL
+```
+
+## When alerts fire
+
+`alerts.on_failure` dispatches when **either**:
+
+- The sync run ends with `total_result.failed > 0` (one or more records failed and the sync did not raise), OR
+- The sync raised an exception (e.g. connection error, query failure).
+
+Alerts do **not** fire on:
+
+- Successful syncs (`failed == 0` and no exception).
+- `--dry-run` invocations (the sync did not actually run).
+
+## Targets
+
+### `type: slack`
+
+Posts a single message to a [Slack incoming webhook](https://api.slack.com/messaging/webhooks).
+
+| Field | Required | Notes |
+|---|---|---|
+| `type` | yes | Must be `"slack"`. |
+| `webhook_url` | one of two | Literal URL. |
+| `webhook_url_env` | one of two | Name of an env var holding the URL. |
+| `message` | no | Format string. Default: `` "drt sync `{sync_name}` failed: {error}" `` |
+
+Example:
+
+```yaml
+alerts:
+  on_failure:
+    - type: slack
+      webhook_url_env: SLACK_ALERT_WEBHOOK
+      message: ":warning: `{sync_name}` failed at {started_at} — {error}"
+```
+
+### `type: webhook`
+
+Sends a generic HTTP POST/PUT to any URL.
+
+| Field | Required | Notes |
+|---|---|---|
+| `type` | yes | Must be `"webhook"`. |
+| `url` | one of two | Literal URL. |
+| `url_env` | one of two | Name of an env var holding the URL. |
+| `method` | no | `POST` (default) or `PUT`. |
+| `headers` | no | Map of header name → value. |
+| `body_template` | no | Format string for the request body. If omitted, drt sends a JSON object containing all template variables. |
+
+Example with PagerDuty Events API v2:
+
+```yaml
+alerts:
+  on_failure:
+    - type: webhook
+      url: https://events.pagerduty.com/v2/enqueue
+      method: POST
+      headers:
+        Content-Type: application/json
+      body_template: |
+        {{
+          "routing_key": "${PD_ROUTING_KEY}",
+          "event_action": "trigger",
+          "payload": {{
+            "summary": "drt sync {sync_name} failed: {error}",
+            "severity": "error",
+            "source": "drt"
+          }}
+        }}
+```
+
+> Note the doubled `{{` / `}}`: Python `str.format()` uses `{}` for variable interpolation, so literal braces in JSON must be escaped.
+
+## Template variables
+
+Available in both `slack.message` and `webhook.body_template`:
+
+| Variable | Type | Meaning |
+|---|---|---|
+| `sync_name` | str | Name of the failing sync (from `name:` field). |
+| `error` | str | First error message from the failed batch, or `<no error message>` if none captured. On exception path: `"<ExceptionClass>: <message>"`. |
+| `rows_processed` | int | `success + failed` row counts at time of failure. |
+| `duration_s` | float | Elapsed wall-clock seconds. |
+| `started_at` | str | ISO-8601 UTC timestamp when the sync started. |
+
+Use `str.format()` syntax: `{sync_name}`, `{error}`, etc. Unknown variables raise `KeyError` at dispatch time and are logged but do not crash the sync.
+
+## Best-effort guarantee
+
+Alert dispatch is **best-effort**:
+
+- A failing alert (network error, 4xx/5xx response, malformed template) is **logged** at WARNING level but never re-raised.
+- The original sync error and `SyncResult` are unaffected by alert failures.
+- Each target dispatches independently — a failing Slack target does not block the webhook target.
+
+**Caveat:** alert dispatch happens *before* the original exception re-propagates to the caller. Each target has a 10-second `urllib` timeout, so a slow webhook endpoint can delay error propagation by up to `10 × len(on_failure)` seconds in the worst case. Keep alert endpoints fast.
+
+## Environment variables
+
+drt expands `${VAR}` references in YAML at load time across all string fields (#385), so you can write:
+
+```yaml
+alerts:
+  on_failure:
+    - type: webhook
+      url: https://api.example.com/${ENV}/alerts
+      headers:
+        Authorization: Bearer ${ALERT_TOKEN}
+```
+
+For URL-only secrets, prefer `webhook_url_env` / `url_env` to keep secrets out of the YAML and out of any logs that might echo it.
+
+## Out of scope (v0.7)
+
+- On-success notifications.
+- `drt test` validator failure alerts.
+- Per-target retry / dedup of alert dispatch.
+
+These may land in a future release if there's user demand. PagerDuty / OpsGenie / Datadog Events / etc. are reachable today via the generic webhook target.

--- a/drt/alerts/__init__.py
+++ b/drt/alerts/__init__.py
@@ -1,0 +1,4 @@
+"""Alert dispatch for sync failures."""
+from drt.alerts.dispatcher import build_context, dispatch_alerts
+
+__all__ = ["dispatch_alerts", "build_context"]

--- a/drt/alerts/dispatcher.py
+++ b/drt/alerts/dispatcher.py
@@ -1,0 +1,58 @@
+"""Routes AlertItems to per-type senders. Best-effort: never raises."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from drt.alerts.slack import send_slack_alert
+from drt.alerts.webhook import send_webhook_alert
+from drt.config.models import (
+    AlertsConfig,
+    SlackAlertConfig,
+    WebhookAlertConfig,
+)
+from drt.destinations.base import SyncResult
+
+logger = logging.getLogger(__name__)
+
+
+def build_context(
+    sync_name: str,
+    result: SyncResult,
+    duration_s: float,
+    started_at: str,
+    exception: BaseException | None = None,
+) -> dict[str, Any]:
+    if exception is not None:
+        error = f"{type(exception).__name__}: {exception}"
+    elif result.errors:
+        error = result.errors[0]
+    else:
+        error = "<no error message>"
+    return {
+        "sync_name": sync_name,
+        "error": error,
+        "rows_processed": result.success + result.failed,
+        "duration_s": duration_s,
+        "started_at": started_at,
+    }
+
+
+def dispatch_alerts(
+    alerts: AlertsConfig | None,
+    event: str,
+    context: dict[str, Any],
+) -> None:
+    if alerts is None:
+        return
+    targets = getattr(alerts, event, []) or []
+    for target in targets:
+        try:
+            if isinstance(target, SlackAlertConfig):
+                send_slack_alert(target, context)
+            elif isinstance(target, WebhookAlertConfig):
+                send_webhook_alert(target, context)
+            else:
+                logger.warning("Unknown alert type: %r", type(target).__name__)
+        except Exception as exc:  # noqa: BLE001  — dispatch is best-effort
+            logger.warning("Alert dispatch failed (%s): %s", type(target).__name__, exc)

--- a/drt/alerts/slack.py
+++ b/drt/alerts/slack.py
@@ -1,0 +1,36 @@
+"""Slack incoming-webhook alert sender."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.request
+from typing import Any
+
+from drt.config.models import SlackAlertConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_url(cfg: SlackAlertConfig) -> str | None:
+    if cfg.webhook_url:
+        return cfg.webhook_url
+    if cfg.webhook_url_env:
+        return os.environ.get(cfg.webhook_url_env)
+    return None
+
+
+def send_slack_alert(cfg: SlackAlertConfig, context: dict[str, Any]) -> None:
+    url = _resolve_url(cfg)
+    if not url:
+        logger.warning("Slack alert: no webhook_url resolved; skipping")
+        return
+    text = cfg.message.format(**context)
+    payload = json.dumps({"text": text}).encode()
+    req = urllib.request.Request(
+        url, data=payload, headers={"Content-Type": "application/json"}
+    )
+    try:
+        urllib.request.urlopen(req, timeout=10).close()
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.warning("Slack alert send failed: %s", exc)

--- a/drt/alerts/webhook.py
+++ b/drt/alerts/webhook.py
@@ -1,0 +1,38 @@
+"""Generic HTTP webhook alert sender."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.request
+from typing import Any
+
+from drt.config.models import WebhookAlertConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_url(cfg: WebhookAlertConfig) -> str | None:
+    if cfg.url:
+        return cfg.url
+    if cfg.url_env:
+        return os.environ.get(cfg.url_env)
+    return None
+
+
+def send_webhook_alert(cfg: WebhookAlertConfig, context: dict[str, Any]) -> None:
+    url = _resolve_url(cfg)
+    if not url:
+        logger.warning("Webhook alert: no url resolved; skipping")
+        return
+    if cfg.body_template:
+        body = cfg.body_template.format(**context).encode()
+    else:
+        body = json.dumps(context, default=str).encode()
+    headers = dict(cfg.headers)
+    headers.setdefault("Content-Type", "application/json")
+    req = urllib.request.Request(url, data=body, headers=headers, method=cfg.method)
+    try:
+        urllib.request.urlopen(req, timeout=10).close()
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.warning("Webhook alert send failed: %s", exc)

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -674,6 +674,44 @@ class SyncTest(BaseModel):
         return self
 
 
+class SlackAlertConfig(BaseModel):
+    type: Literal["slack"]
+    webhook_url: str | None = None
+    webhook_url_env: str | None = None
+    message: str = "drt sync `{sync_name}` failed: {error}"
+
+    @model_validator(mode="after")
+    def _check_url(self) -> "SlackAlertConfig":
+        if not self.webhook_url and not self.webhook_url_env:
+            raise ValueError("Either webhook_url or webhook_url_env is required.")
+        return self
+
+
+class WebhookAlertConfig(BaseModel):
+    type: Literal["webhook"]
+    url: str | None = None
+    url_env: str | None = None
+    method: Literal["POST", "PUT"] = "POST"
+    headers: dict[str, str] = Field(default_factory=dict)
+    body_template: str | None = None  # JSON template; None → default JSON payload
+
+    @model_validator(mode="after")
+    def _check_url(self) -> "WebhookAlertConfig":
+        if not self.url and not self.url_env:
+            raise ValueError("Either url or url_env is required.")
+        return self
+
+
+AlertItem = Annotated[
+    SlackAlertConfig | WebhookAlertConfig,
+    Field(discriminator="type"),
+]
+
+
+class AlertsConfig(BaseModel):
+    on_failure: list[AlertItem] = Field(default_factory=list)
+
+
 class SyncConfig(BaseModel):
     name: str
     description: str = ""
@@ -682,3 +720,4 @@ class SyncConfig(BaseModel):
     destination: DestinationConfig
     sync: SyncOptions = Field(default_factory=SyncOptions)
     tests: list[SyncTest] = Field(default_factory=list)
+    alerts: AlertsConfig | None = None

--- a/drt/engine/sync.py
+++ b/drt/engine/sync.py
@@ -73,7 +73,65 @@ def run_sync(
     """
     started_at = datetime.now(timezone.utc).isoformat()
     t0 = time.perf_counter()
+    total_result = SyncResult()
+    raised: BaseException | None = None
 
+    try:
+        return _run_sync_body(
+            sync=sync,
+            source=source,
+            destination=destination,
+            profile=profile,
+            project_dir=project_dir,
+            dry_run=dry_run,
+            state_manager=state_manager,
+            watermark_storage=watermark_storage,
+            cursor_value_override=cursor_value_override,
+            started_at=started_at,
+            t0=t0,
+            total_result=total_result,
+        )
+    except BaseException as exc:
+        raised = exc
+        raise
+    finally:
+        if not dry_run and (raised is not None or total_result.failed > 0):
+            try:
+                from drt.alerts import build_context, dispatch_alerts
+
+                dispatch_alerts(
+                    sync.alerts,
+                    "on_failure",
+                    build_context(
+                        sync_name=sync.name,
+                        result=total_result,
+                        duration_s=round(time.perf_counter() - t0, 3),
+                        started_at=started_at,
+                        exception=raised,
+                    ),
+                )
+            except Exception as exc:  # noqa: BLE001 — best-effort
+                logger.warning("Alert dispatch outer failure: %s", exc)
+
+
+def _run_sync_body(
+    *,
+    sync: SyncConfig,
+    source: Source,
+    destination: Destination | StagedDestination,
+    profile: ProfileConfig,
+    project_dir: Path,
+    dry_run: bool,
+    state_manager: StateManager | None,
+    watermark_storage: WatermarkStorage | None,
+    cursor_value_override: str | None,
+    started_at: str,
+    t0: float,
+    total_result: SyncResult,
+) -> SyncResult:
+    """Inner body of run_sync. Mutates `total_result` in place so the outer
+    finally-block can read partial results when an exception propagates.
+    """
     # Load last cursor value for incremental syncs (fallback chain)
     cursor_field = sync.sync.cursor_field if sync.sync.mode == "incremental" else None
     last_cursor_value: str | None = None
@@ -122,7 +180,6 @@ def run_sync(
     query = resolve_model_ref(sync.model, project_dir, profile, cursor_field, last_cursor_value)
 
     records_iter = source.extract(query, profile)
-    total_result = SyncResult()
     new_cursor_value: str | None = last_cursor_value
     is_staged = isinstance(destination, StagedDestination)
     staged_count = 0

--- a/tests/unit/test_alerts.py
+++ b/tests/unit/test_alerts.py
@@ -1,0 +1,117 @@
+"""Unit tests for alert dispatch. Uses pytest-httpserver for webhook targets."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from drt.alerts.dispatcher import build_context, dispatch_alerts
+from drt.config.models import AlertsConfig, SlackAlertConfig, WebhookAlertConfig
+from drt.destinations.base import SyncResult
+
+
+class TestBuildContext:
+    def test_context_has_required_fields(self) -> None:
+        result = SyncResult(success=10, failed=2)
+        result.errors = ["BigQuery 403: Permission denied"]
+        ctx = build_context(
+            sync_name="my_sync",
+            result=result,
+            duration_s=12.34,
+            started_at="2026-04-29T10:00:00",
+        )
+        assert ctx["sync_name"] == "my_sync"
+        assert ctx["error"] == "BigQuery 403: Permission denied"
+        assert ctx["rows_processed"] == 12  # success + failed
+        assert ctx["duration_s"] == 12.34
+        assert ctx["started_at"] == "2026-04-29T10:00:00"
+
+    def test_context_with_no_errors_uses_placeholder(self) -> None:
+        result = SyncResult(success=0, failed=5)  # failed but no error message
+        ctx = build_context(sync_name="s", result=result, duration_s=1.0, started_at="t")
+        assert ctx["error"] == "<no error message>"
+
+    def test_context_from_exception(self) -> None:
+        result = SyncResult(success=0, failed=0)
+        ctx = build_context(
+            sync_name="s",
+            result=result,
+            duration_s=1.0,
+            started_at="t",
+            exception=RuntimeError("connection refused"),
+        )
+        assert "connection refused" in ctx["error"]
+
+
+class TestSlackSender:
+    @patch("urllib.request.urlopen")
+    def test_slack_posts_formatted_message(self, mock_urlopen: MagicMock) -> None:
+        from drt.alerts.slack import send_slack_alert
+        cfg = SlackAlertConfig(
+            type="slack",
+            webhook_url="https://hooks.slack.com/services/T/B/C",
+            message="sync {sync_name} failed: {error}",
+        )
+        send_slack_alert(cfg, {"sync_name": "x", "error": "boom"})
+        mock_urlopen.assert_called_once()
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "https://hooks.slack.com/services/T/B/C"
+        body = req.data.decode()
+        assert "sync x failed: boom" in body
+
+    @patch("urllib.request.urlopen", side_effect=OSError("network down"))
+    def test_slack_failure_does_not_raise(self, mock_urlopen: MagicMock) -> None:
+        from drt.alerts.slack import send_slack_alert
+        cfg = SlackAlertConfig(type="slack", webhook_url="https://x")
+        # Must not raise — alert dispatch is best-effort
+        send_slack_alert(cfg, {"sync_name": "x", "error": "y"})
+
+
+class TestWebhookSender:
+    @patch("urllib.request.urlopen")
+    def test_webhook_posts_default_json_body(self, mock_urlopen: MagicMock) -> None:
+        from drt.alerts.webhook import send_webhook_alert
+        cfg = WebhookAlertConfig(type="webhook", url="https://example.com/hook")
+        send_webhook_alert(cfg, {"sync_name": "x", "error": "y", "rows_processed": 5})
+        req = mock_urlopen.call_args[0][0]
+        import json
+        payload = json.loads(req.data.decode())
+        assert payload["sync_name"] == "x"
+        assert payload["rows_processed"] == 5
+
+    @patch("urllib.request.urlopen")
+    def test_webhook_uses_custom_body_template(self, mock_urlopen: MagicMock) -> None:
+        from drt.alerts.webhook import send_webhook_alert
+        cfg = WebhookAlertConfig(
+            type="webhook",
+            url="https://example.com/hook",
+            body_template='{{"text":"{sync_name} broke"}}',
+        )
+        send_webhook_alert(cfg, {"sync_name": "x", "error": "y"})
+        req = mock_urlopen.call_args[0][0]
+        assert b'"text":"x broke"' in req.data
+
+
+class TestDispatcher:
+    @patch("drt.alerts.dispatcher.send_slack_alert")
+    @patch("drt.alerts.dispatcher.send_webhook_alert")
+    def test_dispatch_routes_by_type(
+        self, mock_webhook: MagicMock, mock_slack: MagicMock
+    ) -> None:
+        cfg = AlertsConfig(on_failure=[
+            {"type": "slack", "webhook_url": "https://x"},
+            {"type": "webhook", "url": "https://y"},
+        ])
+        dispatch_alerts(cfg, "on_failure", context={"sync_name": "s", "error": "e"})
+        mock_slack.assert_called_once()
+        mock_webhook.assert_called_once()
+
+    @patch("drt.alerts.dispatcher.send_slack_alert", side_effect=RuntimeError)
+    @patch("drt.alerts.dispatcher.send_webhook_alert")
+    def test_dispatch_continues_after_one_sender_fails(
+        self, mock_webhook: MagicMock, mock_slack: MagicMock
+    ) -> None:
+        cfg = AlertsConfig(on_failure=[
+            {"type": "slack", "webhook_url": "https://x"},
+            {"type": "webhook", "url": "https://y"},
+        ])
+        dispatch_alerts(cfg, "on_failure", context={"sync_name": "s", "error": "e"})
+        mock_webhook.assert_called_once()  # second sender still ran

--- a/tests/unit/test_alerts.py
+++ b/tests/unit/test_alerts.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from drt.alerts.dispatcher import build_context, dispatch_alerts
 from drt.config.models import AlertsConfig, SlackAlertConfig, WebhookAlertConfig
 from drt.destinations.base import SyncResult
@@ -64,6 +66,27 @@ class TestSlackSender:
         # Must not raise — alert dispatch is best-effort
         send_slack_alert(cfg, {"sync_name": "x", "error": "y"})
 
+    @patch("urllib.request.urlopen")
+    def test_slack_resolves_url_from_env(
+        self, mock_urlopen: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from drt.alerts.slack import send_slack_alert
+        monkeypatch.setenv("SLACK_HOOK_URL", "https://env.example/hook")
+        cfg = SlackAlertConfig(type="slack", webhook_url_env="SLACK_HOOK_URL")
+        send_slack_alert(cfg, {"sync_name": "x", "error": "y"})
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "https://env.example/hook"
+
+    @patch("urllib.request.urlopen")
+    def test_slack_skips_when_env_unset(
+        self, mock_urlopen: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from drt.alerts.slack import send_slack_alert
+        monkeypatch.delenv("SLACK_HOOK_UNSET", raising=False)
+        cfg = SlackAlertConfig(type="slack", webhook_url_env="SLACK_HOOK_UNSET")
+        send_slack_alert(cfg, {"sync_name": "x", "error": "y"})
+        mock_urlopen.assert_not_called()
+
 
 class TestWebhookSender:
     @patch("urllib.request.urlopen")
@@ -88,6 +111,34 @@ class TestWebhookSender:
         send_webhook_alert(cfg, {"sync_name": "x", "error": "y"})
         req = mock_urlopen.call_args[0][0]
         assert b'"text":"x broke"' in req.data
+
+    @patch("urllib.request.urlopen")
+    def test_webhook_resolves_url_from_env(
+        self, mock_urlopen: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from drt.alerts.webhook import send_webhook_alert
+        monkeypatch.setenv("WEBHOOK_URL", "https://env.example/hook")
+        cfg = WebhookAlertConfig(type="webhook", url_env="WEBHOOK_URL")
+        send_webhook_alert(cfg, {"sync_name": "x", "error": "y"})
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "https://env.example/hook"
+
+    @patch("urllib.request.urlopen")
+    def test_webhook_skips_when_url_unresolved(
+        self, mock_urlopen: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from drt.alerts.webhook import send_webhook_alert
+        monkeypatch.delenv("WEBHOOK_URL_UNSET", raising=False)
+        cfg = WebhookAlertConfig(type="webhook", url_env="WEBHOOK_URL_UNSET")
+        send_webhook_alert(cfg, {"sync_name": "x", "error": "y"})
+        mock_urlopen.assert_not_called()
+
+    @patch("urllib.request.urlopen", side_effect=OSError("network down"))
+    def test_webhook_failure_does_not_raise(self, mock_urlopen: MagicMock) -> None:
+        from drt.alerts.webhook import send_webhook_alert
+        cfg = WebhookAlertConfig(type="webhook", url="https://x")
+        # Must not raise — alert dispatch is best-effort
+        send_webhook_alert(cfg, {"sync_name": "x", "error": "y"})
 
 
 class TestDispatcher:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pydantic import ValidationError
 
 from drt.config.credentials import BigQueryProfile, load_profile, save_profile
 from drt.config.models import (
@@ -595,3 +596,46 @@ def test_sync_config_without_tests() -> None:
     }
     sync = SyncConfig.model_validate(data)
     assert sync.tests == []
+
+
+# ---------------------------------------------------------------------------
+# Alerts config (sync failure alerts — #414)
+# ---------------------------------------------------------------------------
+
+
+class TestAlertsConfig:
+    def test_default_alerts_is_none(self) -> None:
+        sync = SyncConfig(
+            name="t", model="select 1",
+            destination=RestApiDestinationConfig(type="rest_api", url="https://x"),
+        )
+        assert sync.alerts is None
+
+    def test_slack_alert_parsed_via_discriminator(self) -> None:
+        from drt.config.models import AlertsConfig, SlackAlertConfig
+        cfg = AlertsConfig(on_failure=[
+            {"type": "slack", "webhook_url": "https://hooks.slack.com/x"}
+        ])
+        assert isinstance(cfg.on_failure[0], SlackAlertConfig)
+
+    def test_webhook_alert_parsed_via_discriminator(self) -> None:
+        from drt.config.models import AlertsConfig, WebhookAlertConfig
+        cfg = AlertsConfig(on_failure=[
+            {"type": "webhook", "url": "https://example.com/hook"}
+        ])
+        assert isinstance(cfg.on_failure[0], WebhookAlertConfig)
+
+    def test_unknown_alert_type_rejected(self) -> None:
+        from drt.config.models import AlertsConfig
+        with pytest.raises(ValidationError):
+            AlertsConfig(on_failure=[{"type": "pagerduty", "key": "x"}])
+
+    def test_slack_requires_webhook_url_or_env(self) -> None:
+        from drt.config.models import SlackAlertConfig
+        with pytest.raises(ValueError, match="webhook_url"):
+            SlackAlertConfig(type="slack")
+
+    def test_webhook_requires_url_or_env(self) -> None:
+        from drt.config.models import WebhookAlertConfig
+        with pytest.raises(ValueError, match="url"):
+            WebhookAlertConfig(type="webhook")

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -612,3 +612,117 @@ def test_auto_injection_first_run_no_error(tmp_path: Path) -> None:
 
     assert result.success == 1
     assert result.watermark_source is None
+
+
+# ---------------------------------------------------------------------------
+# Alert dispatch integration
+# ---------------------------------------------------------------------------
+
+
+class _AlertingDestination:
+    """Destination that returns a configurable SyncResult or raises."""
+
+    def __init__(
+        self,
+        result: SyncResult | None = None,
+        raise_exc: BaseException | None = None,
+    ) -> None:
+        self._result = result
+        self._raise = raise_exc
+
+    def load(
+        self,
+        records: list[dict],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        if self._raise is not None:
+            raise self._raise
+        assert self._result is not None
+        return self._result
+
+
+def _make_sync_with_alerts() -> SyncConfig:
+    return SyncConfig.model_validate(
+        {
+            "name": "alerting_sync",
+            "model": "ref('table')",
+            "destination": {"type": "rest_api", "url": "https://example.com"},
+            "sync": {"batch_size": 10, "on_error": "skip"},
+            "alerts": {
+                "on_failure": [
+                    {"type": "slack", "webhook_url": "https://hooks.example/x"}
+                ]
+            },
+        }
+    )
+
+
+class TestEngineAlertDispatch:
+    @patch("drt.alerts.dispatch_alerts")
+    def test_alerts_fired_when_failed_count_positive(
+        self, mock_dispatch: MagicMock, tmp_path: Path
+    ) -> None:
+        rows = [{"id": i} for i in range(3)]
+        source = FakeSource(rows)
+        result = SyncResult()
+        result.success = 1
+        result.failed = 2
+        result.errors = ["downstream 500"]
+        dest = _AlertingDestination(result=result)
+        sync = _make_sync_with_alerts()
+
+        run_sync(sync, source, dest, _make_profile(), tmp_path)
+
+        assert mock_dispatch.called
+        args, kwargs = mock_dispatch.call_args
+        # Signature: dispatch_alerts(alerts, event, context)
+        event = args[1] if len(args) > 1 else kwargs.get("event")
+        assert event == "on_failure"
+
+    @patch("drt.alerts.dispatch_alerts")
+    def test_alerts_fired_on_exception_then_reraised(
+        self, mock_dispatch: MagicMock, tmp_path: Path
+    ) -> None:
+        rows = [{"id": 1}]
+        source = FakeSource(rows)
+        dest = _AlertingDestination(raise_exc=RuntimeError("boom"))
+        sync = _make_sync_with_alerts()
+
+        with pytest.raises(RuntimeError, match="boom"):
+            run_sync(sync, source, dest, _make_profile(), tmp_path)
+
+        assert mock_dispatch.called
+        args, kwargs = mock_dispatch.call_args
+        event = args[1] if len(args) > 1 else kwargs.get("event")
+        assert event == "on_failure"
+
+    @patch("drt.alerts.dispatch_alerts")
+    def test_alerts_not_fired_on_success(
+        self, mock_dispatch: MagicMock, tmp_path: Path
+    ) -> None:
+        rows = [{"id": i} for i in range(10)]
+        source = FakeSource(rows)
+        result = SyncResult()
+        result.success = 10
+        result.failed = 0
+        dest = _AlertingDestination(result=result)
+        sync = _make_sync_with_alerts()
+
+        run_sync(sync, source, dest, _make_profile(), tmp_path)
+
+        assert not mock_dispatch.called
+
+    @patch("drt.alerts.dispatch_alerts")
+    def test_alerts_not_fired_on_dry_run(
+        self, mock_dispatch: MagicMock, tmp_path: Path
+    ) -> None:
+        rows = [{"id": i} for i in range(3)]
+        source = FakeSource(rows)
+        # Result irrelevant — dry_run skips destination entirely.
+        dest = _AlertingDestination(result=SyncResult())
+        sync = _make_sync_with_alerts()
+
+        run_sync(sync, source, dest, _make_profile(), tmp_path, dry_run=True)
+
+        assert not mock_dispatch.called


### PR DESCRIPTION
## Summary

Implements `alerts.on_failure` for sync YAML, closing #414.

- New `alerts.on_failure: list[AlertItem]` block on `SyncConfig`. Discriminated union over `type: slack | webhook`.
- Two target types in v0.7:
  - **`slack`** — Slack incoming webhook with templated `message`.
  - **`webhook`** — generic HTTP `POST`/`PUT` with optional `body_template` and `headers`.
- New module `drt/alerts/` (dispatcher + Slack sender + webhook sender). Senders use stdlib `urllib.request` — no new dependencies.
- Engine integration: `run_sync()` is wrapped in `try/finally`. Alerts fire when either `total_result.failed > 0` after the body completes OR when an exception is raised — and in the exception case the original error still propagates to the caller after dispatch.

## Best-effort guarantee

Alert dispatch is **best-effort**:
- Per-target failures are caught and logged at WARNING; the dispatcher continues with remaining targets.
- A second outer try/except in the engine ensures the dispatcher itself never affects sync correctness or overrides the original exception.
- Dry-run invocations skip dispatch entirely.

## Out of scope

- On-success notifications (only `on_failure` for v0.7).
- `drt test` validator failure alerts.
- PagerDuty / OpsGenie integration (covered by generic webhook target).
- Per-target retry / dedup.

## Architecture note

`run_sync()` was refactored to extract the existing body into a private `_run_sync_body()` helper. The outer wrapper holds `started_at`, `t0`, and the `total_result` accumulator (mutated in place by the helper) so the `finally` block can build alert context with partial counts even on mid-loop exceptions. `state_manager.save_sync()` stays inside the helper so state is persisted before alert dispatch — alerts are notification-only, state is the source of truth.

## Test plan

- [x] `make lint` — ruff + mypy clean
- [x] `make test` — 734 passed, 2 skipped (was 715 before this PR; +19 new tests)
- [x] `make check-i18n` — clean
- [x] New TDD coverage:
  - Config: `AlertsConfig` discriminated union, URL-or-env validators (6 tests)
  - Alerts module: `build_context`, Slack sender, webhook sender, dispatcher routing + per-target isolation (9 tests)
  - Engine: alert dispatch on failed>0, on raised exception (with re-raise verified), no dispatch on success, no dispatch on dry_run (4 tests)

## Governance

Per [GOVERNANCE.md](https://github.com/drt-hub/drt/blob/main/GOVERNANCE.md): **Medium change** (config schema + new module + engine integration, no Protocol break) — 1 Owner approval + 24h objection window.

Reviewer: @yodakanohoshi

Closes #414