### PR TITLE
feat: add drt cloud status stub (closes #491)

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -1115,13 +1115,21 @@ cloud_app = typer.Typer(name="cloud", help="drt Cloud commands (stub).", no_args
 app.add_typer(cloud_app)
 
 
+CLOUD_MESSAGE = (
+    "\n☁️  drt Cloud is coming soon!\nFollow https://github.com/drt-hub/drt for updates.\n"
+)
+
+
 @cloud_app.command(name="push")
 def cloud_push() -> None:
     """Push local project configuration to drt Cloud (stub)."""
-    console.print("\n[bold blue]🚀 drt Cloud[/bold blue]")
-    console.print("This is a stub for the future drt Cloud service.")
-    console.print("Project state would be pushed to your cloud dashboard here.")
-    console.print("\n[dim]Coming soon...[/dim]\n")
+    print(CLOUD_MESSAGE)
+
+
+@cloud_app.command(name="status")
+def cloud_status() -> None:
+    """Check drt Cloud deployment status (stub)."""
+    print(CLOUD_MESSAGE)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_cloud_stub.py
+++ b/tests/unit/test_cli_cloud_stub.py
@@ -1,0 +1,40 @@
+"""Tests for drt cloud (stub) commands."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from drt.cli.main import app
+
+runner = CliRunner()
+
+
+def test_cloud_push_prints_coming_soon() -> None:
+    """drt cloud push prints the coming soon message."""
+    result = runner.invoke(app, ["cloud", "push"])
+    assert result.exit_code == 0
+    assert "coming soon" in result.output.lower()
+    assert "drt-hub/drt" in result.output
+
+
+def test_cloud_status_prints_coming_soon() -> None:
+    """drt cloud status prints the coming soon message."""
+    result = runner.invoke(app, ["cloud", "status"])
+    assert result.exit_code == 0
+    assert "coming soon" in result.output.lower()
+    assert "drt-hub/drt" in result.output
+
+
+def test_cloud_help_shows_subcommands() -> None:
+    """drt cloud --help lists push and status subcommands."""
+    result = runner.invoke(app, ["cloud", "--help"])
+    assert result.exit_code == 0
+    assert "push" in result.output
+    assert "status" in result.output
+
+
+def test_top_level_help_includes_cloud() -> None:
+    """drt --help includes cloud in the command list."""
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "cloud" in result.output


### PR DESCRIPTION
## Summary

Adds `drt cloud status` subcommand alongside the existing `drt cloud push`. Both print a unified coming-soon message pointing to the GitHub repo.

## Changes

- `drt/cli/main.py`: Refactored existing `cloud push` to use a shared `CLOUD_MESSAGE`, added `cloud status` command.
- `tests/unit/test_cli_cloud_stub.py`: 4 tests covering push, status, help listing, and top-level `--help` inclusion.

## Verification

```bash
# Unit tests
uv run pytest tests/unit/test_cli_cloud_stub.py -v

# Lint
uv run ruff check drt/cli/main.py

# Smoke test
uv run drt cloud push
uv run drt cloud status
uv run drt cloud --help
```

Closes #491