### PR TITLE
feat: add --check-connection flag to drt validate (fixes #367)

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -716,6 +716,9 @@ def validate(
         False, "--emit-schema", help="Write JSON Schemas to .drt/schemas/."
     ),
     output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
+    check_connection: bool = typer.Option(
+        False, "--check-connection", help="Test destination connectivity with SELECT 1 (SQL only)."
+    ),
 ) -> None:
     """Validate sync definitions against the JSON Schema."""
 
@@ -732,31 +735,42 @@ def validate(
             print_error(f"No sync named '{select}' found.")
             raise typer.Exit(1)
 
+    connection_status: dict[str, bool | str] = {}
+    if check_connection:
+        from drt.destinations.query import execute_test_query, is_queryable
+
+        for sync in result.syncs:
+            try:
+                if is_queryable(sync.destination):
+                    execute_test_query(sync.destination, "SELECT 1")
+                    connection_status[sync.name] = True
+                else:
+                    connection_status[sync.name] = "skipped"
+            except Exception as exc:
+                connection_status[sync.name] = str(exc)
+
     if output == "json":
         # Collect all deprecations into a flat list for JSON output
         all_deprecations = []
         for sync_name, sync_deprecations in result.deprecations.items():
             all_deprecations.extend(sync_deprecations)
         
-        print(
-            json.dumps(
-                {
-                    "results": [
-                        {
-                            "name": s.name,
-                            "valid": True,
-                            "deprecations": result.deprecations.get(s.name, []),
-                        }
-                        for s in result.syncs
-                    ]
-                    + [
-                        {"name": name, "valid": False, "errors": errs}
-                        for name, errs in result.errors.items()
-                    ],
-                },
-                indent=2,
-            )
-        )
+        sync_results = []
+        for s in result.syncs:
+            entry: dict[str, Any] = {
+                "name": s.name,
+                "valid": True,
+                "deprecations": result.deprecations.get(s.name, []),
+            }
+            if check_connection and s.name in connection_status:
+                status = connection_status[s.name]
+                entry["connection"] = "ok" if status is True else f"skipped ({status})"
+            sync_results.append(entry)
+
+        for name, errs in result.errors.items():
+            sync_results.append({"name": name, "valid": False, "errors": errs})
+
+        print(json.dumps({"results": sync_results}, indent=2))
         if result.errors:
             raise typer.Exit(code=1)
         return
@@ -777,6 +791,15 @@ def validate(
                 console.print(f"       Use {deprecation['replacement']} instead.")
                 if deprecation["docs_link"]:
                     console.print(f"       See {deprecation['docs_link']}")
+        # Connection check result
+        if check_connection and sync.name in connection_status:
+            status = connection_status[sync.name]
+            if status is True:
+                console.print("  [green]✓ connection OK[/green]")
+            elif status == "skipped":
+                console.print("  [dim]⏭ connection check skipped (not a SQL destination)[/dim]")
+            else:
+                console.print(f"  [red]✗ connection failed: {status}[/red]")
 
     for name, errors in result.errors.items():
         print_validation_error(name, errors)

--- a/tests/unit/test_cli_validate.py
+++ b/tests/unit/test_cli_validate.py
@@ -191,3 +191,123 @@ def test_cli_validate_error_shows_field_path(
     result = runner.invoke(app, ["validate"])
     assert "destination" in result.output
     assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI validate --check-connection
+# ---------------------------------------------------------------------------
+
+
+def test_cli_validate_check_connection_skips_non_sql(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--check-connection skips non-SQL destinations gracefully."""
+    _write_sync(tmp_path / "syncs", "api", VALID_SYNC)
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["validate", "--check-connection"])
+    assert result.exit_code == 0
+    assert "✓" in result.output
+    assert "skipped" in result.output
+
+
+def test_cli_validate_check_connection_json_includes_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--check-connection with JSON output includes connection field."""
+    import json as _json
+
+    _write_sync(tmp_path / "syncs", "api", VALID_SYNC)
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["validate", "--check-connection", "--output", "json"])
+    assert result.exit_code == 0
+    data = _json.loads(result.output)
+    assert len(data["results"]) == 1
+    assert data["results"][0]["name"] == "test-sync"
+    assert "connection" in data["results"][0]
+    assert "skipped" in data["results"][0]["connection"]
+
+
+def test_cli_validate_check_connection_reports_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--check-connection reports connection failures for SQL destinations."""
+    sync = {
+        "name": "pg-sync",
+        "model": "SELECT 1",
+        "destination": {
+            "type": "postgres",
+            "host": "localhost",
+            "dbname": "nonexistent",
+            "user": "nobody",
+            "password": "nope",
+            "table": "test",
+            "upsert_key": ["id"],
+        },
+    }
+    _write_sync(tmp_path / "syncs", "pg", sync)
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["validate", "--check-connection"])
+    assert "✓" in result.output
+    assert "✗" in result.output
+    assert "connection failed" in result.output.lower()
+
+
+def test_cli_validate_check_connection_json_reports_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--check-connection JSON output with connection failure message."""
+    import json as _json
+
+    sync = {
+        "name": "pg-sync",
+        "model": "SELECT 1",
+        "destination": {
+            "type": "postgres",
+            "host": "localhost",
+            "dbname": "nonexistent",
+            "user": "nobody",
+            "password": "nope",
+            "table": "test",
+            "upsert_key": ["id"],
+        },
+    }
+    _write_sync(tmp_path / "syncs", "pg", sync)
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["validate", "--check-connection", "--output", "json"])
+    data = _json.loads(result.output)
+    assert result.exit_code == 0
+    pg = next(r for r in data["results"] if r["name"] == "pg-sync")
+    assert pg["connection"] != "ok"
+    assert "connection" in pg
+
+
+def test_cli_validate_without_check_connection_excludes_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without --check-connection, JSON output has no connection field."""
+    import json as _json
+
+    _write_sync(tmp_path / "syncs", "api", VALID_SYNC)
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["validate", "--output", "json"])
+    assert result.exit_code == 0
+    data = _json.loads(result.output)
+    assert "connection" not in data["results"][0]
+    assert data["results"][0]["valid"] is True
+
+
+def test_cli_validate_check_connection_with_select(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--check-connection works with --select to test a specific sync."""
+    sync_a = {**VALID_SYNC, "name": "alpha"}
+    sync_b = {**VALID_SYNC, "name": "beta"}
+    _write_sync(tmp_path / "syncs", "alpha", sync_a)
+    _write_sync(tmp_path / "syncs", "beta", sync_b)
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(
+        app, ["validate", "--check-connection", "--select", "alpha"]
+    )
+    assert result.exit_code == 0
+    assert "✓" in result.output
+    assert "beta" not in result.output


### PR DESCRIPTION
## Summary

Adds `--check-connection` flag to `drt validate` that tests actual destination connectivity using `SELECT 1` for SQL destinations.

## Changes

- `drt/cli/main.py`: Added `--check-connection` boolean option to `validate` command. After schema validation, attempts `execute_test_query(config, "SELECT 1")` for queryable destinations (Postgres, MySQL, ClickHouse). Non-SQL destinations are skipped with a note. Results displayed in both text and JSON output.
- `tests/unit/test_cli_validate.py`: 6 new tests covering:
  - Skip for non-SQL destinations
  - JSON output includes connection status
  - Connection failure reported in text and JSON
  - Without `--check-connection`, no connection field in output  
  - Works with `--select` filter

## Verification

```bash
# Unit tests
uv run pytest tests/unit/test_cli_validate.py -v

# Lint
uv run ruff check drt/cli/main.py

# Type check
uv run mypy drt/cli/main.py
```

All 20 tests pass, lint clean.

Closes #367