### PR TITLE
chore: optimize PyPI keywords and URLs for discoverability (fixes #291)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ keywords = [
     "open-source",
     "mcp",
     "llm-data",
+    "data-sync",
+    "yaml",
+    "duckdb",
+    "data-integration",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -83,8 +87,10 @@ drt = "drt.cli.main:app"
 
 [project.urls]
 Homepage = "https://github.com/drt-hub/drt"
+Documentation = "https://github.com/drt-hub/drt#readme"
 Repository = "https://github.com/drt-hub/drt"
 Issues = "https://github.com/drt-hub/drt/issues"
+Changelog = "https://github.com/drt-hub/drt/blob/main/CHANGELOG.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["drt"]


### PR DESCRIPTION
## Summary

Adds missing PyPI keywords (`data-sync`, `yaml`, `duckdb`, `data-integration`) and missing project URLs (`Documentation`, `Changelog`) to improve discoverability of `drt-core` on PyPI.

## Changes

- `pyproject.toml`: Added 4 keywords and 2 URLs

## Verification

```bash
# Validate TOML is valid
uv run python -c "import tomllib; tomllib.load(open('pyproject.toml', 'rb'))" && echo "TOML valid"

# Verify build metadata
uv run python -c "
import tomllib
with open('pyproject.toml', 'rb') as f:
    data = tomllib.load(f)
kw = data['project']['keywords']
print(f'Keywords: {len(kw)} total')
urls = data['project']['urls']
print(f'URLs: {list(urls.keys())}')
"
```

Closes #291