### PR TITLE
chore(postgres): extend psycopg2.sql migration to swap path (fixes #483)

### DIFF
--- a/drt/destinations/postgres.py
+++ b/drt/destinations/postgres.py
@@ -233,12 +233,20 @@ class PostgresDestination:
         config: PostgresDestinationConfig,
     ) -> SyncResult:
         """Build a shadow table per sync; atomic rename happens in finalize_sync."""
+        from psycopg2 import sql as _pgsql
         result = SyncResult()
         shadow = f"{table}__drt_swap"
 
         if not self._swap_shadow_created:
-            cur.execute(f"DROP TABLE IF EXISTS {shadow}")
-            cur.execute(f"CREATE TABLE {shadow} (LIKE {table} INCLUDING ALL)")
+            cur.execute(
+                _pgsql.SQL("DROP TABLE IF EXISTS {}").format(_pgsql.Identifier(shadow))
+            )
+            cur.execute(
+                _pgsql.SQL("CREATE TABLE {} (LIKE {} INCLUDING ALL)").format(
+                    _pgsql.Identifier(shadow),
+                    _pgsql.Identifier(table),
+                )
+            )
             self._swap_shadow_created = True
             self._swap_table = table
 
@@ -263,7 +271,11 @@ class PostgresDestination:
                     conn.rollback()
                     # Cleanup shadow on hard fail
                     cur = conn.cursor()
-                    cur.execute(f"DROP TABLE IF EXISTS {shadow}")
+                    cur.execute(
+                        _pgsql.SQL("DROP TABLE IF EXISTS {}").format(
+                            _pgsql.Identifier(shadow)
+                        )
+                    )
                     conn.commit()
                     self._swap_shadow_created = False
                     self._swap_table = None
@@ -279,6 +291,8 @@ class PostgresDestination:
         sync_options: SyncOptions,
     ) -> SyncResult | None:
         """Atomic rename: original->old, shadow->original, drop old."""
+        from psycopg2 import sql as _pgsql
+
         if not self._swap_shadow_created or self._swap_table is None:
             return None
 
@@ -293,11 +307,21 @@ class PostgresDestination:
             # Single transaction: original->old, shadow->original.
             # ALTER TABLE ... RENAME TO takes a bare relation name on the RHS;
             # the schema is preserved automatically.
-            cur.execute(f"ALTER TABLE {table} RENAME TO {old.split('.')[-1]}")
-            cur.execute(f"ALTER TABLE {shadow} RENAME TO {table.split('.')[-1]}")
+            cur.execute(
+                _pgsql.SQL("ALTER TABLE {} RENAME TO {}").format(
+                    _pgsql.Identifier(table),
+                    _pgsql.Identifier(old.split(".")[-1]),
+                )
+            )
+            cur.execute(
+                _pgsql.SQL("ALTER TABLE {} RENAME TO {}").format(
+                    _pgsql.Identifier(shadow),
+                    _pgsql.Identifier(table.split(".")[-1]),
+                )
+            )
             conn.commit()
             # DROP old in separate tx (failure here doesn't break the swap).
-            cur.execute(f"DROP TABLE {old}")
+            cur.execute(_pgsql.SQL("DROP TABLE {}").format(_pgsql.Identifier(old)))
             conn.commit()
         finally:
             conn.close()

--- a/tests/unit/test_postgres_destination.py
+++ b/tests/unit/test_postgres_destination.py
@@ -44,6 +44,10 @@ def _fake_connection() -> MagicMock:
     return conn
 
 
+def _query_text(query: Any) -> str:
+    return str(query)
+
+
 # ---------------------------------------------------------------------------
 # Config validation
 # ---------------------------------------------------------------------------
@@ -362,12 +366,14 @@ class TestPostgresReplaceSwap:
         dest = PostgresDestination()
         dest.load(records, _config(), _options(mode="replace", replace_strategy="swap"))
 
-        sqls = [c[0][0] for c in cur.execute.call_args_list]
+        queries = [c[0][0] for c in cur.execute.call_args_list]
+        sqls = [_query_text(q) for q in queries]
         assert any("DROP TABLE IF EXISTS" in s and "__drt_swap" in s for s in sqls)
         assert any(
             "CREATE TABLE" in s and "(LIKE " in s and "INCLUDING ALL" in s for s in sqls
         )
         assert any("INSERT INTO" in s and "__drt_swap" in s for s in sqls)
