### PR TITLE
feat: warn on hardcoded sync secrets

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -19,6 +19,7 @@ import typer
 if TYPE_CHECKING:
     from drt.config.credentials import ProfileConfig
     from drt.config.models import SyncConfig
+    from drt.config.secrets import SecretFinding
     from drt.destinations.base import Destination
     from drt.sources.base import Source
     from drt.state.history import HistoryManager
@@ -736,21 +737,27 @@ def validate(
         False, "--check-connection", help="Test connectivity to SQL destinations."
     ),
     output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
+    strict: bool = typer.Option(False, "--strict", help="Treat warnings as validation errors."),
 ) -> None:
     """Validate sync definitions against the JSON Schema."""
 
     from drt.config.parser import load_syncs_safe
     from drt.config.schema import write_schemas
+    from drt.config.secrets import find_hardcoded_secrets
 
     result = load_syncs_safe(Path("."))
+    secret_findings = find_hardcoded_secrets(Path("."))
 
     if select:
         result.syncs = [s for s in result.syncs if s.name == select]
         result.errors = {k: v for k, v in result.errors.items() if k == select}
         result.deprecations = {k: v for k, v in result.deprecations.items() if k == select}
+        secret_findings = [finding for finding in secret_findings if finding.sync_name == select]
         if not result.syncs and not result.errors:
             print_error(f"No sync named '{select}' found.")
             raise typer.Exit(1)
+
+    secret_warnings_by_sync = _group_secret_findings(secret_findings)
 
     if output == "json":
         # Collect all deprecations into a flat list for JSON output
@@ -764,13 +771,30 @@ def validate(
                 "name": s.name,
                 "valid": True,
                 "deprecations": result.deprecations.get(s.name, []),
+                "warnings": [
+                    finding.to_dict() for finding in secret_warnings_by_sync.get(s.name, [])
+                ],
             }
+            if strict and entry["warnings"]:
+                entry["valid"] = False
+                entry["errors"] = [
+                    finding.message for finding in secret_warnings_by_sync.get(s.name, [])
+                ]
             if check_connection:
                 entry["connection_test"] = _run_connection_test(s)
             results_json.append(entry)
         
         for name, errs in result.errors.items():
