### PR TITLE
docs: sync README.ja.md and CONTRIBUTING.ja.md after #436

### DIFF
--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-sync: base=CONTRIBUTING.md, hash=396f47a3853206889575bf0bde96e6a7b0c17e36 -->
+<!-- i18n-sync: base=CONTRIBUTING.md, hash=73436240f8a7aed9971bbd32b2aa250f4edbe796 -->
 
 [English](./CONTRIBUTING.md) | [日本語](./CONTRIBUTING.ja.md)
 
@@ -146,6 +146,34 @@ fix: handle empty batch in REST API destination
 docs: update quickstart example
 chore: bump dependencies
 ```
+
+## コントリビューターの認定
+
+[all-contributors](https://allcontributors.org/) の仕様に従って、あらゆる種類のコントリビューションを認定します。
+
+**認定の受け方:**
+
+コードを書いたり、ドキュメントを書いたり、ディスカッションを取りまとめたり、何らかの形で貢献していただいた場合、対象の Issue または PR に以下のコメントをすることでコントリビューターリストに追加できます：
+
+```
+@all-contributors please add @username for <contribution-type>
+```
+
+**コントリビューションの種類（例）:**
+
+- `code` — コード変更を含むプルリクエスト
+- `doc` — ドキュメント、ブログ記事、チュートリアル
+- `review` — コードレビューやフィードバック
+- `ideas` — 機能提案や設計ディスカッション
+- `bug` — バグ報告や issue triage
+- `test` — テストの作成・改善
+- `maintenance` — メンテナンスや DevOps
+
+33種類以上のコントリビューションタイプの一覧は [絵文字キー](https://allcontributors.org/docs/en/emoji-key) を参照してください。
+
+**bot PR について:** all-contributors bot は README のコントリビューターリストを更新するプルリクエストを自動で作成します。これらの PR は CI が通り、表示が崩れていなければ、フルレビュー無しでマージして問題ありません。名前とアバターが正しく表示されているかだけ確認してください！
+
+すべてのコントリビューターは [README のコントリビューターセクション](./README.ja.md#コントリビューター-) で all-contributors バッジ付きで表示されます。
 
 ## コネクタの追加
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-sync: base=README.md, hash=a81922aeba9795158b43afb86a38886d2259a5a2 -->
+<!-- i18n-sync: base=README.md, hash=73436240f8a7aed9971bbd32b2aa250f4edbe796 -->
 
 [English](./README.md) | [日本語](./README.ja.md)
 
@@ -21,6 +21,13 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Python](https://img.shields.io/pypi/pyversions/drt-core)](https://pypi.org/project/drt-core/)
 [![GitHub Sponsors](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/masukai)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/drt-hub/drt)
+
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
+[![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors-)
+
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 **drt** は、YAMLとCLIを使って、データウェアハウスから外部サービスへデータを同期します（宣言的に設定可能）。
 `dbt run` → `drt run`のイメージです。同じ開発体験で、データの流れが逆になります。
@@ -345,6 +352,47 @@ typo修正から新しいコネクタの追加まで、あらゆる規模のコ�
 - **始め方:** [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) — セットアップ、ワークフロー、初めてのコネクタチュートリアル
 - **取り組む issue を探す:** [Good First Issues](https://github.com/drt-hub/drt/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
 - **意思決定の仕組みを理解する:** [GOVERNANCE.ja.md](GOVERNANCE.ja.md)
+
+## コントリビューター ✨
+
+ご協力いただいた素晴らしい皆さまに感謝します（[絵文字キー](https://allcontributors.org/docs/en/emoji-key)）：
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://masukai.github.io/portfolio/"><img src="https://avatars.githubusercontent.com/u/37993351?v=4&s=100" width="100px;" alt="K.Masuda"/><br /><sub><b>K.Masuda</b></sub></a><br /><a href="https://github.com/drt-hub/drt/commits?author=masukai" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Muawiya-contact"><img src="https://avatars.githubusercontent.com/u/178013839?v=4&s=100" width="100px;" alt="Moavia Amir"/><br /><sub><b>Moavia Amir</b></sub></a><br /><a href="https://github.com/drt-hub/drt/commits?author=Muawiya-contact" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Khush-domadia"><img src="https://avatars.githubusercontent.com/u/188820207?v=4&s=100" width="100px;" alt="Khush Domadiya"/><br /><sub><b>Khush Domadiya</b></sub></a><br /><a href="https://github.com/drt-hub/drt/commits?author=Khush-domadia" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Pawansingh3889"><img src="https://avatars.githubusercontent.com/u/42340841?v=4&s=100" width="100px;" alt="Pawan Singh Kapkoti"/><br /><sub><b>Pawan Singh Kapkoti</b></sub></a><br /><a href="https://github.com/drt-hub/drt/commits?author=Pawansingh3889" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/PFCAaron12"><img src="https://avatars.githubusercontent.com/u/64714302?v=4&s=100" width="100px;" alt="PFCAaron12"/><br /><sub><b>PFCAaron12</b></sub></a><br /><a href="https://github.com/drt-hub/drt/commits?author=PFCAaron12" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/armorbreak001"><img src="https://avatars.githubusercontent.com/u/274532465?v=4&s=100" width="100px;" alt="armorbreak001"/><br /><sub><b>armorbreak001</b></sub></a><br /><a href="https://github.com/drt-hub/drt/commits?author=armorbreak001" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/pureqin"><img src="https://avatars.githubusercontent.com/u/213101547?v=4&s=100" width="100px;" alt="pureqin"/><br /><sub><b>pureqin</b></sub></a><br /><a href="https://github.com/drt-hub/drt/commits?author=pureqin" title="Code">💻</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/wahajahmed010"><img src="https://avatars.githubusercontent.com/u/57330918?v=4&s=100" width="100px;" alt="Wahaj Ahmed"/><br /><sub><b>Wahaj Ahmed</b></sub></a><br /><a href="https://github.com/drt-hub/drt/commits?author=wahajahmed010" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/cian-ps"><img src="https://avatars.githubusercontent.com/u/231972213?v=4&s=100" width="100px;" alt="cian-ps"/><br /><sub><b>cian-ps</b></sub></a><br /><a href="https://github.com/drt-hub/drt/commits?author=cian-ps" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/xtreellaDev"><img src="https://avatars.githubusercontent.com/u/238762418?v=4&s=100" width="100px;" alt="Erik Estrella"/><br /><sub><b>Erik Estrella</b></sub></a><br /><a href="https://github.com/drt-hub/drt/commits?author=xtreellaDev" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Ai-chan-0411"><img src="https://avatars.githubusercontent.com/u/275152799?v=4&s=100" width="100px;" alt="Ai (藍)"/><br /><sub><b>Ai (藍)</b></sub></a><br /><a href="https://github.com/drt-hub/drt/commits?author=Ai-chan-0411" title="Code">💻</a></td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td align="center" size="13px" colspan="7">
+        <img src="https://raw.githubusercontent.com/all-contributors/all-contributors-cli/1b8533af435da9854653492b1327a23a4dbd0a10/assets/logo-small.svg">
+          <a href="https://all-contributors.js.org/docs/en/bot/usage">Add your contributions</a>
+        </img>
+      </td>
+    </tr>
+  </tfoot>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ## 免責事項
 


### PR DESCRIPTION
## Summary

Catches up the Japanese translations that drifted after #436 (all-contributors workflow) and #407 (devcontainer playground) merged.

- **README.ja.md** — add Codespaces badge, all-contributors badge, and 「コントリビューター ✨」 section (translated intro; contributor table is bot-managed HTML so it stays shared with the English version).
- **CONTRIBUTING.ja.md** — add 「コントリビューターの認定」 section explaining the all-contributors bot workflow + contribution types.
- Refresh both `i18n-sync` marker hashes to `73436240`.

`make check-i18n` is now clean (exit 0) for both files.

## Out of scope

- GOVERNANCE.ja.md still lacks an `i18n-sync` marker (pre-existing — `SKIP`, not `STALE`). Could be addressed in a follow-up.
- Prettier-style table reformatting from #436 was not mirrored to the Japanese tables (Japanese column widths differ anyway, and content equivalence is what `check-i18n` validates).

## Test plan

- [x] `make check-i18n` — both `README.ja.md` and `CONTRIBUTING.ja.md` show `OK`
- [x] No code touched — pure docs change

## Governance

Per GOVERNANCE.md: **Trivial change** (docs-only, translation sync) — Owner self-merge OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)