+        assert not any(isinstance(q, str) and "__drt_swap" in q for q in queries)
         # No swap yet — happens in finalize_sync
         assert not any("RENAME TO" in s for s in sqls)
 
@@ -387,10 +393,12 @@ class TestPostgresReplaceSwap:
             _config(), _options(mode="replace", replace_strategy="swap")
         )
 
-        sqls = [c[0][0] for c in cur.execute.call_args_list]
+        queries = [c[0][0] for c in cur.execute.call_args_list]
+        sqls = [_query_text(q) for q in queries]
         # Two RENAME steps wrapped in a transaction
         rename_sqls = [s for s in sqls if "RENAME TO" in s]
         assert len(rename_sqls) >= 2
+        assert not any(isinstance(q, str) and "RENAME TO" in q for q in queries)
         # Final DROP of old table
         assert any("DROP TABLE" in s and "__drt_old" in s for s in sqls)
 
@@ -426,7 +434,7 @@ class TestPostgresReplaceSwap:
             _options(mode="replace", replace_strategy="swap"),
         )
 
-        sqls = [c[0][0] for c in cur.execute.call_args_list]
+        sqls = [_query_text(c[0][0]) for c in cur.execute.call_args_list]
         create_count = sum(
             1 for s in sqls if "CREATE TABLE" in s and "INCLUDING ALL" in s
         )
@@ -447,8 +455,8 @@ class TestPostgresReplaceSwap:
         # Fail only on INSERT — DROP/CREATE/cleanup succeed.
         insert_call_count = {"n": 0}
 
-        def execute_side_effect(sql: str, *args: Any) -> None:
-            if sql.startswith("INSERT INTO"):
+        def execute_side_effect(sql: Any, *args: Any) -> None:
+            if _query_text(sql).startswith("Composed([SQL('INSERT INTO"):
                 insert_call_count["n"] += 1
                 if insert_call_count["n"] == 2:
                     raise Exception("constraint violation on row 2")
@@ -468,7 +476,7 @@ class TestPostgresReplaceSwap:
         # Rollback called on hard fail
         conn.rollback.assert_called()
         # Cleanup DROP IF EXISTS issued after rollback
-        sqls = [c[0][0] for c in cur.execute.call_args_list]
+        sqls = [_query_text(c[0][0]) for c in cur.execute.call_args_list]
         drops = [s for s in sqls if "DROP TABLE IF EXISTS" in s and "__drt_swap" in s]
         assert len(drops) >= 2  # initial + cleanup
         # State reset → finalize_sync must be a no-op (no RENAME issued)
@@ -476,7 +484,7 @@ class TestPostgresReplaceSwap:
             _config(), _options(mode="replace", replace_strategy="swap")
         )
         assert finalize_result is None
-        sqls_after = [c[0][0] for c in cur.execute.call_args_list]
+        sqls_after = [_query_text(c[0][0]) for c in cur.execute.call_args_list]
         assert not any("RENAME TO" in s for s in sqls_after)
 
 
@@ -511,7 +519,8 @@ class TestPostgresReplaceSwapJsonColumns:
         # Find the INSERT call against the shadow table
         insert_calls = [
             c for c in cur.execute.call_args_list
-            if "INSERT INTO" in c[0][0] and "__drt_swap" in c[0][0]
+            if "INSERT INTO" in _query_text(c[0][0])
+            and "__drt_swap" in _query_text(c[0][0])
         ]
         assert insert_calls, "expected at least one INSERT into shadow table"
         bound_values = insert_calls[0][0][1]


### PR DESCRIPTION
## Summary

Completes the psycopg2.sql migration started in #452 by extending safe SQL composition to the Postgres destination's replace-with-swap path.

## Changes

- `drt/destinations/postgres.py`: All swap-path SQL (DROP TABLE IF EXISTS, CREATE TABLE LIKE, INSERT, ALTER TABLE RENAME, cleanup DROP) now uses `psycopg2.sql.SQL` + `Identifier` instead of f-strings.  
- `tests/unit/test_postgres_destination.py`: Updated test assertions to work with composable SQL objects — uses `str(query)` comparison and verifies composable objects are being sent (not raw strings).  

## Verification

```bash
# Targeted Postgres unit tests
uv run pytest tests/unit/test_postgres_destination.py -v

# Lint
uv run ruff check drt/ tests/

# Type checking
uv run mypy drt/
```

All pass locally.

Closes #483