### PR TITLE
docs: bump README/ROADMAP for v0.7.0 ship

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -275,6 +275,7 @@ Claude Codeの公式スキルをインストールすると、チャットイン
 | Email SMTP | ✅ v0.6 | (core) | ユーザー名/パスワード（環境変数） |
 | Salesforce Bulk API 2.0 | ✅ v0.6 | (core) | OAuth2（username-password） |
 | Staged Upload | ✅ v0.6 | (core) | プロバイダーごとに設定 |
+| Snowflake | ✅ v0.7 | `pip install drt-core[snowflake]` | パスワード（環境変数） |
 
 ### インテグレーション
 
@@ -304,8 +305,9 @@ Claude Codeの公式スキルをインストールすると、チャットイン
 | **v0.5** ✅ | Snowflake / MySQL sources · ClickHouse / Parquet / Teams / CSV+JSON / Jira / Linear / SendGrid destinations · `drt test` · `--output json` · `--profile` · `${VAR}` 環境変数展開 · dbt manifest · secrets.toml · Docker |
 | **v0.5.4** ✅ | `destination_lookup` — 同期中にデスティネーションDBからFK値を解決（MySQL / Postgres / ClickHouse） |
 | **v0.6** ✅ | Databricks / SQL Server sources · Notion / Twilio / Intercom / Email SMTP / Salesforce Bulk / Staged Upload destinations · Airflow / Prefect integrations · `drt serve` · `drt sources` / `drt destinations` · `--threads` 並列実行 · `--log-format json` · `--cursor-value` · `watermark.default_value` · テストバリデータ（freshness, unique, accepted_values） · JSON Schema validation · GOVERNANCE.md |
+| **v0.7** ✅ | **Production Ready** — SIGTERM/SIGINT グレースフルシャットダウン · per-destination retry override · sync 実行履歴 · zero-downtime atomic table swap · `json_columns` 設定 · FK存在チェック (`lookups.check_only`) · Slack/webhook 失敗通知 · `drt doctor` · `--quiet` フラグ · `drt test --output json` / `--dry-run` · Snowflake destination · GitHub Codespaces プレイグラウンド · `OPEN_CORE.md` |
 
