### PR TITLE
fix(destinations): replace_strategy=swap now honors json_columns (#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **PostgreSQL destination**: crash on `dict` values bound for JSONB columns — wrapped with `psycopg2.extras.Json` (#315). Contributed by @armorbreak001.
 - **Notion destination**: `sync_options.retry` override was silently ignored — Notion always used the hardcoded `_DEFAULT_RETRY` (3 attempts) regardless of user configuration. Now respects user-configured retry like every other HTTP destination (#438). Contributes to #365.
+- **`replace_strategy: swap` ignored `json_columns` config** (#448): When both `replace_strategy: swap` (#338) and `json_columns` (#316) were configured on a Postgres or MySQL destination, swap mode silently bypassed the explicit JSON column declarations because `_load_replace_swap` did not thread `config.json_columns` through to `_serialize_value`. Now both strategies honour the config consistently — swap-mode dict values in unlisted columns raise the same fail-fast `ValueError` as truncate mode. ClickHouse is unaffected (its connector handles JSON encoding driver-side and has no `json_columns` config). Discovered post-rebase of #435 onto #382 — neither feature was wrong in isolation; the gap was an interaction artifact of parallel development.
 
 ## [0.6.2] - 2026-04-20
 

--- a/drt/destinations/mysql.py
+++ b/drt/destinations/mysql.py
@@ -95,6 +95,7 @@ class MySQLDestination:
                         columns,
                         config.table,
                         sync_options,
+                        config,
                     )
                 else:
                     result = self._load_replace(
@@ -211,6 +212,7 @@ class MySQLDestination:
         columns: list[str],
         table: str,
         sync_options: SyncOptions,
+        config: MySQLDestinationConfig,
     ) -> SyncResult:
         """Build a shadow table per sync; atomic rename happens in finalize_sync."""
         result = SyncResult()
@@ -230,7 +232,7 @@ class MySQLDestination:
 
         for i, record in enumerate(records):
             try:
-                values = [_serialize_value(record.get(c)) for c in columns]
+                values = [_serialize_value(record.get(c), c, config.json_columns) for c in columns]
                 cur.execute(sql, values)
                 result.success += 1
             except Exception as e:

--- a/drt/destinations/postgres.py
+++ b/drt/destinations/postgres.py
@@ -121,6 +121,7 @@ class PostgresDestination:
                         columns,
                         config.table,
                         sync_options,
+                        config,
                     )
                 else:
                     result = self._load_replace(
@@ -228,6 +229,7 @@ class PostgresDestination:
         columns: list[str],
         table: str,
         sync_options: SyncOptions,
+        config: PostgresDestinationConfig,
     ) -> SyncResult:
         """Build a shadow table per sync; atomic rename happens in finalize_sync."""
         result = SyncResult()
@@ -243,7 +245,7 @@ class PostgresDestination:
 
         for i, record in enumerate(records):
             try:
-                values = [_serialize_value(record.get(c)) for c in columns]
+                values = [_serialize_value(record.get(c), c, config.json_columns) for c in columns]
                 cur.execute(sql, values)
                 result.success += 1
             except Exception as e:

--- a/tests/unit/test_mysql_destination.py
+++ b/tests/unit/test_mysql_destination.py
@@ -487,3 +487,72 @@ class TestMySQLReplaceSwap:
         assert finalize_result is None
         sqls_after = [c[0][0] for c in cur.execute.call_args_list]
         assert not any("RENAME TABLE" in s for s in sqls_after)
+
+
+# ---------------------------------------------------------------------------
+# Replace mode — swap strategy + json_columns interaction (#448)
+# ---------------------------------------------------------------------------
+
+
+class TestMySQLReplaceSwapJsonColumns:
+    """Swap mode must honor json_columns the same way truncate mode does.
+
+    Discovered post-rebase of #435 onto #382 — the two features were
+    developed in parallel and _load_replace_swap was missing the
+    json_columns plumbing that _load_replace already had.
+    """
+
+    @patch("drt.destinations.mysql.MySQLDestination._connect")
+    def test_swap_serializes_dict_in_listed_json_column(
+        self, mock_connect: MagicMock
+    ) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        records = [
+            {
+                "user_id": 1,
+                "company_id": 5,
+                "score": 0.9,
+                "profile": {"lang": "ja"},
+            }
+        ]
+        config = _config(json_columns=["profile"])
+
+        MySQLDestination().load(
+            records, config, _options(mode="replace", replace_strategy="swap"),
+        )
+
+        insert_calls = [
+            c for c in cur.execute.call_args_list
+            if "INSERT INTO" in c[0][0] and "__drt_swap" in c[0][0]
+        ]
+        assert insert_calls, "expected at least one INSERT into shadow table"
+        bound_values = insert_calls[0][0][1]
+        # dict value must be JSON-serialized to a string
+        assert '{"lang": "ja"}' in bound_values
+
+    @patch("drt.destinations.mysql.MySQLDestination._connect")
+    def test_swap_rejects_dict_in_unlisted_column(
+        self, mock_connect: MagicMock
+    ) -> None:
+        conn = _fake_connection()
+        mock_connect.return_value = conn
+
+        records = [
+            {
+                "user_id": 1,
+                "company_id": 5,
+                "score": 0.5,
+                "extra": {"unexpected": "dict"},
+            }
+        ]
+        config = _config(json_columns=["profile"])  # 'extra' not listed
+
+        result = MySQLDestination().load(
+            records, config, _options(mode="replace", replace_strategy="swap"),
+        )
+
+        assert result.failed == 1
+        assert "not listed in json_columns" in result.row_errors[0].error_message

--- a/tests/unit/test_postgres_destination.py
+++ b/tests/unit/test_postgres_destination.py
@@ -470,3 +470,65 @@ class TestPostgresReplaceSwap:
         assert finalize_result is None
         sqls_after = [c[0][0] for c in cur.execute.call_args_list]
         assert not any("RENAME TO" in s for s in sqls_after)
+
+
+# ---------------------------------------------------------------------------
+# Replace mode — swap strategy + json_columns interaction (#448)
+# ---------------------------------------------------------------------------
+
+
+class TestPostgresReplaceSwapJsonColumns:
+    """Swap mode must honor json_columns the same way truncate mode does.
+
+    Discovered post-rebase of #435 onto #382 — the two features were
+    developed in parallel and _load_replace_swap was missing the
+    json_columns plumbing that _load_replace already had.
+    """
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_swap_wraps_dict_value_in_listed_json_column(
+        self, mock_connect: MagicMock
+    ) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        records = [{"id": 1, "profile": {"lang": "ja"}}]
+        config = _config(json_columns=["profile"])
+
+        PostgresDestination().load(
+            records, config, _options(mode="replace", replace_strategy="swap")
+        )
+
+        # Find the INSERT call against the shadow table
+        insert_calls = [
+            c for c in cur.execute.call_args_list
+            if "INSERT INTO" in c[0][0] and "__drt_swap" in c[0][0]
+        ]
+        assert insert_calls, "expected at least one INSERT into shadow table"
+        bound_values = insert_calls[0][0][1]
+        # dict value must be wrapped (Json or fallback string), not pass-through
+        try:
+            from psycopg2.extras import Json
+            assert isinstance(bound_values[1], Json)
+        except ImportError:
+            assert isinstance(bound_values[1], str)
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_swap_rejects_dict_in_unlisted_column(
+        self, mock_connect: MagicMock
+    ) -> None:
+        """Swap must surface the same fail-fast ValueError as truncate when
+        a dict value lands in a column not declared in json_columns."""
+        conn = _fake_connection()
+        mock_connect.return_value = conn
+
+        records = [{"id": 1, "extra": {"unexpected": "dict"}}]
+        config = _config(json_columns=["profile"])  # 'extra' not listed
+
+        result = PostgresDestination().load(
+            records, config, _options(mode="replace", replace_strategy="swap"),
+        )
+
+        assert result.failed == 1
+        assert "not listed in json_columns" in result.row_errors[0].error_message


### PR DESCRIPTION
Closes #448

## Summary

When both `replace_strategy: swap` (#338) and `json_columns` (#316) were configured on a Postgres or MySQL destination, swap mode silently bypassed the explicit JSON column declarations because `_load_replace_swap` did not thread `config.json_columns` through to `_serialize_value`.

Both strategies now honor the config consistently:

| Mode | dict in listed col | dict in unlisted col |
|---|---|---|
| `truncate` (default) | wrapped (`Json` / JSON string) | fail-fast `ValueError` |
| `swap` (this fix) | wrapped (same) | fail-fast `ValueError` (same) |

## Issue body correction

The issue I filed listed three affected destinations including ClickHouse. Investigation showed **ClickHouse is not affected**:

- ClickHouse swap path uses `client.insert(shadow, row, column_names=columns)` — the clickhouse-connect driver handles JSON encoding driver-side
- `ClickHouseDestinationConfig` has no `json_columns` field (the JSON-columns config only exists on Postgres + MySQL)

So this PR touches **2 destinations** (postgres + mysql), not 3.

## Diff shape

For each of postgres + mysql:

- `_load_replace_swap` signature gains `config: <Postgres|MySQL>DestinationConfig`
- The `_serialize_value(record.get(c))` call inside the batch loop becomes `_serialize_value(record.get(c), c, config.json_columns)` — mirrors the existing `_load_replace` pattern exactly
- The `load()` dispatcher passes `config` through to swap path

## Tests

4 new tests across `TestPostgresReplaceSwapJsonColumns` and `TestMySQLReplaceSwapJsonColumns`:

- `test_swap_(wraps|serializes)_dict_value_in_listed_json_column` — positive case, dict in declared column survives
- `test_swap_rejects_dict_in_unlisted_column` — fail-fast `ValueError` matches truncate-mode behavior

This **second test was the differential** — without the fix, an unlisted dict was silently auto-wrapped via the legacy backward-compat path because `json_columns` was None. Now the strict validation fires for swap-mode too.

Full unit suite: **782 passed, 2 skipped**. ruff + mypy clean.

## Why now

This fix was deferred from #449 (review feedback): yodakanohoshi explicitly approved landing #435 first and handling #448 separately to keep that PR's review surface stable. With #435 merged this morning, the `_load_replace_swap` methods now exist on `main` and we can patch them.

## Related

- #338 / PR #435 — zero-downtime swap (introduced the gap)
- #316 / PR #382 — json_columns (the config being bypassed)
- #449 — discovered during rebase of #435 onto current main

🤖 Generated with [Claude Code](https://claude.com/claude-code)