### PR TITLE
docs: realign ROADMAP v0.7 / v0.8 / v0.9 to reflect actual scope

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,12 +11,19 @@ Targets are indicative, not guarantees. Scope may shift between versions — whe
 **Theme:** Reliability, observability, and correctness for real production use.
 
 **Scope:**
-- **Reliability** — retry policy in sync YAML (#277) · graceful shutdown on SIGTERM/SIGINT (#279) · sync execution history as local JSON log + `drt status --history` tail (#276, scope-reduced)
+- **Reliability** — retry policy in sync YAML (#277) · graceful shutdown on SIGTERM/SIGINT (#279) · sync execution history as local JSON log + `drt status --history` tail (#276, scope-reduced) · sync failure alerts (Slack / webhook) (#414)
 - **Correctness** — `json_columns` explicit JSON serialization (#316) · FK existence check without value resolution (#354) · zero-downtime replace via staging table swap (#338)
+- **Observability** — opt-in anonymous usage telemetry (#263, moved up from v0.8 — PR #446 in review)
 - **DX** — `drt doctor` environment diagnostics (#264) · `--quiet` flag for `drt run` (#265)
 - **Tests** — `on_error='fail'` and retry config tests across all destinations (#365)
 
-**Out of scope (→ v0.8):** Cloud destinations (Snowflake / BigQuery / Databricks / S3 / GCS / Azure), dead letter queue, opt-in telemetry, benchmark suite, Growth/README refresh items, schema-aware serialization epic.
+**Also shipped in v0.7 (originally scoped for later):**
+- **Snowflake destination** (#353, originally v0.8) — first DWH destination, ahead of the v0.8 cloud rollout
+- **Codespaces playground** (#283 → PR #407, originally v0.8 Growth)
+- **PyPI keywords / classifiers + `drt cloud push` stub** (#307 / #302 → PR #409, originally v0.8 / v0.9)
+- **all-contributors workflow** (#436) — community recognition, meta
+
+**Out of scope (→ v0.8):** Remaining cloud destinations (BigQuery / Databricks / S3 / GCS / Azure), dead letter queue, benchmark suite, remaining Growth/README refresh items, schema-aware serialization epic.
 
 **Target:** 2026-05 · **Progress:** [milestone/4](https://github.com/drt-hub/drt/milestone/4)
 
@@ -27,12 +34,12 @@ Targets are indicative, not guarantees. Scope may shift between versions — whe
 **Theme:** DWH/Lakehouse destinations + community growth push.
 
 **Scope:**
-- **Cloud destinations** — Snowflake (#164) · BigQuery (#165) · Databricks Delta Lake (#167) · S3 Parquet/CSV (#168) · GCS (#169) · Azure Blob (#170)
+- **Cloud destinations** — BigQuery (#165) · Databricks Delta Lake (#167) · S3 Parquet/CSV (#168) · GCS (#169) · Azure Blob (#170) — *Snowflake (#164) shipped early in v0.7 via PR #353*
 - **Lakehouse sources** — Delta Lake (#172) · Apache Iceberg (#173)
-- **Reliability follow-on** — dead letter queue (#278) · opt-in anonymous usage telemetry (#263)
+- **Reliability follow-on** — dead letter queue (#278) — *opt-in telemetry (#263) moved up to v0.7*
 - **Correctness epic** — schema-aware serialization via INFORMATION_SCHEMA (#317)
 - **Engine** — `sync.mode: mirror` differential delete (#340)
-- **Growth / README** — hero section redesign (#281) · Quickstart GIF/asciinema (#282) · Codespaces devcontainer (#283) · "Why OSS Reverse ETL" blog (#284) · production use case blog (#285) · Discord (#378) · X account link (#379) · PyPI keywords (#307) · Awesome lists (#290) · Reddit/HN launch (#289)
+- **Growth / README** — hero section redesign (#281) · Quickstart GIF/asciinema (#282) · "Why OSS Reverse ETL" blog (#284) · production use case blog (#285) · Discord (#378) · X account link (#379) · Awesome lists (#290) · Reddit/HN launch (#289) — *Codespaces devcontainer (#283) and PyPI keywords (#307) shipped early in v0.7*
 - **Ecosystem** — GitHub Action (#292) · VS Code extension (#293)
 - **Dev tooling** — FakeSource (#364) · `drt_run_test` MCP tool (#368) · `/drt-troubleshoot` skill (#369) · `/drt-changelog` repo skill (#372) · connection test in `drt validate` (#367)
 
@@ -48,7 +55,7 @@ Targets are indicative, not guarantees. Scope may shift between versions — whe
 
 **Scope:**
 - **Interfaces** — RBAC interface spec (#298) · audit log hooks (#299) · plugin system for third-party connectors (#297)
-- **Protocol stability** — review and freeze preparation (#300) · config encryption for secrets at rest (#303) · `drt cloud push` stub (#302)
+- **Protocol stability** — review and freeze preparation (#300) · config encryption for secrets at rest (#303) — *`drt cloud push` stub (#302) shipped early in v0.7 via PR #409*
 - **Performance** — benchmark suite (#280) + I/O vs CPU profiling for Rust migration decision (#301)
 
 **Out of scope:** Implementing RBAC/audit log in OSS, actual Cloud service backend, Rust migration itself.


### PR DESCRIPTION
Pure docs change — keeps [ROADMAP.md](ROADMAP.md) honest as we close in on v0.7 release. No code paths affected, no review urgency.

## What changed

### v0.7 — Production Ready
- **Reliability** — added `sync failure alerts (Slack / webhook) (#414)` (already shipped via #437)
- **Observability** (new subsection) — `opt-in anonymous usage telemetry (#263, moved up from v0.8 — PR #446 in review)`
- **Also shipped in v0.7 (originally scoped for later)** — new subsection enumerating the items that landed early:
  - Snowflake destination (#353, originally v0.8)
  - Codespaces playground (#283 → PR #407, originally v0.8 Growth)
  - PyPI keywords / classifiers + ` + "`drt cloud push`" + ` stub (#307 / #302 → PR #409, originally v0.8 / v0.9)
  - all-contributors workflow (#436)
- **Out of scope** — removed "opt-in telemetry" (now in scope), reworded cloud destinations line as "remaining cloud destinations" since Snowflake slipped forward

### v0.8 — Cloud Destinations & Growth
Items that shipped in v0.7 are annotated with italic notes (kept in place rather than silently dropped — easier to scan history):
- Cloud destinations: ` + "`*Snowflake (#164) shipped early in v0.7 via PR #353*`" + `
- Reliability follow-on: ` + "`*opt-in telemetry (#263) moved up to v0.7*`" + `
- Growth / README: ` + "`*Codespaces devcontainer (#283) and PyPI keywords (#307) shipped early in v0.7*`" + `

### v0.9 — Enterprise Foundation
- Protocol stability: ` + "`*\\`drt cloud push\\` stub (#302) shipped early in v0.7 via PR #409*`" + `

## Why this is its own PR

Per the SSoT pattern in [CLAUDE.md](CLAUDE.md): *"When scope shifts, update ROADMAP.md first, then re-label issues, then update milestone desc if needed."* This PR is the first half — the issue/milestone re-labeling already happened (PR #446 milestone set to v0.7 a few days ago).

## Out of scope

- README.md / README.ja.md Roadmap sections — already pointer-only ("Next: ROADMAP.md#v07..."), no edit needed per the established SSoT structure
- GitHub milestone descriptions — already point to ROADMAP.md anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)