### PR TITLE
polish: restore Rich formatting for cloud stubs

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -1256,20 +1256,22 @@ app.add_typer(cloud_app)
 
 
 CLOUD_MESSAGE = (
-    "\n☁️  drt Cloud is coming soon!\nFollow https://github.com/drt-hub/drt for updates.\n"
+    "\n[bold blue]🚀 drt Cloud[/bold blue]\n"
+    "This is a stub for the future drt Cloud service.\n"
+    "[dim]Coming soon... Follow https://github.com/drt-hub/drt for updates.[/dim]\n"
 )
 
 
 @cloud_app.command(name="push")
 def cloud_push() -> None:
     """Push local project configuration to drt Cloud (stub)."""
-    print(CLOUD_MESSAGE)
+    console.print(CLOUD_MESSAGE)
 
 
 @cloud_app.command(name="status")
 def cloud_status() -> None:
     """Check drt Cloud deployment status (stub)."""
-    print(CLOUD_MESSAGE)
+    console.print(CLOUD_MESSAGE)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #494.

## Summary
- render both `drt cloud push` and `drt cloud status` through Rich `console.print`
- restore the bold blue `drt Cloud` heading and dim coming-soon footer
- keep the `drt-hub/drt` update link in the stub text

## Validation
- `uv run pytest tests/unit/test_cli_cloud_stub.py -v`
- `uv run ruff check drt/cli/main.py tests/unit/test_cli_cloud_stub.py`
- `uv run drt cloud push`
- `uv run drt cloud status`