### PR TITLE
feat: add Zendesk destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 | Discord Webhook         | ✅ v0.4.2 | (core)                             | Webhook URL                       |
 | GitHub Actions          | ✅ v0.1   | (core)                             | Token (env var)                   |
 | HubSpot                 | ✅ v0.1   | (core)                             | Token (env var)                   |
+| Zendesk                 | ✅ v0.7   | (core)                             | Basic (email + API token)         |
 | Google Ads              | ✅ v0.6   | (core)                             | OAuth2 Client Credentials         |
 | Google Sheets           | ✅ v0.4   | `pip install drt-core[sheets]`     | Service Account Keyfile           |
 | PostgreSQL (upsert)     | ✅ v0.4   | `pip install drt-core[postgres]`   | Password (env var)                |

--- a/docs/connectors/zendesk.md
+++ b/docs/connectors/zendesk.md
@@ -1,0 +1,100 @@
+# Zendesk Destination
+
+> Upsert users or organizations into Zendesk Support.
+
+## YAML Example
+
+```yaml
+destination:
+  type: zendesk
+  subdomain_env: ZENDESK_SUBDOMAIN
+  email_env: ZENDESK_EMAIL
+  api_token_env: ZENDESK_API_TOKEN
+  object: user
+  id_field: zendesk_user_id
+  custom_fields_template: |
+    {
+      "health_score": "{{ row.health_score }}",
+      "plan": "{{ row.plan }}"
+    }
+```
+
+## Configuration
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `type` | `"zendesk"` | - | Required |
+| `subdomain` | string \| null | null | Zendesk subdomain, such as `acme` for `acme.zendesk.com` |
+| `subdomain_env` | string \| null | null | Env var containing the subdomain |
+| `email` | string \| null | null | Zendesk user email |
+| `email_env` | string \| null | null | Env var containing the Zendesk user email |
+| `api_token` | string \| null | null | Zendesk API token |
+| `api_token_env` | string \| null | null | Env var containing the API token |
+| `object` | `user\|organization` | `user` | Zendesk object type to upsert |
+| `id_field` | string \| null | null | Source row field containing a Zendesk `id` |
+| `custom_fields_template` | string \| null | null | Jinja2 template that renders a JSON object of custom fields |
+| `retry` | RetryConfig \| null | null | Destination-level retry override |
+
+## Authentication
+
+Create an API token in Zendesk, then set:
+
+```bash
+export ZENDESK_SUBDOMAIN="acme"
+export ZENDESK_EMAIL="admin@example.com"
+export ZENDESK_API_TOKEN="..."
+```
+
+## Common Patterns
+
+**Upsert users by email or external ID:**
+
+```yaml
+destination:
+  type: zendesk
+  subdomain_env: ZENDESK_SUBDOMAIN
+  email_env: ZENDESK_EMAIL
+  api_token_env: ZENDESK_API_TOKEN
+  object: user
+```
+
+Rows are sent as Zendesk user objects. Include `email`, `external_id`, `name`, `tags`, `phone`, or any other Zendesk user fields in the source query.
+
+**Map a warehouse ID column to Zendesk `id`:**
+
+```yaml
+destination:
+  type: zendesk
+  subdomain_env: ZENDESK_SUBDOMAIN
+  email_env: ZENDESK_EMAIL
+  api_token_env: ZENDESK_API_TOKEN
+  object: organization
+  id_field: zendesk_organization_id
+```
+
+The source-only `zendesk_organization_id` column is copied to Zendesk `id` and removed from the outgoing payload.
+
+**Custom user fields:**
+
+```yaml
+destination:
+  type: zendesk
+  subdomain_env: ZENDESK_SUBDOMAIN
+  email_env: ZENDESK_EMAIL
+  api_token_env: ZENDESK_API_TOKEN
+  object: user
+  custom_fields_template: |
+    {
+      "plan_tier": "{{ row.plan }}",
+      "health_score": "{{ row.health_score }}"
+    }
+```
+
+For users, custom fields are attached as `user_fields`. For organizations, they are attached as `organization_fields`.
+
+## Notes
+
+- User upserts use Zendesk's `users/create_or_update_many` endpoint in batches of 100.
+- Organization upserts use Zendesk's `organizations/create_or_update` endpoint per row.
+- drt caps the default request rate at 11 requests per second, below Zendesk's common 700 requests/minute account limit.
+- `custom_fields_template` must render a JSON object.

--- a/docs/guides/comparison.md
+++ b/docs/guides/comparison.md
@@ -85,7 +85,7 @@ drt currently supports:
 
 **Sources (10):** BigQuery, DuckDB, PostgreSQL, Snowflake, SQLite, Redshift, ClickHouse, MySQL, Databricks, SQL Server
 
