### PR TITLE
fix(engine): normalize tz-aware cursor values to naive UTC (#475)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.0] - 2026-05-06
+### Fixed
+
+- **Watermark advance for tz-aware cursor values** (#475): `drt/engine/sync.py` was calling `str()` directly on cursor field values, which for tz-aware datetimes (e.g. BigQuery `TIMESTAMP` columns returned by the Python BQ client) produced strings with a `+00:00` suffix. When user SQL or `default_value` was written tz-naive (the common case for warehouses where the `TIMESTAMP` literal is parsed as UTC), the next run compared a naive `WHERE col >= TIMESTAMP('YYYY-MM-DD HH:MM:SS')` against the tz-aware persisted form representing the same instant. The boundary row matched again and re-fired on every subsequent run. The engine now normalizes tz-aware datetimes to naive UTC before stringifying, preserving the same instant in a form that round-trips through naive `TIMESTAMP()` literals. Other types (naive datetime, string, numeric) pass through unchanged. Reported by @K-Masuda-SL after a prod incident where a single `recording_sessions` row triggered a downstream GHA `workflow_dispatch` three times in a row at the watermark boundary.
+
+
 
 **Theme: Production Ready.** Reliability, observability, and correctness for syncs that run in production environments — graceful shutdown on SIGTERM/SIGINT, retry knobs per destination, atomic zero-downtime table replace, sync execution history, FK existence filtering, opinionated JSON column handling. Plus the first DWH destination (Snowflake), the GitHub Codespaces playground for zero-setup onboarding, and `OPEN_CORE.md` documenting the open core boundary.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Watermark advance for tz-aware cursor values** (#475): `drt/engine/sync.py` was calling `str()` directly on cursor field values, which for tz-aware datetimes (e.g. BigQuery `TIMESTAMP` columns returned by the Python BQ client) produced strings with a `+00:00` suffix. When user SQL or `default_value` was written tz-naive (the common case for warehouses where the `TIMESTAMP` literal is parsed as UTC), the next run compared a naive `WHERE col >= TIMESTAMP('YYYY-MM-DD HH:MM:SS')` against the tz-aware persisted form representing the same instant. The boundary row matched again and re-fired on every subsequent run. The engine now normalizes tz-aware datetimes to naive UTC before stringifying, preserving the same instant in a form that round-trips through naive `TIMESTAMP()` literals. Other types (naive datetime, string, numeric) pass through unchanged. Reported by @K-Masuda-SL after a prod incident where a single `recording_sessions` row triggered a downstream GHA `workflow_dispatch` three times in a row at the watermark boundary.
 
-
+## [0.7.0] - 2026-05-06
 
 **Theme: Production Ready.** Reliability, observability, and correctness for syncs that run in production environments — graceful shutdown on SIGTERM/SIGINT, retry knobs per destination, atomic zero-downtime table replace, sync execution history, FK existence filtering, opinionated JSON column handling. Plus the first DWH destination (Snowflake), the GitHub Codespaces playground for zero-setup onboarding, and `OPEN_CORE.md` documenting the open core boundary.
 

--- a/drt/engine/sync.py
+++ b/drt/engine/sync.py
@@ -36,6 +36,26 @@ def _cursor_gt(new: str, current: str) -> bool:
         return new > current
 
 
+def _stringify_cursor_value(val: Any) -> str:
+    """Convert a cursor value into a stable string representation.
+
+    For tz-aware datetimes (e.g. BigQuery TIMESTAMP returns from the
+    Python BQ client), normalize to **naive UTC** before stringifying.
+    This avoids a re-emit-at-boundary bug (#475) where the persisted
+    watermark gained a ``+00:00`` suffix while user SQL / default_value
+    is typically written tz-naive — causing the same instant to be
+    represented two different ways and ``WHERE col >= TIMESTAMP(...)``
+    to re-match the boundary row on every subsequent run.
+
+    BigQuery (and most warehouses) parse ``TIMESTAMP('YYYY-MM-DD HH:MM:SS')``
+    as UTC, so dropping the ``+00:00`` suffix preserves the same instant.
+    Other types pass through ``str()`` unchanged.
+    """
+    if isinstance(val, datetime) and val.tzinfo is not None:
+        val = val.astimezone(timezone.utc).replace(tzinfo=None)
+    return str(val)
+
+
 def batch(iterable: Iterator[Any], size: int) -> Iterator[list[Any]]:
     """Yield successive batches of `size` from an iterator."""
     chunk: list[Any] = []
@@ -258,12 +278,14 @@ def _run_sync_body(
 
         total_result.rows_extracted += len(record_batch)
 
-        # Track max cursor value seen across all batches
+        # Track max cursor value seen across all batches.
+        # Stringify with tz-naive UTC normalization for tz-aware datetimes
+        # to avoid #475 (re-emit-at-boundary when user SQL is tz-naive).
         if cursor_field:
             for row in record_batch:
                 val = row.get(cursor_field)
                 if val is not None:
-                    str_val = str(val)
+                    str_val = _stringify_cursor_value(val)
                     if new_cursor_value is None or _cursor_gt(str_val, new_cursor_value):
                         new_cursor_value = str_val
 

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -206,6 +206,116 @@ def test_incremental_saves_max_cursor(tmp_path: Path) -> None:
     assert state.last_cursor_value == "2024-01-03"
 
 
+# ---------------------------------------------------------------------------
+# Cursor value stringification (#475)
+# ---------------------------------------------------------------------------
+
+
+class TestCursorStringification:
+    """tz-aware datetimes (e.g. BigQuery TIMESTAMP) must persist as naive UTC
+    so that user SQL written tz-naive doesn't re-fire the boundary row.
+    """
+
+    def test_tz_aware_datetime_normalized_to_naive_utc(self, tmp_path: Path) -> None:
+        from datetime import datetime, timezone
+
+        from drt.state.manager import StateManager
+
+        # Simulate what BigQuery's Python client returns for a TIMESTAMP column
+        tz_aware = datetime(2026, 5, 7, 12, 24, 17, tzinfo=timezone.utc)
+        rows = [{"id": 1, "updated_at": tz_aware}]
+        source = FakeSource(rows)
+        dest = FakeDestination()
+        sync = _make_incremental_sync()
+        state_mgr = StateManager(tmp_path)
+
+        run_sync(sync, source, dest, _make_profile(), tmp_path, state_manager=state_mgr)
+
+        state = state_mgr.get_last_sync("inc_sync")
+        assert state is not None
+        # No "+00:00" suffix — the persisted form should round-trip through
+        # naive TIMESTAMP() literals in user SQL.
+        assert state.last_cursor_value is not None
+        assert "+00:00" not in state.last_cursor_value
+        assert state.last_cursor_value == "2026-05-07 12:24:17"
+
+    def test_tz_aware_non_utc_normalized_to_utc_then_naive(
+        self, tmp_path: Path
+    ) -> None:
+        """JST 21:24 → UTC 12:24 (naive) — preserves the instant."""
+        from datetime import datetime, timedelta, timezone
+
+        from drt.state.manager import StateManager
+
+        jst = timezone(timedelta(hours=9))
+        tz_aware = datetime(2026, 5, 7, 21, 24, 17, tzinfo=jst)
+        rows = [{"id": 1, "updated_at": tz_aware}]
+        source = FakeSource(rows)
+        dest = FakeDestination()
+        sync = _make_incremental_sync()
+        state_mgr = StateManager(tmp_path)
+
+        run_sync(sync, source, dest, _make_profile(), tmp_path, state_manager=state_mgr)
+
+        state = state_mgr.get_last_sync("inc_sync")
+        assert state is not None
+        assert state.last_cursor_value == "2026-05-07 12:24:17"
+
+    def test_naive_datetime_preserved_unchanged(self, tmp_path: Path) -> None:
+        """Naive datetimes were already correct — must not be touched."""
+        from datetime import datetime
+
+        from drt.state.manager import StateManager
+
+        naive = datetime(2026, 5, 7, 12, 24, 17)
+        rows = [{"id": 1, "updated_at": naive}]
+        source = FakeSource(rows)
+        dest = FakeDestination()
+        sync = _make_incremental_sync()
+        state_mgr = StateManager(tmp_path)
+
+        run_sync(sync, source, dest, _make_profile(), tmp_path, state_manager=state_mgr)
+
+        state = state_mgr.get_last_sync("inc_sync")
+        assert state is not None
+        assert state.last_cursor_value == "2026-05-07 12:24:17"
+
+    def test_string_cursor_unchanged(self, tmp_path: Path) -> None:
+        """String cursors (e.g. ISO date strings) pass through str() unchanged."""
+        from drt.state.manager import StateManager
+
+        rows = [
+            {"id": 1, "updated_at": "2026-05-07"},
+            {"id": 2, "updated_at": "2026-05-09"},
+        ]
+        source = FakeSource(rows)
+        dest = FakeDestination()
+        sync = _make_incremental_sync()
+        state_mgr = StateManager(tmp_path)
+
+        run_sync(sync, source, dest, _make_profile(), tmp_path, state_manager=state_mgr)
+
+        state = state_mgr.get_last_sync("inc_sync")
+        assert state is not None
+        assert state.last_cursor_value == "2026-05-09"
+
+    def test_numeric_cursor_unchanged(self, tmp_path: Path) -> None:
+        """Numeric cursors (epoch seconds, auto-incrementing IDs) unchanged."""
+        from drt.state.manager import StateManager
+
+        rows = [{"id": 1, "updated_at": 1746619457}]
+        source = FakeSource(rows)
+        dest = FakeDestination()
+        sync = _make_incremental_sync()
+        state_mgr = StateManager(tmp_path)
+
+        run_sync(sync, source, dest, _make_profile(), tmp_path, state_manager=state_mgr)
+
+        state = state_mgr.get_last_sync("inc_sync")
+        assert state is not None
+        assert state.last_cursor_value == "1746619457"
+
+
 def test_incremental_uses_saved_cursor(tmp_path: Path) -> None:
     from drt.state.manager import StateManager, SyncState
 


### PR DESCRIPTION
Closes #475

## Bug — production incident

Reported by @K-Masuda-SL. When the source is BigQuery and the sync's \`cursor_field\` is a TIMESTAMP column, the Python BQ client returns a tz-aware UTC datetime. The engine was calling \`str()\` directly on it, which yields \`"YYYY-MM-DD HH:MM:SS+00:00"\`.

If the user's sync YAML / \`default_value\` is tz-naive (common when the upstream column is "naive numerals stored in a UTC TIMESTAMP container"), the next run renders:

\`\`\`sql
WHERE col >= TIMESTAMP('2026-05-07 12:24:17+00:00')
\`\`\`

Both sides represent the same physical instant, so \`>=\` matches the boundary row and re-fires it on every subsequent run.

A \`recording_sessions\` row triggered a downstream GHA \`workflow_dispatch\` three times in a row at 04:10 / 05:10 / 06:10 UTC on 2026-05-07, all with identical \`session_ids\`. Discovered when the downstream workflow's idempotency check started rejecting duplicate dispatches.

## Fix

New \`_stringify_cursor_value(val)\` helper in [\`drt/engine/sync.py\`](drt/engine/sync.py):

\`\`\`python
def _stringify_cursor_value(val: Any) -> str:
    if isinstance(val, datetime) and val.tzinfo is not None:
        val = val.astimezone(timezone.utc).replace(tzinfo=None)
    return str(val)
\`\`\`

The engine's per-batch cursor-tracking loop calls \`_stringify_cursor_value(val)\` instead of \`str(val)\`.

## Why this is safe

- BigQuery and other major warehouses parse \`TIMESTAMP('YYYY-MM-DD HH:MM:SS')\` as **UTC**, so dropping the \`+00:00\` suffix preserves the same instant.
- Tz-naive setups (which were already correct) are unaffected — \`isinstance(val, datetime) and val.tzinfo is not None\` filters out everything that wasn't already broken.
- Backward compatible — the persisted form changes only for tz-aware values, which were the broken case.

## Tests

5 new tests in \`TestCursorStringification\`:

- tz-aware UTC datetime → \`"2026-05-07 12:24:17"\` (no suffix)
- tz-aware JST datetime → \`"2026-05-07 12:24:17"\` (converted to UTC, then naive)
- naive datetime → passes through unchanged
- string cursor → passes through unchanged
- numeric cursor → passes through unchanged

Full unit suite: **851 passed, 5 skipped**. ruff + mypy clean.

## Considered alternatives

| Option | Why not |
|---|---|
| Sync option \`cursor_value_format: naive_utc \| iso8601_utc \| raw_str\` | Adds a config knob users must understand; the buggy default is the one that needs fixing |
| Doc-only — instruct users to write \`+00:00\` suffix in their SQL | Discoverable only after the bug bites; doesn't fix the existing prod incidents |
| Normalize at watermark-storage layer instead of engine | Same effect; engine is a more central point and easier to test |

## v0.7.1 inclusion

Real prod incident, small surface, backward compatible. Should ship in v0.7.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)