-**次のリリース:** [v0.7 Production Ready](ROADMAP.md#v07--production-ready) → [v0.8 Cloud Destinations & Growth](ROADMAP.md#v08--cloud-destinations--growth) → [v0.9 Enterprise Foundation](ROADMAP.md#v09--enterprise-foundation) → [v1.0 Stable Release](ROADMAP.md#v10--stable-release) → [v1.x Rust Engine](ROADMAP.md#v1x--rust-engine)
+**次のリリース:** [v0.7.1 Production Ready Follow-up](ROADMAP.md#v071--production-ready-follow-up) → [v0.8 Cloud Destinations & Growth](ROADMAP.md#v08--cloud-destinations--growth) → [v0.9 Enterprise Foundation](ROADMAP.md#v09--enterprise-foundation) → [v1.0 Stable Release](ROADMAP.md#v10--stable-release) → [v1.x Rust Engine](ROADMAP.md#v1x--rust-engine)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 | Email SMTP              | ✅ v0.6   | (core)                             | Username / Password (env var)     |
 | Salesforce Bulk API 2.0 | ✅ v0.6   | (core)                             | OAuth2 (username-password)        |
 | Staged Upload           | ✅ v0.6   | (core)                             | Configurable per provider         |
+| Snowflake               | ✅ v0.7   | `pip install drt-core[snowflake]`  | Password (env var)                |
 
 ### Integrations
 
@@ -302,8 +303,9 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 | **v0.5** ✅   | Snowflake / MySQL sources · ClickHouse / Parquet / Teams / CSV+JSON / Jira / Linear / SendGrid destinations · `drt test` · `--output json` · `--profile` · `${VAR}` substitution · dbt manifest · secrets.toml · Docker                                                                                                                                                                                            |
 | **v0.5.4** ✅ | `destination_lookup` — resolve FK values by querying destination DB during sync (MySQL / Postgres / ClickHouse)                                                                                                                                                                                                                                                                                                    |
 | **v0.6** ✅   | Databricks / SQL Server sources · Notion / Twilio / Intercom / Email SMTP / Salesforce Bulk / Staged Upload destinations · Airflow / Prefect integrations · `drt serve` · `drt sources` / `drt destinations` · `--threads` parallel execution · `--log-format json` · `--cursor-value` · `watermark.default_value` · test validators (freshness, unique, accepted_values) · JSON Schema validation · GOVERNANCE.md |
+| **v0.7** ✅   | **Production Ready** — graceful shutdown on SIGTERM/SIGINT · per-destination retry override · sync execution history · zero-downtime atomic table swap · `json_columns` config · FK existence check (`lookups.check_only`) · Slack/webhook failure alerts · `drt doctor` · `--quiet` flag · `drt test --output json` / `--dry-run` · Snowflake destination · GitHub Codespaces playground · `OPEN_CORE.md`                                                                                                                                                                                                                                                              |
 
-**Next:** [v0.7 Production Ready](ROADMAP.md#v07--production-ready) → [v0.8 Cloud Destinations & Growth](ROADMAP.md#v08--cloud-destinations--growth) → [v0.9 Enterprise Foundation](ROADMAP.md#v09--enterprise-foundation) → [v1.0 Stable Release](ROADMAP.md#v10--stable-release) → [v1.x Rust Engine](ROADMAP.md#v1x--rust-engine)
+**Next:** [v0.7.1 Production Ready Follow-up](ROADMAP.md#v071--production-ready-follow-up) → [v0.8 Cloud Destinations & Growth](ROADMAP.md#v08--cloud-destinations--growth) → [v0.9 Enterprise Foundation](ROADMAP.md#v09--enterprise-foundation) → [v1.0 Stable Release](ROADMAP.md#v10--stable-release) → [v1.x Rust Engine](ROADMAP.md#v1x--rust-engine)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,26 +6,11 @@ Targets are indicative, not guarantees. Scope may shift between versions — whe
 
 ---
 
-## v0.7 — Production Ready
+## v0.7 — Production Ready ✅ Shipped 2026-05-06
 
-**Theme:** Reliability, observability, and correctness for real production use.
+Released as **v0.7.0** on 2026-05-06. See [CHANGELOG.md](CHANGELOG.md#070---2026-05-06) and the [GitHub Release](https://github.com/drt-hub/drt/releases/tag/v0.7.0) for the full feature list.
 
-**Scope:**
-- **Reliability** — retry policy in sync YAML (#277) · graceful shutdown on SIGTERM/SIGINT (#279) · sync execution history as local JSON log + `drt status --history` tail (#276, scope-reduced) · sync failure alerts (Slack / webhook) (#414)
-- **Correctness** — `json_columns` explicit JSON serialization (#316) · FK existence check without value resolution (#354) · zero-downtime replace via staging table swap (#338)
-- **Observability** — opt-in anonymous usage telemetry (#263, moved up from v0.8 — PR #446 in review)
-- **DX** — `drt doctor` environment diagnostics (#264) · `--quiet` flag for `drt run` (#265)
-- **Tests** — `on_error='fail'` and retry config tests across all destinations (#365)
-
-**Also shipped in v0.7 (originally scoped for later):**
-- **Snowflake destination** (#353, originally v0.8) — first DWH destination, ahead of the v0.8 cloud rollout
-- **Codespaces playground** (#283 → PR #407, originally v0.8 Growth)
-- **PyPI keywords / classifiers + `drt cloud push` stub** (#307 / #302 → PR #409, originally v0.8 / v0.9)
-- **all-contributors workflow** (#436) — community recognition, meta
-
-**Out of scope (→ v0.8):** Remaining cloud destinations (BigQuery / Databricks / S3 / GCS / Azure), dead letter queue, benchmark suite, remaining Growth/README refresh items, schema-aware serialization epic.
-
-**Target:** 2026-05 · **Progress:** [milestone/4](https://github.com/drt-hub/drt/milestone/4)
+Tail items continue in [v0.7.1](#v071--production-ready-follow-up) below.
 
 ---
 


### PR DESCRIPTION
Post-release housekeeping after v0.7.0 tag (2026-05-06).

- README.md / README.ja.md: add Snowflake destination row + v0.7 Shipped row + update Next: pointer to v0.7.1
- ROADMAP.md: v0.7 section compacted to a Shipped pointer (anchor preserved)

i18n-sync hash for README.ja.md will update in a follow-up commit after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)