### PR TITLE
docs(i18n): sync README.ja.md hash to #461 merge commit

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-sync: base=README.md, hash=73436240f8a7aed9971bbd32b2aa250f4edbe796 -->
+<!-- i18n-sync: base=README.md, hash=e3dc31e9cd69cbf671e24f01c5c1659f844eec82 -->
 
 [English](./README.md) | [日本語](./README.ja.md)
 


### PR DESCRIPTION
Standard i18n-sync followup after #461 merged. README.ja.md content was already updated in #461 — this commit only advances the hash pointer.

`make check-i18n`: OK ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)