### PR TITLE
ci(release): inject telemetry API key from POSTHOG_WRITE_KEY secret

### DIFF
--- a/.github/workflows/publish-drt-core.yml
+++ b/.github/workflows/publish-drt-core.yml
@@ -23,6 +23,37 @@ jobs:
       - name: Install uv
         run: pip install uv
 
+      - name: Inject telemetry API key
+        env:
+          POSTHOG_WRITE_KEY: ${{ secrets.POSTHOG_WRITE_KEY }}
+        run: |
+          # If telemetry.py exists and the secret is set, replace the
+          # placeholder _DEFAULT_API_KEY = None with the real key.
+          # Fail-safe: if the secret is unset (community fork, accidental
+          # config drift), the build proceeds with telemetry physically
+          # disabled — is_enabled() short-circuits to False without a key.
+          if [ ! -f drt/telemetry.py ]; then
+            echo "drt/telemetry.py not present — skipping injection (pre-#446 release)."
+            exit 0
+          fi
+          if [ -z "$POSTHOG_WRITE_KEY" ]; then
+            echo "::warning::POSTHOG_WRITE_KEY secret not set — release will ship with telemetry disabled."
+            exit 0
+          fi
+          python -c "
+          import pathlib, os
+          p = pathlib.Path('drt/telemetry.py')
+          src = p.read_text()
+          needle = '_DEFAULT_API_KEY: str | None = None'
+          repl = f'_DEFAULT_API_KEY: str | None = \"{os.environ[\"POSTHOG_WRITE_KEY\"]}\"'
+          if needle not in src:
+              raise SystemExit(f'placeholder {needle!r} not found in {p} — refusing to build')
+          p.write_text(src.replace(needle, repl, 1))
+          "
+          # Smoke check: the rebuilt module must report the key as truthy.
+          PYTHONPATH=. python -c "from drt import telemetry; assert telemetry._DEFAULT_API_KEY, 'injection failed'"
+          echo "Telemetry API key injected successfully."
+
       - name: Build
         run: uv build
 


### PR DESCRIPTION
## Summary

Adds an injection step to [`publish-drt-core.yml`](.github/workflows/publish-drt-core.yml) that runs before `uv build` when a `v*` tag is pushed. Companion to [#446](https://github.com/drt-hub/drt/pull/446) — the workflow side of the release-time API key injection that #446's docs/telemetry.md "For maintainers" section describes.

## Behavior matrix

| `drt/telemetry.py` present | `POSTHOG_WRITE_KEY` set | Action |
|---|---|---|
| ❌ | (any) | Skip silently — pre-#446 release path stays green |
| ✅ | ❌ | Log a warning, skip injection — release ships with telemetry disabled (fail-safe) |
| ✅ | ✅ | In-place replace `_DEFAULT_API_KEY: str \| None = None` with the real key, then smoke-check via `from drt import telemetry; assert telemetry._DEFAULT_API_KEY` |

If the placeholder string `_DEFAULT_API_KEY: str \| None = None` is unexpectedly missing (e.g. a future refactor renames the constant), the script raises `SystemExit` and the release fails loudly — better than silently shipping a None key.

## Why fail-safe on missing secret

Community forks shouldn't be blocked from cutting their own releases. Without a key, `is_enabled()` short-circuits to `False` regardless of user opt-in, so the package on PyPI is physically incapable of sending telemetry. The warning makes the omission visible in the workflow log without aborting.

## Order of operations

Once #446 lands and `POSTHOG_WRITE_KEY` is set as a repo secret, the next `v*` tag push will:

1. Checkout
2. Setup Python 3.12 + uv
3. **Inject telemetry API key** ← this step
4. `uv build` (now builds with the key embedded)
5. Publish to PyPI via Trusted Publishing

## Test plan

- [x] Workflow syntax: linted via `gh actions-extension yamllint` equivalent (no syntax errors)
- [ ] Dry-run validation: cannot fully test without a `v*` tag; behavior matrix verified by reading
- [ ] Live test on v0.7.2 release tag (after #446 + `POSTHOG_WRITE_KEY` secret are in place)

## Related

- Companion to #446 (telemetry feature, by @kiwamizamurai)
- Docs reference: `docs/telemetry.md` "For maintainers" → "Release-time API key injection" (ships in #446)

🤖 Generated with [Claude Code](https://claude.com/claude-code)