### PR TITLE
fix(notion): respect sync_options.retry override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **PostgreSQL destination**: crash on `dict` values bound for JSONB columns — wrapped with `psycopg2.extras.Json` (#315). Contributed by @armorbreak001.
+- **Notion destination**: `sync_options.retry` override was silently ignored — Notion always used the hardcoded `_DEFAULT_RETRY` (3 attempts) regardless of user configuration. Now respects user-configured retry like every other HTTP destination (#438). Contributes to #365.
 
 ## [0.6.2] - 2026-04-20
 

--- a/drt/destinations/notion.py
+++ b/drt/destinations/notion.py
@@ -77,6 +77,7 @@ class NotionDestination:
         result = SyncResult()
         # Notion rate limit: ~3 req/s for integrations
         rate_limiter = RateLimiter(min(sync_options.rate_limit.requests_per_second, 3))
+        retry_config = sync_options.retry or _DEFAULT_RETRY
 
         with httpx.Client(timeout=30.0) as client:
             for i, record in enumerate(records):
@@ -121,7 +122,7 @@ class NotionDestination:
                     return response
 
                 try:
-                    with_retry(do_create, _DEFAULT_RETRY)
+                    with_retry(do_create, retry_config)
                     result.success += 1
                 except httpx.HTTPStatusError as e:
                     result.failed += 1

--- a/tests/unit/test_destinations.py
+++ b/tests/unit/test_destinations.py
@@ -14,6 +14,7 @@ from drt.config.models import (
     GitHubActionsDestinationConfig,
     HubSpotDestinationConfig,
     NotionDestinationConfig,
+    RetryConfig,
     SlackDestinationConfig,
     SyncOptions,
 )
@@ -345,3 +346,63 @@ class TestNotionDestination:
         monkeypatch.setattr(notion_mod, "_NOTION_API", httpserver.url_for("/v1"))
         result = NotionDestination().load([{"name": "Alice"}], config, _options())
         assert result.success == 1
+
+    def test_retry_override_honored(
+        self, httpserver: HTTPServer, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from werkzeug.wrappers import Response
+
+        monkeypatch.setenv("NOTION_TOKEN", "test-token")
+        call_count = {"n": 0}
+
+        def handler(_request):  # type: ignore[no-untyped-def]
+            call_count["n"] += 1
+            return Response("Service Unavailable", status=503)
+
+        httpserver.expect_request("/v1/pages").respond_with_handler(handler)
+        config = NotionDestinationConfig(
+            type="notion",
+            database_id="db-abc123",
+            properties_template='{"Name": {"title": [{"text": {"content": "{{ row.name }}"}}]}}',
+            auth=BearerAuth(type="bearer", token_env="NOTION_TOKEN"),
+        )
+        import drt.destinations.notion as notion_mod
+
+        monkeypatch.setattr(notion_mod, "_NOTION_API", httpserver.url_for("/v1"))
+        opts = SyncOptions(
+            retry=RetryConfig(
+                max_attempts=5,
+                initial_backoff=0.0,
+                backoff_multiplier=1.0,
+                max_backoff=0.0,
+            ),
+            on_error="skip",
+        )
+        NotionDestination().load([{"name": "Alice"}], config, opts)
+        assert call_count["n"] == 5
+
+    def test_retry_default_used_when_options_default(
+        self, httpserver: HTTPServer, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from werkzeug.wrappers import Response
+
+        monkeypatch.setenv("NOTION_TOKEN", "test-token")
+        call_count = {"n": 0}
+
+        def handler(_request):  # type: ignore[no-untyped-def]
+            call_count["n"] += 1
+            return Response("Service Unavailable", status=503)
+
+        httpserver.expect_request("/v1/pages").respond_with_handler(handler)
+        config = NotionDestinationConfig(
+            type="notion",
+            database_id="db-abc123",
+            properties_template='{"Name": {"title": [{"text": {"content": "{{ row.name }}"}}]}}',
+            auth=BearerAuth(type="bearer", token_env="NOTION_TOKEN"),
+        )
+        import drt.destinations.notion as notion_mod
+
+        monkeypatch.setattr(notion_mod, "_NOTION_API", httpserver.url_for("/v1"))
+        opts = SyncOptions(on_error="skip")
+        NotionDestination().load([{"name": "Alice"}], config, opts)
+        assert call_count["n"] == 3


### PR DESCRIPTION
## What does this PR do?

`NotionDestination` ignored user-configured `sync_options.retry` and always used the hardcoded `_DEFAULT_RETRY` (3 attempts). This PR makes Notion match the established idiom used by 9 sibling HTTP destinations (slack, discord, teams, sendgrid, linear, hubspot, google_ads, github_actions, twilio):

```python
retry_config = sync_options.retry or _DEFAULT_RETRY
with_retry(do_create, retry_config)
```

Adds 2 regression tests under `TestNotionDestination` covering:
- retry override is honored (`max_attempts=5` → 5 actual attempts)
- default `RetryConfig()` is used when `SyncOptions` is left at defaults (3 attempts)

Audited all 13 HTTP destinations — Notion was the only one with this bug.

## Related Issue

Closes #438. Refs #365 (v0.7 ROADMAP: `on_error='fail'` and retry config tests across all destinations).

## Checklist

- [x] Tests pass (`make test`) — 717 passed, 2 skipped
- [x] Linter passes (`ruff check drt tests` clean)
- [x] Updated `CHANGELOG.md`