-            results_json.append({"name": name, "valid": False, "errors": errs})
+            results_json.append(
+                {
+                    "name": name,
+                    "valid": False,
+                    "errors": errs,
+                    "warnings": [
+                        finding.to_dict() for finding in secret_warnings_by_sync.get(name, [])
+                    ],
+                }
+            )
 
         print(
             json.dumps(
@@ -778,7 +802,7 @@ def validate(
                 indent=2,
             )
         )
-        if result.errors:
+        if result.errors or (strict and secret_findings):
             raise typer.Exit(code=1)
         return
 
@@ -787,6 +811,8 @@ def validate(
         return
 
     for sync in result.syncs:
+        if strict and sync.name in secret_warnings_by_sync:
+            continue
         print_validation_ok(sync.name)
         # Print deprecation warnings for this sync
         if sync.name in result.deprecations:
@@ -798,6 +824,9 @@ def validate(
                 console.print(f"       Use {deprecation['replacement']} instead.")
                 if deprecation["docs_link"]:
                     console.print(f"       See {deprecation['docs_link']}")
+
+        for finding in secret_warnings_by_sync.get(sync.name, []):
+            console.print(f"  [yellow]WARNING[/yellow] {finding.message}")
 
         if check_connection:
             from drt.cli.output import print_connection_test_result
@@ -811,7 +840,11 @@ def validate(
     for name, errors in result.errors.items():
         print_validation_error(name, errors)
 
-    if result.errors:
+    if strict:
+        for name, findings in secret_warnings_by_sync.items():
+            print_validation_error(name, [finding.message for finding in findings])
+
+    if result.errors or (strict and secret_findings):
         raise typer.Exit(code=1)
 
     if emit_schema:
@@ -820,6 +853,15 @@ def validate(
         console.print(f"\n[dim]Schemas written to {schema_dir}/[/dim]")
         for p in written:
             console.print(f"  {p}")
+
+
+def _group_secret_findings(
+    findings: list[SecretFinding],
+) -> dict[str, list[SecretFinding]]:
+    grouped: dict[str, list[SecretFinding]] = {}
+    for finding in findings:
+        grouped.setdefault(finding.sync_name, []).append(finding)
+    return grouped
 
 
 def _run_connection_test(sync: SyncConfig) -> dict[str, Any]:

--- a/drt/config/secrets.py
+++ b/drt/config/secrets.py
@@ -1,0 +1,152 @@
+"""Hardcoded secret detection for project YAML files."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_SECRET_FIELD_SUFFIXES = ("_key", "_token", "_password", "_secret")
+_NON_SECRET_SUFFIXES = ("_env", "_path")
+_KNOWN_SECRET_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("OpenAI-style token", re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b")),
+    ("Slack token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{16,}\b")),
+    ("Google API key", re.compile(r"\bAIza[A-Za-z0-9_-]{20,}\b")),
+    ("GitHub token", re.compile(r"\bgh[opsru]_[A-Za-z0-9_]{20,}\b")),
+    ("AWS access key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    ("Stripe live secret key", re.compile(r"\bsk_live_[A-Za-z0-9]{16,}\b")),
+)
+_MIN_ENTROPY_SECRET_LENGTH = 20
+_SHANNON_ENTROPY_THRESHOLD = 3.5
+
+
+@dataclass(frozen=True)
+class SecretFinding:
+    """A likely hardcoded secret in a sync YAML file."""
+
+    sync_name: str
+    file: str
+    path: str
+    reason: str
+
+    @property
+    def message(self) -> str:
+        return f"{self.path}: looks like a hardcoded secret; use ${{ENV_VAR}} instead"
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "sync": self.sync_name,
+            "file": self.file,
+            "path": self.path,
+            "reason": self.reason,
+            "message": self.message,
+        }
+
+
+def find_hardcoded_secrets(project_dir: Path = Path(".")) -> list[SecretFinding]:
+    """Return likely hardcoded secret values in ``syncs/*.yml`` files.
+
+    The scanner reads raw YAML before environment expansion so ``${ENV_VAR}``
+    references are treated as safe even when the environment value is secret.
+    """
+    syncs_dir = project_dir / "syncs"
+    if not syncs_dir.exists():
+        return []
+
+    findings: list[SecretFinding] = []
+    for path in sorted(syncs_dir.glob("*.yml")):
+        try:
+            with path.open() as f:
+                data = yaml.safe_load(f)
+        except yaml.YAMLError:
+            continue
+        if not isinstance(data, dict):
+            continue
+        sync_name = str(data.get("name") or path.stem)
+        findings.extend(_find_in_value(data, sync_name, path.name, ()))
+    return findings
+
+
+def _find_in_value(
+    value: Any,
+    sync_name: str,
+    filename: str,
+    path_parts: tuple[str, ...],
+) -> list[SecretFinding]:
+    if isinstance(value, dict):
+        findings: list[SecretFinding] = []
+        for key, child in value.items():
+            key_str = str(key)
+            child_path = (*path_parts, key_str)
+            if _is_secret_field(key_str) and isinstance(child, str):
+                reason = _secret_reason(child)
+                if reason is not None:
+                    findings.append(
+                        SecretFinding(
+                            sync_name=sync_name,
+                            file=filename,
+                            path=".".join(child_path),
+                            reason=reason,
+                        )
+                    )
+            findings.extend(_find_in_value(child, sync_name, filename, child_path))
+        return findings
+
+    if isinstance(value, list):
+        findings = []
+        for index, child in enumerate(value):
+            findings.extend(
+                _find_in_value(child, sync_name, filename, (*path_parts, f"[{index}]"))
+            )
+        return findings
+
+    return []
+
+
+def _is_secret_field(field_name: str) -> bool:
+    lower = field_name.lower()
+    if lower.endswith(_NON_SECRET_SUFFIXES):
+        return False
+    return (
+        lower.startswith("api_")
+        or lower in {"password", "secret", "token", "api_key", "auth_token"}
+        or lower.endswith(_SECRET_FIELD_SUFFIXES)
+    )
+
+
+def _secret_reason(value: str) -> str | None:
+    if "${" in value:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+
+    for name, pattern in _KNOWN_SECRET_PATTERNS:
+        if pattern.search(stripped):
+            return name
+
+    if _looks_high_entropy(stripped):
+        return f"high entropy ({_shannon_entropy(stripped):.2f})"
+
+    return None
+
+
+def _looks_high_entropy(value: str) -> bool:
+    if len(value) < _MIN_ENTROPY_SECRET_LENGTH:
+        return False
+    if any(char.isspace() for char in value):
+        return False
+    return _shannon_entropy(value) >= _SHANNON_ENTROPY_THRESHOLD
+
+
+def _shannon_entropy(value: str) -> float:
+    if not value:
+        return 0.0
+    counts = Counter(value)
+    length = len(value)
+    return -sum((count / length) * math.log2(count / length) for count in counts.values())

--- a/tests/unit/test_cli_validate.py
+++ b/tests/unit/test_cli_validate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -191,3 +192,88 @@ def test_cli_validate_error_shows_field_path(
     result = runner.invoke(app, ["validate"])
     assert "destination" in result.output
     assert result.exit_code == 1
+
+
+def test_cli_validate_warns_on_hardcoded_secret(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sync = {
+        **VALID_SYNC,
+        "destination": {
+            **VALID_SYNC["destination"],
+            "auth": {"type": "bearer", "token": "sk-" + "a" * 32},
+        },
+    }
+    _write_sync(tmp_path / "syncs", "secret", sync)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["validate"])
+
+    assert result.exit_code == 0
+    assert "WARNING" in result.output
+    assert "destination.auth.token" in result.output
+    assert "hardcoded secret" in result.output
+
+
+def test_cli_validate_does_not_warn_on_env_secret_reference(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("API_TOKEN", "sk-" + "b" * 32)
+    sync = {
+        **VALID_SYNC,
+        "destination": {
+            **VALID_SYNC["destination"],
+            "auth": {"type": "bearer", "token": "${API_TOKEN}"},
+        },
+    }
+    _write_sync(tmp_path / "syncs", "env-secret", sync)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["validate"])
+
+    assert result.exit_code == 0
+    assert "WARNING" not in result.output
+    assert "hardcoded secret" not in result.output
+
+
+def test_cli_validate_strict_promotes_secret_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sync = {
+        **VALID_SYNC,
+        "destination": {
+            **VALID_SYNC["destination"],
+            "auth": {"type": "bearer", "token": "sk-" + "c" * 32},
+        },
+    }
+    _write_sync(tmp_path / "syncs", "secret", sync)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["validate", "--strict"])
+
+    assert result.exit_code == 1
+    assert "✗" in result.output
+    assert "destination.auth.token" in result.output
+    assert "hardcoded secret" in result.output
+
+
+def test_cli_validate_json_includes_secret_warnings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sync = {
+        **VALID_SYNC,
+        "destination": {
+            **VALID_SYNC["destination"],
+            "auth": {"type": "bearer", "token": "sk-" + "d" * 32},
+        },
+    }
+    _write_sync(tmp_path / "syncs", "secret", sync)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["validate", "--output", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    warning = payload["results"][0]["warnings"][0]
+    assert warning["path"] == "destination.auth.token"
+    assert "hardcoded secret" in warning["message"]

--- a/tests/unit/test_config_secrets.py
+++ b/tests/unit/test_config_secrets.py
@@ -1,0 +1,79 @@
+"""Tests for hardcoded secret detection helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from drt.config.secrets import (
+    _looks_high_entropy,
+    _secret_reason,
+    _shannon_entropy,
+    find_hardcoded_secrets,
+)
+
+
+def test_find_hardcoded_secrets_skips_bad_and_non_mapping_yaml(tmp_path: Path) -> None:
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    (syncs_dir / "bad.yml").write_text("name: [")
+    (syncs_dir / "scalar.yml").write_text("just-a-string")
+
+    assert find_hardcoded_secrets(tmp_path) == []
+
+
+def test_find_hardcoded_secrets_recurses_lists_and_uses_filename_fallback(
+    tmp_path: Path,
+) -> None:
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    (syncs_dir / "nested.yml").write_text(
+        "\n".join(
+            [
+                "destination:",
+                "  credentials:",
+                "    - api_key: sk-" + "A" * 32,
+            ]
+        )
+    )
+
+    findings = find_hardcoded_secrets(tmp_path)
+
+    assert len(findings) == 1
+    assert findings[0].sync_name == "nested"
+    assert findings[0].file == "nested.yml"
+    assert findings[0].path == "destination.credentials.[0].api_key"
+    assert findings[0].reason == "OpenAI-style token"
+
+
+def test_find_hardcoded_secrets_ignores_env_and_path_suffixes(tmp_path: Path) -> None:
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    (syncs_dir / "safe.yml").write_text(
+        "\n".join(
+            [
+                "name: safe",
+                "destination:",
+                "  token_env: sk-" + "B" * 32,
+                "  password_path: /run/secrets/db-password",
+            ]
+        )
+    )
+
+    assert find_hardcoded_secrets(tmp_path) == []
+
+
+def test_secret_reason_uses_entropy_and_ignores_blank_values() -> None:
+    assert _secret_reason("   ") is None
+    assert _secret_reason("abc123abc123") is None
+    assert _secret_reason("abc def ghi jkl mno pqr stu") is None
+
+    reason = _secret_reason("A1b2C3d4E5f6G7h8I9j0K1l2M3n4")
+
+    assert reason is not None
+    assert reason.startswith("high entropy")
+
+
+def test_entropy_helpers_cover_boundary_cases() -> None:
+    assert _shannon_entropy("") == 0.0
+    assert not _looks_high_entropy("short-token")
+    assert not _looks_high_entropy("long token with whitespace value")


### PR DESCRIPTION
## Summary

- Add a raw-YAML hardcoded secret scanner for `syncs/*.yml` with known token patterns and a Shannon entropy fallback.
- Wire findings into `drt validate` as warnings while keeping the default exit code at 0.
- Add `drt validate --strict` to promote warnings to validation errors, and include warning details in JSON output.

Closes #424

## Validation

- `uv run pytest tests/unit/test_cli_validate.py -v`
- `uv run pytest tests/unit/test_deprecations.py tests/unit/test_cli_validate.py -v`
- `uv run ruff check drt/config/secrets.py drt/cli/main.py tests/unit/test_cli_validate.py`
- `uv run mypy drt/config/secrets.py drt/cli/main.py`
- `git diff --check`
- `uv run drt validate --help`
- Manual sample: hardcoded `destination.auth.token` warns with exit 0, and `--strict` reports the same finding as an error with exit 1.
