### PR TITLE
fix: quote qualified Postgres table identifiers

### DIFF
--- a/drt/destinations/postgres.py
+++ b/drt/destinations/postgres.py
@@ -87,6 +87,39 @@ def _serialize_value(
     return value
 
 
+def _split_qualified(table: str) -> tuple[str | None, str]:
+    """Split an optional ``schema.table`` name into schema and relation parts."""
+    if "." not in table:
+        return None, table
+    schema, relation = table.split(".", 1)
+    return schema or None, relation
+
+
+def _join_qualified(schema: str | None, relation: str) -> str:
+    if schema is None:
+        return relation
+    return f"{schema}.{relation}"
+
+
+def _qualified_ident(table: str) -> Any:
+    """Return a psycopg2 Identifier that quotes each qualified-name part."""
+    from psycopg2 import sql as _pgsql
+
+    schema, relation = _split_qualified(table)
+    if schema is None:
+        return _pgsql.Identifier(relation)
+    return _pgsql.Identifier(schema, relation)
+
+
+def _relation_name(table: str) -> str:
+    return _split_qualified(table)[1]
+
+
+def _with_relation_suffix(table: str, suffix: str) -> str:
+    schema, relation = _split_qualified(table)
+    return _join_qualified(schema, f"{relation}{suffix}")
+
+
 class PostgresDestination:
     """Upsert or replace records into a PostgreSQL table."""
 
@@ -166,7 +199,7 @@ class PostgresDestination:
         try:
             cur = conn.cursor()
             query = sql.SQL("SELECT COUNT(*) FROM {}").format(
-                sql.Identifier(config.table)
+                _qualified_ident(config.table)
             )
             cur.execute(query)
             row = cur.fetchone()
@@ -199,7 +232,7 @@ class PostgresDestination:
         result = SyncResult()
 
         if not self._replace_truncated:
-            cur.execute(_pgsql.SQL("TRUNCATE TABLE {}").format(_pgsql.Identifier(table)))
+            cur.execute(_pgsql.SQL("TRUNCATE TABLE {}").format(_qualified_ident(table)))
             self._replace_truncated = True
 
         query = self._build_insert_sql(table, columns)
@@ -225,7 +258,11 @@ class PostgresDestination:
                 conn.rollback()
                 cur = conn.cursor()
                 if not self._replace_truncated:
-                    cur.execute(_pgsql.SQL("TRUNCATE TABLE {}").format(_pgsql.Identifier(table)))
+                    cur.execute(
+                        _pgsql.SQL("TRUNCATE TABLE {}").format(
+                            _qualified_ident(table)
+                        )
+                    )
                     self._replace_truncated = True
                 continue
 
@@ -245,16 +282,16 @@ class PostgresDestination:
         """Build a shadow table per sync; atomic rename happens in finalize_sync."""
         from psycopg2 import sql as _pgsql
         result = SyncResult()
-        shadow = f"{table}__drt_swap"
+        shadow = _with_relation_suffix(table, "__drt_swap")
 
         if not self._swap_shadow_created:
             cur.execute(
-                _pgsql.SQL("DROP TABLE IF EXISTS {}").format(_pgsql.Identifier(shadow))
+                _pgsql.SQL("DROP TABLE IF EXISTS {}").format(_qualified_ident(shadow))
             )
             cur.execute(
                 _pgsql.SQL("CREATE TABLE {} (LIKE {} INCLUDING ALL)").format(
-                    _pgsql.Identifier(shadow),
-                    _pgsql.Identifier(table),
+                    _qualified_ident(shadow),
+                    _qualified_ident(table),
                 )
             )
             self._swap_shadow_created = True
@@ -283,7 +320,7 @@ class PostgresDestination:
                     cur = conn.cursor()
                     cur.execute(
                         _pgsql.SQL("DROP TABLE IF EXISTS {}").format(
-                            _pgsql.Identifier(shadow)
+                            _qualified_ident(shadow)
                         )
                     )
                     conn.commit()
@@ -308,8 +345,8 @@ class PostgresDestination:
 
         assert isinstance(config, PostgresDestinationConfig)
         table = self._swap_table
-        shadow = f"{table}__drt_swap"
-        old = f"{table}__drt_old"
+        shadow = _with_relation_suffix(table, "__drt_swap")
+        old = _with_relation_suffix(table, "__drt_old")
 
         conn = self._connect(config)
         try:
@@ -319,19 +356,19 @@ class PostgresDestination:
             # the schema is preserved automatically.
             cur.execute(
                 _pgsql.SQL("ALTER TABLE {} RENAME TO {}").format(
-                    _pgsql.Identifier(table),
-                    _pgsql.Identifier(old.split(".")[-1]),
+                    _qualified_ident(table),
+                    _pgsql.Identifier(_relation_name(old)),
                 )
             )
             cur.execute(
                 _pgsql.SQL("ALTER TABLE {} RENAME TO {}").format(
-                    _pgsql.Identifier(shadow),
-                    _pgsql.Identifier(table.split(".")[-1]),
+                    _qualified_ident(shadow),
+                    _pgsql.Identifier(_relation_name(table)),
                 )
             )
             conn.commit()
             # DROP old in separate tx (failure here doesn't break the swap).
-            cur.execute(_pgsql.SQL("DROP TABLE {}").format(_pgsql.Identifier(old)))
+            cur.execute(_pgsql.SQL("DROP TABLE {}").format(_qualified_ident(old)))
             conn.commit()
         finally:
             conn.close()
@@ -387,7 +424,7 @@ class PostgresDestination:
     def _build_insert_sql(table: str, columns: list[str]) -> Any:
         from psycopg2 import sql as _pgsql
         return _pgsql.SQL("INSERT INTO {} ({}) VALUES ({})").format(
-            _pgsql.Identifier(table),
+            _qualified_ident(table),
             _pgsql.SQL(", ").join(_pgsql.Identifier(c) for c in columns),
             _pgsql.SQL(", ").join(_pgsql.Placeholder() for _ in columns),
         )
@@ -414,7 +451,7 @@ class PostgresDestination:
         return _pgsql.SQL(
             "INSERT INTO {} ({}) VALUES ({}) ON CONFLICT ({}) {}"
         ).format(
-            _pgsql.Identifier(table),
+            _qualified_ident(table),
             _pgsql.SQL(", ").join(_pgsql.Identifier(c) for c in columns),
             _pgsql.SQL(", ").join(_pgsql.Placeholder() for _ in columns),
             _pgsql.SQL(", ").join(_pgsql.Identifier(c) for c in upsert_key),

--- a/tests/unit/test_postgres_destination.py
+++ b/tests/unit/test_postgres_destination.py
@@ -13,7 +13,12 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 from drt.config.models import PostgresDestinationConfig, SyncOptions
-from drt.destinations.postgres import PostgresDestination
+from drt.destinations.postgres import (
+    PostgresDestination,
+    _qualified_ident,
+    _split_qualified,
+    _with_relation_suffix,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -46,6 +51,10 @@ def _fake_connection() -> MagicMock:
 
 def _query_text(query: Any) -> str:
     return str(query)
+
+
+def _split_identifier_text(schema: str, relation: str) -> str:
+    return f"Identifier('{schema}', '{relation}')"
 
 
 # ---------------------------------------------------------------------------
@@ -87,7 +96,7 @@ class TestUpsertSql:
             update_cols=["score", "updated_at"],
         )
         assert "INSERT INTO" in str(sql)
-        assert "public.scores" in str(sql)
+        assert _split_identifier_text("public", "scores") in str(sql)
         assert "ON CONFLICT" in str(sql)
         assert "DO UPDATE SET" in str(sql)
         assert "score" in str(sql)
@@ -135,6 +144,26 @@ class TestPostgresDestinationLoad:
         assert result.failed == 0
         assert conn.cursor().execute.call_count == 2
         conn.commit.assert_called_once()
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_upsert_uses_schema_qualified_identifier(
+        self, mock_connect: MagicMock
+    ) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        config = _config(table="marketing.email_events")
+        result = PostgresDestination().load(
+            [{"id": 1, "score": 0.95}],
+            config,
+            _options(),
+        )
+
+        assert result.success == 1
+        query = _query_text(cur.execute.call_args.args[0])
+        assert "INSERT INTO" in query
+        assert _split_identifier_text("marketing", "email_events") in query
 
     @patch("drt.destinations.postgres.PostgresDestination._connect")
     def test_empty_records(self, mock_connect: MagicMock) -> None:
@@ -213,10 +242,51 @@ class TestInsertSql:
         )
         rendered = str(sql)
         assert "INSERT INTO" in rendered
-        assert "public.scores" in rendered
+        assert _split_identifier_text("public", "scores") in rendered
         assert "id" in rendered
         assert "score" in rendered
         assert "updated_at" in rendered
+
+
+class TestQualifiedIdentifiers:
+    def test_split_qualified_table_name(self) -> None:
+        assert _split_qualified("marketing.email_events") == (
+            "marketing",
+            "email_events",
+        )
+        assert _split_qualified("email_events") == (None, "email_events")
+
+    def test_qualified_identifier_quotes_schema_and_relation_separately(self) -> None:
+        rendered = str(_qualified_ident("marketing.email_events"))
+        assert _split_identifier_text("marketing", "email_events") in rendered
+
+    def test_shadow_table_suffix_stays_on_relation(self) -> None:
+        assert (
+            _with_relation_suffix("marketing.email_events", "__drt_swap")
+            == "marketing.email_events__drt_swap"
+        )
+        assert (
+            _with_relation_suffix("email_events", "__drt_swap")
+            == "email_events__drt_swap"
+        )
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_get_row_count_uses_schema_qualified_identifier(
+        self, mock_connect: MagicMock
+    ) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        cur.fetchone.return_value = (7,)
+        mock_connect.return_value = conn
+
+        count = PostgresDestination().get_row_count(
+            _config(table="marketing.email_events")
+        )
+
+        assert count == 7
+        query = _query_text(cur.execute.call_args.args[0])
+        assert _split_identifier_text("marketing", "email_events") in query
+        assert "marketing.email_events" not in query
 
 
 class TestPostgresReplaceMode:
@@ -268,6 +338,88 @@ class TestPostgresReplaceMode:
         # The INSERT call (second execute, after TRUNCATE)
         insert_sql = str(cur.execute.call_args_list[1][0][0])
         assert "INSERT INTO" in insert_sql
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_replace_uses_schema_qualified_identifier(
+        self, mock_connect: MagicMock
+    ) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        config = _config(table="marketing.email_events")
+        PostgresDestination().load(
+            [{"id": 1, "score": 0.95}],
+            config,
+            _options(mode="replace"),
+        )
+
+        sqls = [_query_text(c[0][0]) for c in cur.execute.call_args_list]
+        assert any(
+            "TRUNCATE TABLE" in s
+            and _split_identifier_text("marketing", "email_events") in s
+            for s in sqls
+        )
+        assert any(
+            "INSERT INTO" in s
+            and _split_identifier_text("marketing", "email_events") in s
+            for s in sqls
+        )
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_replace_on_error_fail_rolls_back_and_returns(
+        self, mock_connect: MagicMock
+    ) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        def execute_side_effect(sql: Any, *args: Any) -> None:
+            if "INSERT INTO" in _query_text(sql):
+                raise Exception("bad row")
+
+        cur.execute.side_effect = execute_side_effect
+
+        result = PostgresDestination().load(
+            [{"id": 1, "score": 0.95}],
+            _config(table="marketing.email_events"),
+            _options(mode="replace", on_error="fail"),
+        )
+
+        assert result.failed == 1
+        assert "bad row" in result.row_errors[0].error_message
+        conn.rollback.assert_called_once()
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_replace_on_error_skip_retruncates_after_reset_state(
+        self, mock_connect: MagicMock
+    ) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+        dest = PostgresDestination()
+
+        def execute_side_effect(sql: Any, *args: Any) -> None:
+            if "INSERT INTO" in _query_text(sql):
+                dest._replace_truncated = False
+                raise Exception("bad row")
+
+        cur.execute.side_effect = execute_side_effect
+
+        result = dest.load(
+            [{"id": 1, "score": 0.95}],
+            _config(table="marketing.email_events"),
+            _options(mode="replace", on_error="skip"),
+        )
+
+        sqls = [_query_text(c[0][0]) for c in cur.execute.call_args_list]
+        truncate_sqls = [s for s in sqls if "TRUNCATE TABLE" in s]
+        assert result.failed == 1
+        assert len(truncate_sqls) == 2
+        assert all(
+            _split_identifier_text("marketing", "email_events") in s
+            for s in truncate_sqls
+        )
 
     def test_list_passes_through(self) -> None:
         """Non-dict types (including list) must pass through unchanged."""
@@ -401,6 +553,43 @@ class TestPostgresReplaceSwap:
         assert not any(isinstance(q, str) and "RENAME TO" in q for q in queries)
         # Final DROP of old table
         assert any("DROP TABLE" in s and "__drt_old" in s for s in sqls)
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_swap_uses_schema_qualified_identifiers(
+        self, mock_connect: MagicMock
+    ) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        config = _config(table="marketing.email_events")
+        dest = PostgresDestination()
+        dest.load(
+            [{"id": 1, "score": 0.95}],
+            config,
+            _options(mode="replace", replace_strategy="swap"),
+        )
+        dest.finalize_sync(config, _options(mode="replace", replace_strategy="swap"))
+
+        sqls = [_query_text(c[0][0]) for c in cur.execute.call_args_list]
+        assert any(
+            "CREATE TABLE" in s
+            and _split_identifier_text("marketing", "email_events__drt_swap") in s
+            and _split_identifier_text("marketing", "email_events") in s
+            for s in sqls
+        )
+        assert any(
+            "ALTER TABLE" in s
+            and _split_identifier_text("marketing", "email_events") in s
+            and "Identifier('email_events__drt_old')" in s
+            for s in sqls
+        )
+        assert any(
+            "ALTER TABLE" in s
+            and _split_identifier_text("marketing", "email_events__drt_swap") in s
+            and "Identifier('email_events')" in s
+            for s in sqls
+        )
 
     @patch("drt.destinations.postgres.PostgresDestination._connect")
     def test_swap_finalize_noop_when_no_swap_in_progress(


### PR DESCRIPTION
Closes #442.

## Summary
- add helpers that split optional `schema.table` names and compose `psycopg2.sql.Identifier` with separate schema/relation parts
- use the helpers across Postgres row count, replace, swap, finalize, insert, and upsert SQL paths
- keep swap shadow/old suffixes on the relation name so `marketing.email_events` becomes `marketing.email_events__drt_swap`, not a single quoted identifier
- add regression coverage for schema-qualified upsert, replace, swap, row-count, and replace error paths

## Validation
- `uv run --extra dev --extra postgres python -m pytest tests/unit/test_postgres_destination.py tests/unit/test_dry_run_row_count.py tests/unit/test_dry_run_summary.py -v`
- `uv run --extra dev --extra postgres python -m pytest --cov=drt.destinations.postgres --cov-report=term-missing tests/unit/test_postgres_destination.py`
- `uv run --extra dev --extra postgres ruff check drt/destinations/postgres.py tests/unit/test_postgres_destination.py`
- `uv run --extra dev --extra postgres mypy drt/destinations/postgres.py`
- `git diff --check`