### PR TITLE
feat: add ConnectionTestable destination protocol

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -831,6 +831,7 @@ def _run_connection_test(sync: SyncConfig) -> dict[str, Any]:
         SnowflakeDestinationConfig,
     )
     from drt.connectors.registry import get_destination
+    from drt.destinations.base import ConnectionTestable
 
     dest_config = sync.destination
     is_sql = isinstance(
@@ -848,9 +849,8 @@ def _run_connection_test(sync: SyncConfig) -> dict[str, Any]:
 
     try:
         dest = get_destination(dest_config)
-        tester = getattr(dest, "test_connection", None)
-        if callable(tester):
-            tester(dest_config)
+        if isinstance(dest, ConnectionTestable):
+            dest.test_connection(dest_config)
             return {"success": True, "error": None, "skipped": False}
         else:
             return {

--- a/drt/destinations/base.py
+++ b/drt/destinations/base.py
@@ -57,6 +57,15 @@ class Destination(Protocol):
 
 
 @runtime_checkable
+class ConnectionTestable(Protocol):
+    """Optional destination capability for validating external connectivity."""
+
+    def test_connection(self, config: DestinationConfig) -> None:
+        """Raise an exception if the destination cannot be reached."""
+        ...
+
+
+@runtime_checkable
 class StagedDestination(Protocol):
     """Destination that accumulates records, then uploads as a batch job.
 

--- a/drt/destinations/clickhouse.py
+++ b/drt/destinations/clickhouse.py
@@ -37,7 +37,10 @@ from drt.destinations.row_errors import RowError
 
 
 class ClickHouseDestination:
-    """Insert records into a ClickHouse table."""
+    """Insert records into a ClickHouse table.
+
+    Implements ConnectionTestable via test_connection().
+    """
 
     def __init__(self) -> None:
         self._replace_truncated: bool = False

--- a/drt/destinations/mysql.py
+++ b/drt/destinations/mysql.py
@@ -62,7 +62,10 @@ def _serialize_value(
 
 
 class MySQLDestination:
-    """Upsert or replace records into a MySQL table."""
+    """Upsert or replace records into a MySQL table.
+
+    Implements ConnectionTestable via test_connection().
+    """
 
     def __init__(self) -> None:
         self._replace_truncated: bool = False

--- a/drt/destinations/postgres.py
+++ b/drt/destinations/postgres.py
@@ -88,7 +88,10 @@ def _serialize_value(
 
 
 class PostgresDestination:
-    """Upsert or replace records into a PostgreSQL table."""
+    """Upsert or replace records into a PostgreSQL table.
+
+    Implements ConnectionTestable via test_connection().
+    """
 
     def __init__(self) -> None:
         self._replace_truncated: bool = False

--- a/tests/unit/test_cli_validate_connection.py
+++ b/tests/unit/test_cli_validate_connection.py
@@ -3,15 +3,27 @@ from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
 from drt.cli.main import app
-from drt.config.models import PostgresDestinationConfig, SlackDestinationConfig
+from drt.config.models import (
+    DestinationConfig,
+    PostgresDestinationConfig,
+    SlackDestinationConfig,
+)
 
 runner = CliRunner()
 
+
+class _ConnectionTestDestination:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+
+    def test_connection(self, config: DestinationConfig) -> None:
+        if self.error is not None:
+            raise self.error
+
+
 def test_validate_check_connection_sql_success() -> None:
     """Test validate --check-connection for an SQL destination (success)."""
-    mock_dest = MagicMock()
-    # Mocking that the destination has test_connection
-    mock_dest.test_connection.return_value = None
+    mock_dest = _ConnectionTestDestination()
     
     with patch("drt.connectors.registry.get_destination", return_value=mock_dest), \
          patch("drt.config.parser.load_syncs_safe") as mock_load:
@@ -37,8 +49,7 @@ def test_validate_check_connection_sql_success() -> None:
 
 def test_validate_check_connection_sql_failure() -> None:
     """Test validate --check-connection for an SQL destination (failure)."""
-    mock_dest = MagicMock()
-    mock_dest.test_connection.side_effect = Exception("Conn Error")
+    mock_dest = _ConnectionTestDestination(Exception("Conn Error"))
     
     with patch("drt.connectors.registry.get_destination", return_value=mock_dest), \
          patch("drt.config.parser.load_syncs_safe") as mock_load:
@@ -112,8 +123,7 @@ def test_validate_check_connection_sql_no_tester_method() -> None:
 def test_validate_check_connection_json() -> None:
     """Test validate --check-connection --output json."""
     import json
-    mock_dest = MagicMock()
-    mock_dest.test_connection.return_value = None
+    mock_dest = _ConnectionTestDestination()
     
     with patch("drt.connectors.registry.get_destination", return_value=mock_dest), \
          patch("drt.config.parser.load_syncs_safe") as mock_load:

--- a/tests/unit/test_destination_contract.py
+++ b/tests/unit/test_destination_contract.py
@@ -6,7 +6,7 @@ import inspect
 
 import pytest
 
-from drt.destinations.base import Destination, SyncResult
+from drt.destinations.base import ConnectionTestable, Destination, SyncResult
 from drt.destinations.clickhouse import ClickHouseDestination
 from drt.destinations.discord import DiscordDestination
 from drt.destinations.file import FileDestination
@@ -19,6 +19,7 @@ from drt.destinations.parquet import ParquetDestination
 from drt.destinations.postgres import PostgresDestination
 from drt.destinations.rest_api import RestApiDestination
 from drt.destinations.slack import SlackDestination
+from drt.destinations.snowflake import SnowflakeDestination
 from drt.destinations.teams import TeamsDestination
 
 ALL_DESTINATIONS = [
@@ -32,6 +33,26 @@ ALL_DESTINATIONS = [
     NotionDestination,
     ParquetDestination,
     PostgresDestination,
+    RestApiDestination,
+    SlackDestination,
+    TeamsDestination,
+]
+
+CONNECTION_TESTABLE_DESTINATIONS = [
+    ClickHouseDestination,
+    MySQLDestination,
+    PostgresDestination,
+    SnowflakeDestination,
+]
+
+NON_CONNECTION_TESTABLE_DESTINATIONS = [
+    DiscordDestination,
+    FileDestination,
+    GitHubActionsDestination,
+    GoogleSheetsDestination,
+    HubSpotDestination,
+    NotionDestination,
+    ParquetDestination,
     RestApiDestination,
     SlackDestination,
     TeamsDestination,
@@ -55,3 +76,17 @@ def test_load_return_annotation(cls: type) -> None:
     sig = inspect.signature(cls.load)
     ann = sig.return_annotation
     assert ann is SyncResult or ann == "SyncResult"
+
+
+@pytest.mark.parametrize("cls", CONNECTION_TESTABLE_DESTINATIONS, ids=lambda c: c.__name__)
+def test_sql_destinations_implement_connection_testable(cls: type) -> None:
+    assert isinstance(cls(), ConnectionTestable)
+
+
+@pytest.mark.parametrize(
+    "cls",
+    NON_CONNECTION_TESTABLE_DESTINATIONS,
+    ids=lambda c: c.__name__,
+)
+def test_non_sql_destinations_do_not_implement_connection_testable(cls: type) -> None:
+    assert not isinstance(cls(), ConnectionTestable)


### PR DESCRIPTION
Closes #495.

## Summary
- add a runtime-checkable `ConnectionTestable` destination protocol for optional connection probes
- switch `drt validate --check-connection` from dynamic `getattr` dispatch to `isinstance(dest, ConnectionTestable)`
- document SQL destinations that expose `test_connection` and add contract coverage for SQL vs non-SQL destinations
- replace protocol-positive test mocks with a concrete fake so Python 3.12 runtime protocol checks exercise the intended path

## Validation
- `uv run pytest tests/unit/test_cli_validate_connection.py tests/unit/test_destination_contract.py -v`
- `uv run --python 3.12 --extra dev python -m pytest tests/unit/test_cli_validate_connection.py tests/unit/test_destination_contract.py -v`
- `uv run ruff check drt/cli/main.py drt/destinations/base.py drt/destinations/clickhouse.py drt/destinations/mysql.py drt/destinations/postgres.py tests/unit/test_cli_validate_connection.py tests/unit/test_destination_contract.py`
- `uv run --python 3.12 --extra dev ruff check drt/cli/main.py drt/destinations/base.py drt/destinations/clickhouse.py drt/destinations/mysql.py drt/destinations/postgres.py tests/unit/test_cli_validate_connection.py tests/unit/test_destination_contract.py`
- `git diff --check`