### PR TITLE
chore(i18n): sync README.ja.md hash after v0.7.2 release

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-sync: base=README.md, hash=474502e36e59eb896d68bf3e2350b2a82505c92f -->
+<!-- i18n-sync: base=README.md, hash=c55dc5c98718f609e3212b34dd9a479638ef8189 -->
 
 [English](./README.md) | [日本語](./README.ja.md)
 


### PR DESCRIPTION
Follows the convention from #477 — translation content was bundled in #489, this PR refreshes the i18n-sync marker hash to point at the v0.7.2 release commit c55dc5c.

`make check-i18n` now reports synced locally.