-**Destinations (22):** REST API, Slack, Discord, Teams, GitHub Actions, HubSpot, Google Sheets, PostgreSQL, MySQL, ClickHouse, Parquet, CSV/JSON/JSONL, Jira, Linear, SendGrid, Notion, Twilio SMS, Intercom, Email SMTP, Salesforce Bulk API, Google Ads, Staged Upload
+**Destinations (23):** REST API, Slack, Discord, Teams, GitHub Actions, HubSpot, Zendesk, Google Sheets, PostgreSQL, MySQL, ClickHouse, Parquet, CSV/JSON/JSONL, Jira, Linear, SendGrid, Notion, Twilio SMS, Intercom, Email SMTP, Salesforce Bulk API, Google Ads, Staged Upload
 
 **Integrations:** Dagster (`dagster-drt`), Airflow (built-in), Prefect (built-in), dbt manifest reader
 

--- a/docs/guides/retry.md
+++ b/docs/guides/retry.md
@@ -50,7 +50,7 @@ sync:
     max_attempts: 3
 ```
 
-Supported on every HTTP destination: `discord`, `github_actions`, `google_ads`, `hubspot`, `intercom`, `jira`, `linear`, `notion`, `rest_api`, `sendgrid`, `slack`, `teams`, `twilio`.
+Supported on every HTTP destination: `discord`, `github_actions`, `google_ads`, `hubspot`, `intercom`, `jira`, `linear`, `notion`, `rest_api`, `sendgrid`, `slack`, `teams`, `twilio`, `zendesk`.
 
 ## When retry happens
 

--- a/docs/llm/API_REFERENCE.md
+++ b/docs/llm/API_REFERENCE.md
@@ -276,6 +276,25 @@ destination:
     token_env: HUBSPOT_TOKEN      # Private App token with CRM write scope
 ```
 
