### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,13 +37,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-05-07
+
+**Theme: Production Ready follow-up.** Tail of the v0.7 cycle — the `drt diff` dry-run preview (#413) that shipped as the original v0.7.1 DX feature, a watermark cursor correctness fix surfaced by a prod incident (#475), `on_error=fail` semantic alignment across the remaining HTTP destinations (#463), and the new `VERSIONING.md` policy doc (#457).
+
+### Breaking Changes
+
+None. Drop-in upgrade from v0.7.0.
+
 ### Added
 
 - **`drt run --dry-run --diff`** (#413): Record-level preview before deploying a sync. For queryable destinations (Postgres / MySQL / ClickHouse), compares extracted source records against the destination state keyed on `upsert_key` and shows added / updated (with field-level `old → new` diffs) / deleted records. For non-queryable destinations (REST API, Slack, HubSpot, Notion, file destinations, etc.) falls back to "sample mode" — shows the first N records that would be sent, with a note that comparison is unavailable. Output works in both text (rich tables) and `--output json` (embedded `diff` key per sync). New flag `--diff-limit N` (default 20) caps records shown per category. The `--diff` flag is only valid alongside `--dry-run`. Doc: [docs/guides/dry-run-and-diff.md](docs/guides/dry-run-and-diff.md). Follow-ups: #468 (Snowflake support), #469 (Protocol method), #470 (perf), #471 (`--diff-fields`), #472 (API-based SaaS diff).
+- **`VERSIONING.md` — semver and deprecation policy** (#457, #464): Documents the project's versioning contract pre-1.0, what counts as a breaking change at each layer (CLI / config schema / Python API), and the deprecation cadence (announced one minor version, removable one minor after that). Cross-linked from `CONTRIBUTING.md` PR checklist. Initial draft contributed by @Muawiya-contact, follow-up polish in #464 also by @Muawiya-contact.
 
 ### Fixed
 
 - **Watermark advance for tz-aware cursor values** (#475): `drt/engine/sync.py` was calling `str()` directly on cursor field values, which for tz-aware datetimes (e.g. BigQuery `TIMESTAMP` columns returned by the Python BQ client) produced strings with a `+00:00` suffix. When user SQL or `default_value` was written tz-naive (the common case for warehouses where the `TIMESTAMP` literal is parsed as UTC), the next run compared a naive `WHERE col >= TIMESTAMP('YYYY-MM-DD HH:MM:SS')` against the tz-aware persisted form representing the same instant. The boundary row matched again and re-fired on every subsequent run. The engine now normalizes tz-aware datetimes to naive UTC before stringifying, preserving the same instant in a form that round-trips through naive `TIMESTAMP()` literals. Other types (naive datetime, string, numeric) pass through unchanged. Reported by @K-Masuda-SL after a prod incident where a single `recording_sessions` row triggered a downstream GHA `workflow_dispatch` three times in a row at the watermark boundary.
+- **`on_error=fail` not respected by Notion / REST API / Email SMTP destinations** (#463, contributes to #365): Three HTTP destinations continued processing the rest of the batch after the first row failure even when `on_error: fail` was configured at the sync level — only logging the error and counting `failed += 1`. Other HTTP destinations (Slack / Discord / Teams / HubSpot / Twilio / Intercom / SendGrid / Google Ads) were already correct. Now all three short-circuit and `return result` on the first failure, matching the documented contract and the behavior of every other destination. New `on_error=fail` and per-destination retry override tests added across the webhook surface to lock the semantic in.
 
 ## [0.7.0] - 2026-05-06
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,8 @@ make fmt      # ruff format + fix
 
 ## Current Status
 
-- **v0.7.0 released** — Production Ready theme: graceful shutdown on SIGTERM/SIGINT (#279), per-destination retry override (#277), sync execution history (#276), zero-downtime replace via staging table swap (#338), FK existence check via `lookups.check_only` (#354), `json_columns` config (#316), `drt doctor` (#264), `--quiet` flag (#265), Slack/webhook failure alerts (#414). Plus first DWH destination (Snowflake #353), Codespaces playground (#407), and `OPEN_CORE.md`.
+- **v0.7.1 released** — Production Ready follow-up: `drt run --dry-run --diff` for record-level preview (#413), tz-aware cursor stringification fix (#475), `on_error=fail` alignment for Notion / REST API / Email SMTP (#463), `VERSIONING.md` policy doc (#457).
+- **v0.7.0** — Production Ready theme: graceful shutdown on SIGTERM/SIGINT (#279), per-destination retry override (#277), sync execution history (#276), zero-downtime replace via staging table swap (#338), FK existence check via `lookups.check_only` (#354), `json_columns` config (#316), `drt doctor` (#264), `--quiet` flag (#265), Slack/webhook failure alerts (#414). Plus first DWH destination (Snowflake #353), Codespaces playground (#407), and `OPEN_CORE.md`.
 - **v0.6.2** — `watermark.default_value` + `--cursor-value` CLI + watermark observability (#390, #391)
 - **v0.6.1** — `${VAR}` env substitution in all sync YAML string fields (#385)
 - **v0.6.0** — Notion/Twilio/Intercom/Email SMTP/Salesforce Bulk/Google Ads destinations, `--threads` parallel execution, `--log-format json`, `--select tag:`, JSON Schema validation, freshness/unique/accepted_values tests, `drt sources`/`drt destinations`, `--dry-run` row count diff, StagedDestination Protocol, destination_lookup, GOVERNANCE.md

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,16 +14,23 @@ Tail items continue in [v0.7.1](#v071--production-ready-follow-up) below.
 
 ---
 
-## v0.7.1 — Production Ready Follow-up
+## v0.7.1 — Production Ready Follow-up ✅ Shipped 2026-05-07
 
-**Theme:** Tail of the v0.7 cycle — items originally scoped for v0.7 that didn't make the v0.7.0 tag, plus quality polish on top of the production-ready surface.
+Released as **v0.7.1** on 2026-05-07. See [CHANGELOG.md](CHANGELOG.md#071---2026-05-07) and the [GitHub Release](https://github.com/drt-hub/drt/releases/tag/v0.7.1) for the full feature list.
+
+Tail items continue in [v0.7.2](#v072--production-ready-follow-up-2) below.
+
+---
+
+## v0.7.2 — Production Ready Follow-up #2
+
+**Theme:** Items deferred from v0.7.1 — opt-in telemetry and the Postgres `psycopg2.sql` migration, both held while their respective contributors complete polish iterations.
 
 **Scope:**
-- **Observability** — opt-in anonymous usage telemetry (#263, PR #446 in review by @kiwamizamurai — Production Ready originally scoped this for v0.7; rolled to v0.7.1 only because the polish push needed an extra cycle)
-- **Tests** — `on_error='fail'` and retry config tests across all destinations (#365, `good first issue`)
-- **DX** — `drt diff` for record-level dry-run visibility (#413)
+- **Observability** — opt-in anonymous usage telemetry (#263, PR #446 by @kiwamizamurai)
+- **Hardening** — Postgres destination `psycopg2.sql` SQL composition (#442, PR #452 by @Khush-domadia)
 
-**Target:** ~2 weeks post-v0.7.0 · **Progress:** [milestone/8](https://github.com/drt-hub/drt/milestone/8)
+**Target:** TBD (driven by contributor cadence) · **Progress:** [milestone/9](https://github.com/drt-hub/drt/milestone/9)
 
 ---
 

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -14,7 +14,7 @@ dlt (load into DWH) → dbt (transform) → drt (activate out of DWH)
 - **Tagline:** "Reverse ETL for the code-first data stack"
 - **Install:** `pip install drt-core` or `uv add drt-core`
 - **Package name:** `drt-core` (PyPI) — CLI command is `drt`
-- **Current version:** v0.7.0
+- **Current version:** v0.7.1
 
 ## What drt is NOT
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "drt-core"
-version = "0.7.0"
+version = "0.7.1"
 description = "Reverse ETL for the code-first data stack"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

**Theme: Production Ready follow-up.** Tail of the v0.7 cycle — record-level dry-run preview, watermark cursor correctness fix, `on_error=fail` alignment for the remaining HTTP destinations, and the new VERSIONING.md policy doc.

### Added
- `drt run --dry-run --diff` for record-level preview (#413)
- VERSIONING.md — semver and deprecation policy (#457, polished in #464)

### Fixed
- Watermark advance for tz-aware cursor values (#475 — prod incident reported by @K-Masuda-SL)
- `on_error=fail` not respected by Notion / REST API / Email SMTP destinations (#463, contributes to #365)

### Deferred to v0.7.2
- Opt-in anonymous usage telemetry (#263, PR #446)
- Postgres `psycopg2.sql` SQL composition (#442, PR #452)

Both PRs are healthy but their respective contributors haven't returned for the polish iteration. New v0.7.2 milestone exists as the home for these.

## Test plan
- [x] `make lint` clean (ruff + mypy)
- [x] `make test` — 874 passed, 5 skipped
- [ ] CI green
- [ ] Self-merge with --admin to cut the v0.7.1 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)