+### `type: zendesk`
+
+```yaml
+destination:
+  type: zendesk
+  subdomain_env: ZENDESK_SUBDOMAIN       # e.g. "acme" for acme.zendesk.com
+  email_env: ZENDESK_EMAIL               # Zendesk user email
+  api_token_env: ZENDESK_API_TOKEN       # Zendesk API token
+  object: user                           # "user" (default) | "organization"
+  id_field: zendesk_user_id              # optional: source field copied to Zendesk id
+  custom_fields_template: |              # optional: JSON object for custom fields
+    {
+      "health_score": "{{ row.health_score }}",
+      "plan": "{{ row.plan }}"
+    }
+```
+
+> Users are upserted through `users/create_or_update_many` in 100-record batches. Organizations use `organizations/create_or_update` per row. Custom fields are sent as `user_fields` or `organization_fields`.
+
 ### `type: jira`
 
 ```yaml

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -84,6 +84,7 @@ default:
 | Microsoft Teams | `teams` | Incoming Webhook, Adaptive Card support |
 | GitHub Actions | `github_actions` | workflow_dispatch trigger |
 | HubSpot CRM | `hubspot` | Contacts / Deals / Companies upsert |
+| Zendesk | `zendesk` | Users / organizations upsert |
 | Google Sheets | `google_sheets` | Overwrite or append. Requires `drt-core[sheets]` |
 | PostgreSQL (upsert) | `postgres` | INSERT ... ON CONFLICT DO UPDATE. Requires `drt-core[postgres]` |
 | MySQL (upsert) | `mysql` | INSERT ... ON DUPLICATE KEY UPDATE. Requires `drt-core[mysql]` |

--- a/drt/config/connectors.py
+++ b/drt/config/connectors.py
@@ -43,4 +43,5 @@ DESTINATIONS = [
     ("staged_upload", "Staged Upload"),
     ("teams", "Microsoft Teams"),
     ("twilio", "Twilio"),
+    ("zendesk", "Zendesk"),
 ]

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -234,6 +234,23 @@ class HubSpotDestinationConfig(BaseModel):
         return f"{self.type} ({self.object_type})"
 
 
+class ZendeskDestinationConfig(BaseModel):
+    type: Literal["zendesk"]
+    subdomain: str | None = None
+    subdomain_env: str | None = None
+    email: str | None = None
+    email_env: str | None = None
+    api_token: str | None = None
+    api_token_env: str | None = None
+    object: Literal["user", "organization"] = "user"
+    id_field: str | None = None
+    custom_fields_template: str | None = None
+    retry: RetryConfig | None = None  # destination-level override of sync.retry
+
+    def describe(self) -> str:
+        return f"{self.type} ({self.object})"
+
+
 class IntercomDestinationConfig(BaseModel):
     type: Literal["intercom"]
 
@@ -621,6 +638,7 @@ DestinationConfig = Annotated[
     | DiscordDestinationConfig
     | GitHubActionsDestinationConfig
     | HubSpotDestinationConfig
+    | ZendeskDestinationConfig
     | SendGridDestinationConfig
     | LinearDestinationConfig
     | GoogleSheetsDestinationConfig

--- a/drt/connectors/registry.py
+++ b/drt/connectors/registry.py
@@ -163,6 +163,7 @@ def _register_all_connectors() -> None:
         StagedUploadDestinationConfig,
         TeamsDestinationConfig,
         TwilioDestinationConfig,
+        ZendeskDestinationConfig,
     )
 
     # Import destination classes
@@ -189,6 +190,7 @@ def _register_all_connectors() -> None:
     from drt.destinations.staged_upload import StagedUploadDestination
     from drt.destinations.teams import TeamsDestination
     from drt.destinations.twilio import TwilioDestination
+    from drt.destinations.zendesk import ZendeskDestination
 
     # Import source classes
     from drt.sources.bigquery import BigQuerySource
@@ -209,6 +211,7 @@ def _register_all_connectors() -> None:
     register_destination("discord", DiscordDestinationConfig, DiscordDestination)
     register_destination("github_actions", GitHubActionsDestinationConfig, GitHubActionsDestination)
     register_destination("hubspot", HubSpotDestinationConfig, HubSpotDestination)
+    register_destination("zendesk", ZendeskDestinationConfig, ZendeskDestination)
     register_destination("jira", JiraDestinationConfig, JiraDestination)
     register_destination("sendgrid", SendGridDestinationConfig, SendGridDestination)
     register_destination("google_sheets", GoogleSheetsDestinationConfig, GoogleSheetsDestination)

--- a/drt/destinations/zendesk.py
+++ b/drt/destinations/zendesk.py
@@ -1,0 +1,326 @@
+"""Zendesk destination — users and organizations upsert.
+
+Syncs rows into Zendesk Support through the Ticketing API.
+
+Example sync YAML — users:
+
+    destination:
+      type: zendesk
+      subdomain_env: ZENDESK_SUBDOMAIN
+      email_env: ZENDESK_EMAIL
+      api_token_env: ZENDESK_API_TOKEN
+      object: user
+      id_field: zendesk_user_id
+      custom_fields_template: |
+        {
+          "health_score": "{{ row.health_score }}",
+          "plan": "{{ row.plan }}"
+        }
+
+Example sync YAML — organizations:
+
+    destination:
+      type: zendesk
+      subdomain: example
+      email_env: ZENDESK_EMAIL
+      api_token_env: ZENDESK_API_TOKEN
+      object: organization
+      id_field: zendesk_organization_id
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+
+import httpx
+
+from drt.config.credentials import resolve_env
+from drt.config.models import DestinationConfig, RetryConfig, SyncOptions, ZendeskDestinationConfig
+from drt.destinations.base import SyncResult
+from drt.destinations.rate_limiter import RateLimiter
+from drt.destinations.retry import resolve_retry, with_retry
+from drt.destinations.row_errors import RowError
+from drt.templates.renderer import render_template
+
+_ZENDESK_API_TEMPLATE = "https://{subdomain}.zendesk.com/api/v2"
+_ZENDESK_MAX_USER_BATCH_SIZE = 100
+_ZENDESK_MAX_REQUESTS_PER_SECOND = 11
+_USER_CUSTOM_FIELDS_KEY = "user_fields"
+_ORGANIZATION_CUSTOM_FIELDS_KEY = "organization_fields"
+_CANONICAL_ID_FIELDS = {"id", "external_id"}
+
+
+class ZendeskDestination:
+    """Upsert Zendesk users or organizations from sync records."""
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, ZendeskDestinationConfig)
+
+        credentials = _resolve_credentials(config)
+        base_url = _base_url(credentials["subdomain"])
+        auth = httpx.BasicAuth(
+            username=f"{credentials['email']}/token",
+            password=credentials["api_token"],
+        )
+        headers = {"Content-Type": "application/json"}
+        retry_config = resolve_retry(config.retry, sync_options)
+        rate_limiter = RateLimiter(
+            min(sync_options.rate_limit.requests_per_second, _ZENDESK_MAX_REQUESTS_PER_SECOND)
+        )
+        result = SyncResult()
+
+        with httpx.Client(timeout=30.0) as client:
+            if config.object == "user":
+                self._load_users(
+                    records,
+                    client=client,
+                    config=config,
+                    sync_options=sync_options,
+                    base_url=base_url,
+                    auth=auth,
+                    headers=headers,
+                    rate_limiter=rate_limiter,
+                    result=result,
+                    retry_config=retry_config,
+                )
+            else:
+                self._load_organizations(
+                    records,
+                    client=client,
+                    config=config,
+                    sync_options=sync_options,
+                    base_url=base_url,
+                    auth=auth,
+                    headers=headers,
+                    rate_limiter=rate_limiter,
+                    result=result,
+                    retry_config=retry_config,
+                )
+
+        return result
+
+    def _load_users(
+        self,
+        records: list[dict[str, Any]],
+        *,
+        client: httpx.Client,
+        config: ZendeskDestinationConfig,
+        sync_options: SyncOptions,
+        base_url: str,
+        auth: httpx.BasicAuth,
+        headers: dict[str, str],
+        rate_limiter: RateLimiter,
+        result: SyncResult,
+        retry_config: RetryConfig,
+    ) -> None:
+        indexed_payloads: list[tuple[int, dict[str, Any], dict[str, Any]]] = []
+        for index, record in enumerate(records):
+            try:
+                payload = _build_zendesk_object(record, config, _USER_CUSTOM_FIELDS_KEY)
+                indexed_payloads.append((index, record, payload))
+            except Exception as exc:
+                _add_row_error(result, index, record, None, str(exc))
+                if sync_options.on_error == "fail":
+                    return
+
+        url = f"{base_url}/users/create_or_update_many.json"
+        for chunk in _chunks(indexed_payloads, _ZENDESK_MAX_USER_BATCH_SIZE):
+            users = [payload for _, _, payload in chunk]
+
+            def do_post() -> httpx.Response:
+                response = client.post(
+                    url,
+                    json={"users": users},
+                    auth=auth,
+                    headers=headers,
+                )
+                response.raise_for_status()
+                return response
+
+            try:
+                rate_limiter.acquire()
+                with_retry(do_post, retry_config)
+                result.success += len(chunk)
+            except httpx.HTTPStatusError as exc:
+                for index, record, _ in chunk:
+                    _add_row_error(
+                        result,
+                        index,
+                        record,
+                        exc.response.status_code,
+                        exc.response.text[:500],
+                    )
+                if sync_options.on_error == "fail":
+                    break
+            except Exception as exc:
+                for index, record, _ in chunk:
+                    _add_row_error(result, index, record, None, str(exc))
+                if sync_options.on_error == "fail":
+                    break
+
+    def _load_organizations(
+        self,
+        records: list[dict[str, Any]],
+        *,
+        client: httpx.Client,
+        config: ZendeskDestinationConfig,
+        sync_options: SyncOptions,
+        base_url: str,
+        auth: httpx.BasicAuth,
+        headers: dict[str, str],
+        rate_limiter: RateLimiter,
+        result: SyncResult,
+        retry_config: RetryConfig,
+    ) -> None:
+        url = f"{base_url}/organizations/create_or_update.json"
+        for index, record in enumerate(records):
+            try:
+                organization = _build_zendesk_object(
+                    record,
+                    config,
+                    _ORGANIZATION_CUSTOM_FIELDS_KEY,
+                )
+            except Exception as exc:
+                _add_row_error(result, index, record, None, str(exc))
+                if sync_options.on_error == "fail":
+                    break
+                continue
+
+            def do_post() -> httpx.Response:
+                response = client.post(
+                    url,
+                    json={"organization": organization},
+                    auth=auth,
+                    headers=headers,
+                )
+                response.raise_for_status()
+                return response
+
+            try:
+                rate_limiter.acquire()
+                with_retry(do_post, retry_config)
+                result.success += 1
+            except httpx.HTTPStatusError as exc:
+                _add_row_error(
+                    result,
+                    index,
+                    record,
+                    exc.response.status_code,
+                    exc.response.text[:500],
+                )
+                if sync_options.on_error == "fail":
+                    break
+            except Exception as exc:
+                _add_row_error(result, index, record, None, str(exc))
+                if sync_options.on_error == "fail":
+                    break
+
+
+def _resolve_credentials(config: ZendeskDestinationConfig) -> dict[str, str]:
+    subdomain = resolve_env(config.subdomain, config.subdomain_env)
+    email = resolve_env(config.email, config.email_env)
+    api_token = resolve_env(config.api_token, config.api_token_env)
+    missing = []
+    if not subdomain:
+        missing.append("ZENDESK_SUBDOMAIN")
+    if not email:
+        missing.append("ZENDESK_EMAIL")
+    if not api_token:
+        missing.append("ZENDESK_API_TOKEN")
+    if missing:
+        raise ValueError(
+            "Zendesk destination: provide subdomain/email/api_token "
+            f"or set env vars: {', '.join(missing)}."
+        )
+    assert subdomain is not None
+    assert email is not None
+    assert api_token is not None
+    return {
+        "subdomain": subdomain,
+        "email": email,
+        "api_token": api_token,
+    }
+
+
+def _base_url(subdomain: str) -> str:
+    return _ZENDESK_API_TEMPLATE.format(subdomain=subdomain).rstrip("/")
+
+
+def _build_zendesk_object(
+    record: dict[str, Any],
+    config: ZendeskDestinationConfig,
+    custom_fields_key: str,
+) -> dict[str, Any]:
+    payload = dict(record)
+    if config.id_field:
+        id_value = record.get(config.id_field)
+        should_copy_to_id = (
+            _has_value(id_value)
+            and "id" not in payload
+            and config.id_field not in _CANONICAL_ID_FIELDS
+        )
+        if should_copy_to_id:
+            payload["id"] = id_value
+        if config.id_field not in _CANONICAL_ID_FIELDS:
+            payload.pop(config.id_field, None)
+
+    custom_fields = _render_custom_fields(config, record)
+    if custom_fields:
+        existing = payload.get(custom_fields_key)
+        if isinstance(existing, dict):
+            payload[custom_fields_key] = {**existing, **custom_fields}
+        else:
+            payload[custom_fields_key] = custom_fields
+
+    return payload
+
+
+def _render_custom_fields(
+    config: ZendeskDestinationConfig,
+    record: dict[str, Any],
+) -> dict[str, Any]:
+    if not config.custom_fields_template:
+        return {}
+
+    rendered = render_template(config.custom_fields_template, record)
+    data = json.loads(rendered)
+    if not isinstance(data, dict):
+        raise ValueError("custom_fields_template must render a JSON object.")
+    return data
+
+
+def _has_value(value: Any) -> bool:
+    return value is not None and str(value).strip() != ""
+
+
+def _chunks(
+    records: list[tuple[int, dict[str, Any], dict[str, Any]]],
+    size: int,
+) -> Iterator[list[tuple[int, dict[str, Any], dict[str, Any]]]]:
+    for start in range(0, len(records), size):
+        yield records[start : start + size]
+
+
+def _add_row_error(
+    result: SyncResult,
+    index: int,
+    record: dict[str, Any],
+    http_status: int | None,
+    message: str,
+) -> None:
+    result.failed += 1
+    result.row_errors.append(
+        RowError(
+            batch_index=index,
+            record_preview=json.dumps(record, default=str)[:200],
+            http_status=http_status,
+            error_message=message,
+        )
+    )

--- a/drt/destinations/zendesk.py
+++ b/drt/destinations/zendesk.py
@@ -134,10 +134,10 @@ class ZendeskDestination:
         for chunk in _chunks(indexed_payloads, _ZENDESK_MAX_USER_BATCH_SIZE):
             users = [payload for _, _, payload in chunk]
 
-            def do_post() -> httpx.Response:
+            def do_post(_users: list[dict[str, Any]] = users) -> httpx.Response:
                 response = client.post(
                     url,
-                    json={"users": users},
+                    json={"users": _users},
                     auth=auth,
                     headers=headers,
                 )
@@ -193,10 +193,10 @@ class ZendeskDestination:
                     break
                 continue
 
-            def do_post() -> httpx.Response:
+            def do_post(_organization: dict[str, Any] = organization) -> httpx.Response:
                 response = client.post(
                     url,
-                    json={"organization": organization},
+                    json={"organization": _organization},
                     auth=auth,
                     headers=headers,
                 )
@@ -243,7 +243,7 @@ def _resolve_credentials(config: ZendeskDestinationConfig) -> dict[str, str]:
     assert email is not None
     assert api_token is not None
     return {
-        "subdomain": subdomain,
+        "subdomain": subdomain.strip(),
         "email": email,
         "api_token": api_token,
     }

--- a/drt/mcp/server.py
+++ b/drt/mcp/server.py
@@ -261,6 +261,7 @@ def create_server(project_dir: Path | None = None) -> Any:
                 {"name": "Microsoft Teams", "type": "teams", "install": "(core)"},
                 {"name": "GitHub Actions", "type": "github_actions", "install": "(core)"},
                 {"name": "HubSpot", "type": "hubspot", "install": "(core)"},
+                {"name": "Zendesk", "type": "zendesk", "install": "(core)"},
                 {"name": "Google Sheets", "type": "google_sheets", "install": "drt-core[sheets]"},
                 {"name": "PostgreSQL", "type": "postgres", "install": "drt-core[postgres]"},
                 {"name": "MySQL", "type": "mysql", "install": "drt-core[mysql]"},

--- a/tests/unit/test_connector_registry.py
+++ b/tests/unit/test_connector_registry.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import pytest
 
 from drt.config.credentials import DuckDBProfile, PostgresProfile
-from drt.config.models import RestApiDestinationConfig, SlackDestinationConfig, SyncConfig
+from drt.config.models import (
+    RestApiDestinationConfig,
+    SlackDestinationConfig,
+    SyncConfig,
+    ZendeskDestinationConfig,
+)
 from drt.connectors import get_destination, get_source
 
 
@@ -31,6 +36,18 @@ class TestConnectorRegistry:
         destination = get_destination(config)
         assert destination is not None
         assert type(destination).__name__ == "RestApiDestination"
+
+    def test_get_destination_zendesk(self):
+        """Get a Zendesk destination from registry."""
+        config = ZendeskDestinationConfig(
+            type="zendesk",
+            subdomain="example",
+            email="bot@example.com",
+            api_token="token",
+        )
+        destination = get_destination(config)
+        assert destination is not None
+        assert type(destination).__name__ == "ZendeskDestination"
 
     def test_get_source_postgres(self):
         """Get a Postgres source from registry."""

--- a/tests/unit/test_describe.py
+++ b/tests/unit/test_describe.py
@@ -17,6 +17,7 @@ from drt.config.models import (
     SendGridDestinationConfig,
     SlackDestinationConfig,
     TeamsDestinationConfig,
+    ZendeskDestinationConfig,
 )
 
 ALL_DESTINATIONS = [
@@ -61,6 +62,12 @@ ALL_DESTINATIONS = [
     ClickHouseDestinationConfig(type="clickhouse", host="localhost", database="db", table="table"),
     ParquetDestinationConfig(type="parquet", path="output.parquet"),
     FileDestinationConfig(type="file", path="output.csv"),
+    ZendeskDestinationConfig(
+        type="zendesk",
+        subdomain="example",
+        email="bot@example.com",
+        api_token="token",
+    ),
 ]
 
 

--- a/tests/unit/test_destination_contract.py
+++ b/tests/unit/test_destination_contract.py
@@ -20,6 +20,7 @@ from drt.destinations.postgres import PostgresDestination
 from drt.destinations.rest_api import RestApiDestination
 from drt.destinations.slack import SlackDestination
 from drt.destinations.teams import TeamsDestination
+from drt.destinations.zendesk import ZendeskDestination
 
 ALL_DESTINATIONS = [
     ClickHouseDestination,
@@ -35,6 +36,7 @@ ALL_DESTINATIONS = [
     RestApiDestination,
     SlackDestination,
     TeamsDestination,
+    ZendeskDestination,
 ]
 
 

--- a/tests/unit/test_zendesk_destination.py
+++ b/tests/unit/test_zendesk_destination.py
@@ -1,0 +1,373 @@
+"""Unit tests for Zendesk destination."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from drt.config.models import RateLimitConfig, RetryConfig, SyncOptions, ZendeskDestinationConfig
+from drt.destinations.zendesk import ZendeskDestination
+
+
+def _config(**overrides: object) -> ZendeskDestinationConfig:
+    data: dict[str, object] = {
+        "type": "zendesk",
+        "subdomain": "demo",
+        "email": "bot@example.com",
+        "api_token": "token-123",
+    }
+    data.update(overrides)
+    return ZendeskDestinationConfig(**data)
+
+
+def _options(**overrides: object) -> SyncOptions:
+    data: dict[str, object] = {
+        "rate_limit": RateLimitConfig(requests_per_second=0),
+        "retry": RetryConfig(max_attempts=1, initial_backoff=0.0, backoff_multiplier=1.0),
+        "on_error": "skip",
+    }
+    data.update(overrides)
+    return SyncOptions(**data)
+
+
+def _response(status_code: int = 200, text: str = "{}") -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = text
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _http_error(status_code: int, text: str) -> httpx.HTTPStatusError:
+    response = httpx.Response(
+        status_code=status_code,
+        text=text,
+        request=httpx.Request("POST", "https://demo.zendesk.com/api/v2/test"),
+    )
+    return httpx.HTTPStatusError(
+        message=f"HTTP {status_code}",
+        request=response.request,
+        response=response,
+    )
+
+
+class TestZendeskDestination:
+    def test_user_bulk_upsert_success(self) -> None:
+        records = [
+            {
+                "zendesk_user_id": 101,
+                "email": "alice@example.com",
+                "name": "Alice",
+                "health_score": 91,
+                "user_fields": {"segment": "strategic"},
+            },
+            {
+                "zendesk_user_id": 102,
+                "email": "bob@example.com",
+                "name": "Bob",
+                "health_score": 82,
+            },
+        ]
+        config = _config(
+            object="user",
+            id_field="zendesk_user_id",
+            custom_fields_template='{"health_score": "{{ row.health_score }}"}',
+        )
+
+        with patch("drt.destinations.zendesk.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = _response()
+
+            result = ZendeskDestination().load(records, config, _options())
+
+        assert result.success == 2
+        assert result.failed == 0
+        mock_client.post.assert_called_once()
+        args, kwargs = mock_client.post.call_args
+        assert args[0] == "https://demo.zendesk.com/api/v2/users/create_or_update_many.json"
+        assert kwargs["json"]["users"][0]["id"] == 101
+        assert "zendesk_user_id" not in kwargs["json"]["users"][0]
+        assert kwargs["json"]["users"][0]["user_fields"] == {
+            "health_score": "91",
+            "segment": "strategic",
+        }
+
+    def test_user_bulk_splits_batches_at_zendesk_limit(self) -> None:
+        records = [
+            {"external_id": f"user-{index}", "email": f"user-{index}@example.com"}
+            for index in range(101)
+        ]
+
+        with patch("drt.destinations.zendesk.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = _response()
+
+            result = ZendeskDestination().load(records, _config(), _options())
+
+        assert result.success == 101
+        assert result.failed == 0
+        assert mock_client.post.call_count == 2
+        first_call = mock_client.post.call_args_list[0]
+        second_call = mock_client.post.call_args_list[1]
+        assert len(first_call.kwargs["json"]["users"]) == 100
+        assert len(second_call.kwargs["json"]["users"]) == 1
+
+    def test_organization_upsert_success(self) -> None:
+        record = {
+            "zendesk_organization_id": 555,
+            "name": "Acme Ltd",
+            "tier": "enterprise",
+        }
+        config = _config(
+            object="organization",
+            id_field="zendesk_organization_id",
+            custom_fields_template='{"plan_tier": "{{ row.tier }}"}',
+        )
+
+        with patch("drt.destinations.zendesk.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = _response()
+
+            result = ZendeskDestination().load([record], config, _options())
+
+        assert result.success == 1
+        assert result.failed == 0
+        args, kwargs = mock_client.post.call_args
+        assert args[0] == "https://demo.zendesk.com/api/v2/organizations/create_or_update.json"
+        organization = kwargs["json"]["organization"]
+        assert organization["id"] == 555
+        assert organization["organization_fields"] == {"plan_tier": "enterprise"}
+        assert "zendesk_organization_id" not in organization
+
+    def test_env_credentials_are_resolved(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ZENDESK_SUBDOMAIN", "envdemo")
+        monkeypatch.setenv("ZENDESK_EMAIL", "envbot@example.com")
+        monkeypatch.setenv("ZENDESK_API_TOKEN", "env-token")
+        config = _config(
+            subdomain=None,
+            email=None,
+            api_token=None,
+            subdomain_env="ZENDESK_SUBDOMAIN",
+            email_env="ZENDESK_EMAIL",
+            api_token_env="ZENDESK_API_TOKEN",
+        )
+
+        with patch("drt.destinations.zendesk.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = _response()
+
+            result = ZendeskDestination().load([{"email": "alice@example.com"}], config, _options())
+
+        assert result.success == 1
+        args, _ = mock_client.post.call_args
+        assert args[0] == "https://envdemo.zendesk.com/api/v2/users/create_or_update_many.json"
+
+    def test_missing_credentials_raise(self) -> None:
+        config = _config(subdomain=None, email=None, api_token=None)
+
+        with pytest.raises(ValueError, match="ZENDESK_SUBDOMAIN"):
+            ZendeskDestination().load([{"email": "alice@example.com"}], config, _options())
+
+    def test_custom_fields_template_error_records_row_error(self) -> None:
+        config = _config(custom_fields_template='{"missing": "{{ row.missing }}"}')
+
+        with patch("drt.destinations.zendesk.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+
+            result = ZendeskDestination().load([{"email": "alice@example.com"}], config, _options())
+
+        assert result.success == 0
+        assert result.failed == 1
+        assert "Template error" in result.row_errors[0].error_message
+        mock_client.post.assert_not_called()
+
+    def test_custom_fields_template_must_render_json_object(self) -> None:
+        config = _config(custom_fields_template='["not", "an", "object"]')
+
+        with patch("drt.destinations.zendesk.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+
+            result = ZendeskDestination().load([{"email": "alice@example.com"}], config, _options())
+
+        assert result.failed == 1
+        assert "must render a JSON object" in result.row_errors[0].error_message
+        mock_client.post.assert_not_called()
+
+    def test_user_template_error_with_on_error_fail_stops_before_post(self) -> None:
+        config = _config(custom_fields_template='{"missing": "{{ row.missing }}"}')
+
+        with patch("drt.destinations.zendesk.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+
+            result = ZendeskDestination().load(
+                [{"email": "alice@example.com"}, {"email": "bob@example.com"}],
+                config,
+                _options(on_error="fail"),
+            )
+
+        assert result.failed == 1
+        mock_client.post.assert_not_called()
+
+    def test_http_error_marks_each_row_in_failed_user_batch(self) -> None:
+        records = [
+            {"email": "alice@example.com"},
+            {"email": "bob@example.com"},
+        ]
+
+        with patch("drt.destinations.zendesk.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.side_effect = _http_error(429, "rate limited")
+
+            result = ZendeskDestination().load(records, _config(), _options())
+
+        assert result.success == 0
+        assert result.failed == 2
+        assert [error.http_status for error in result.row_errors] == [429, 429]
+
+    def test_on_error_fail_stops_after_first_user_batch(self) -> None:
+        records = [
+            {"external_id": f"user-{index}", "email": f"user-{index}@example.com"}
+            for index in range(101)
+        ]
+
+        with patch("drt.destinations.zendesk.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.side_effect = _http_error(400, "bad request")
+
+            result = ZendeskDestination().load(
+                records,
+                _config(),
+                _options(on_error="fail"),
+            )
+
+        assert result.success == 0
+        assert result.failed == 100
+        assert mock_client.post.call_count == 1
+
+    def test_generic_user_batch_error_marks_batch_failed(self) -> None:
+        records = [
+            {"external_id": f"user-{index}", "email": f"user-{index}@example.com"}
+            for index in range(101)
+        ]
+
+        with patch("drt.destinations.zendesk.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            response = _response()
+            response.raise_for_status.side_effect = RuntimeError("boom")
+            mock_client.post.return_value = response
+
+            result = ZendeskDestination().load(
+                records,
+                _config(),
+                _options(on_error="fail"),
+            )
+
+        assert result.failed == 100
+        assert mock_client.post.call_count == 1
+        assert result.row_errors[0].error_message == "boom"
+
+    def test_organization_template_error_skips_row(self) -> None:
+        config = _config(
+            object="organization",
+            custom_fields_template='{"missing": "{{ row.missing }}"}',
+        )
+
+        with patch("drt.destinations.zendesk.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+
+            result = ZendeskDestination().load(
+                [{"name": "Broken Org"}, {"name": "Also Broken"}],
+                config,
+                _options(),
+            )
+
+        assert result.failed == 2
+        mock_client.post.assert_not_called()
+
+    def test_organization_template_error_with_on_error_fail_stops(self) -> None:
+        config = _config(
+            object="organization",
+            custom_fields_template='{"missing": "{{ row.missing }}"}',
+        )
+
+        with patch("drt.destinations.zendesk.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+
+            result = ZendeskDestination().load(
+                [{"name": "Broken Org"}, {"name": "Also Broken"}],
+                config,
+                _options(on_error="fail"),
+            )
+
+        assert result.failed == 1
+        mock_client.post.assert_not_called()
+
+    def test_organization_http_error_fail_stops(self) -> None:
+        config = _config(object="organization")
+
+        with patch("drt.destinations.zendesk.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.side_effect = _http_error(400, "bad request")
+
+            result = ZendeskDestination().load(
+                [{"name": "Org 1"}, {"name": "Org 2"}],
+                config,
+                _options(on_error="fail"),
+            )
+
+        assert result.failed == 1
+        assert result.row_errors[0].http_status == 400
+        assert mock_client.post.call_count == 1
+
+    def test_organization_generic_error_fail_stops(self) -> None:
+        config = _config(object="organization")
+
+        with patch("drt.destinations.zendesk.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            response = _response()
+            response.raise_for_status.side_effect = RuntimeError("boom")
+            mock_client.post.return_value = response
+
+            result = ZendeskDestination().load(
+                [{"name": "Org 1"}, {"name": "Org 2"}],
+                config,
+                _options(on_error="fail"),
+            )
+
+        assert result.failed == 1
+        assert result.row_errors[0].error_message == "boom"
+        assert mock_client.post.call_count == 1
+
+    def test_rate_limiter_called_per_request(self) -> None:
+        records = [
+            {"external_id": f"user-{index}", "email": f"user-{index}@example.com"}
+            for index in range(101)
+        ]
+
+        with patch("drt.destinations.zendesk.RateLimiter") as mock_limiter_cls:
+            limiter = MagicMock()
+            mock_limiter_cls.return_value = limiter
+            with patch("drt.destinations.zendesk.httpx.Client") as mock_client_cls:
+                mock_client = MagicMock()
+                mock_client_cls.return_value.__enter__.return_value = mock_client
+                mock_client.post.return_value = _response()
+
+                ZendeskDestination().load(records, _config(), _options())
+
+        assert limiter.acquire.call_count == 2

--- a/tests/unit/test_zendesk_destination.py
+++ b/tests/unit/test_zendesk_destination.py
@@ -95,6 +95,28 @@ class TestZendeskDestination:
             "segment": "strategic",
         }
 
+    def test_custom_fields_template_wins_user_field_conflicts(self) -> None:
+        record = {
+            "email": "alice@example.com",
+            "plan": "enterprise",
+            "user_fields": {"plan": "legacy", "segment": "strategic"},
+        }
+        config = _config(custom_fields_template='{"plan": "{{ row.plan }}"}')
+
+        with patch("drt.destinations.zendesk.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = _response()
+
+            result = ZendeskDestination().load([record], config, _options())
+
+        assert result.success == 1
+        _, kwargs = mock_client.post.call_args
+        assert kwargs["json"]["users"][0]["user_fields"] == {
+            "plan": "enterprise",
+            "segment": "strategic",
+        }
+
     def test_user_bulk_splits_batches_at_zendesk_limit(self) -> None:
         records = [
             {"external_id": f"user-{index}", "email": f"user-{index}@example.com"}


### PR DESCRIPTION
Closes #421

## Summary
- adds a core Zendesk destination for user and organization upserts
- supports env-based Zendesk credentials, source id-field mapping, custom user/organization fields, per-destination retry, and conservative request limiting
- registers Zendesk in runtime, CLI, MCP, docs, and destination contract coverage

## Validation
- uv run pytest tests/unit/test_zendesk_destination.py tests/unit/test_connector_registry.py tests/unit/test_describe.py tests/unit/test_destination_contract.py tests/unit/test_cli_list_connectors.py -v
- uv run pytest tests/unit/test_config.py -v
- uv run pytest --cov=drt.destinations.zendesk --cov-report=term-missing tests/unit/test_zendesk_destination.py (100% new-file coverage)
- uv run ruff check drt/config/models.py drt/connectors/registry.py drt/config/connectors.py drt/mcp/server.py drt/destinations/zendesk.py tests/unit/test_zendesk_destination.py tests/unit/test_connector_registry.py tests/unit/test_describe.py tests/unit/test_destination_contract.py tests/unit/test_cli_list_connectors.py
- uv run mypy drt/destinations/zendesk.py drt/connectors/registry.py drt/config/models.py
- git diff --check
- uv run drt destinations