### PR TITLE
feat(docs): `drt docs generate --format mermaid` (P1 of #499)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ uv.lock
 .drt/
 state.json
 
+# drt docs generate output (#499)
+target/
+
 # Testing
 .pytest_cache/
 .coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Connection test in `drt validate`** (#367, PR #484): Added `--check-connection` flag to test connectivity to SQL destinations (PostgreSQL, MySQL, ClickHouse, Snowflake) before running syncs via `SELECT 1`. Reports pass/fail per sync in both text and `--output json`; non-SQL destinations are skipped gracefully. Snowflake destination internally refactored to share a `_connect()` helper between `load` and `test_connection`. Contributed by @GokulKashyap.
 - **`drt cloud status` stub command** (#491, PR #488): Companion stub to `drt cloud push`. Both commands now print a unified "drt Cloud coming soon" message via a shared `CLOUD_MESSAGE` constant. Lays groundwork for the future drt Cloud control plane. Contributed by @Photon101.
+- **`drt docs generate --format mermaid`** (epic #499, sub-issue #501): First slice of the sync catalog & lineage primitive. Renders a Mermaid `graph LR` of `source → sync → destination`, including heuristic lookup edges between syncs whose destination table is referenced by another sync's `lookups`. Pinable in README via GitHub-flavored Mermaid fence. `--format html` and `--format json` raise `NotImplementedError` pending follow-up phases (P2/P3 of #499). New package `drt/docs/` lays the foundation for `drt docs generate --format html` (Phase 3, v0.8) and `drt docs serve` (Phase 4, v0.8.x).
 
 ## [0.7.2] - 2026-05-11
 

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -1273,6 +1273,60 @@ def cloud_status() -> None:
 
 
 # ---------------------------------------------------------------------------
+# docs (epic #499 — sync catalog & lineage UI)
+# ---------------------------------------------------------------------------
+
+docs_app = typer.Typer(
+    name="docs",
+    help="Generate or serve the project's sync catalog.",
+    no_args_is_help=True,
+)
+app.add_typer(docs_app)
+
+
+@docs_app.command(name="generate")
+def docs_generate(
+    output: Path = typer.Option(
+        Path("target/docs"), "--output", "-o", help="Output directory."
+    ),
+    format: str = typer.Option(
+        "html", "--format", "-f", help="Output format: html | mermaid | json."
+    ),
+    no_state: bool = typer.Option(
+        False, "--no-state", help="Exclude per-sync run state from the manifest."
+    ),
+) -> None:
+    """Generate the project's sync catalog (Phase 1: --format mermaid only)."""
+    from drt.docs.builder import build_manifest
+    from drt.docs.mermaid import render_mermaid
+
+    fmt = format.lower()
+    if fmt == "mermaid":
+        manifest = build_manifest(Path("."))
+        print(render_mermaid(manifest))
+        return
+
+    if fmt in ("html", "json"):
+        raise NotImplementedError(
+            f"--format {fmt} is scheduled for a follow-up phase of #499. "
+            "Use --format mermaid for now."
+        )
+
+    raise typer.BadParameter(
+        f"Unknown --format value: {format!r}. Expected: html | mermaid | json."
+    )
+
+
+@docs_app.command(name="serve")
+def docs_serve() -> None:
+    """Live Web UI for the sync catalog (scheduled for v0.8.x — epic #499)."""
+    raise NotImplementedError(
+        "`drt docs serve` is scheduled for v0.8.x (Phase 4 of epic #499). "
+        "Use `drt docs generate --format mermaid` in the meantime."
+    )
+
+
+# ---------------------------------------------------------------------------
 # mcp
 # ---------------------------------------------------------------------------
 

--- a/drt/docs/builder.py
+++ b/drt/docs/builder.py
@@ -1,0 +1,110 @@
+"""Build a `Manifest` from a drt project on disk."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from drt import __version__
+from drt.config.models import SyncConfig
+from drt.config.parser import load_project, load_syncs_safe
+from drt.docs.manifest import (
+    SCHEMA_VERSION,
+    Destination,
+    Edge,
+    Manifest,
+    Source,
+    Sync,
+)
+
+_SLUG_RE = re.compile(r"[^A-Za-z0-9_]+")
+
+
+def _slug(value: str) -> str:
+    """Mermaid-safe node id."""
+    return _SLUG_RE.sub("_", value).strip("_") or "node"
+
+
+def _destination_id(sync: SyncConfig) -> str:
+    """Synthesize a stable destination node id; shared across syncs that target the same one."""
+    dest = sync.destination
+    # describe() is type-specific (e.g. "postgres (public.users)", "slack (#alerts)")
+    return f"dest_{_slug(dest.type)}_{_slug(dest.describe())}"
+
+
+def _destination_table(sync: SyncConfig) -> str | None:
+    """SQL-shaped destinations expose `.table`; non-SQL ones don't."""
+    return getattr(sync.destination, "table", None)
+
+
+def _destination_lookup_tables(sync: SyncConfig) -> list[str]:
+    """Tables referenced via `lookups` on the destination, if any."""
+    lookups = getattr(sync.destination, "lookups", None)
+    if not lookups:
+        return []
+    return [cfg.table for cfg in lookups.values()]
+
+
+def build_manifest(project_dir: Path = Path(".")) -> Manifest:
+    """Build a `Manifest` from sync YAMLs + project config under *project_dir*.
+
+    State is NOT included in P1 (Mermaid output doesn't render it; `--no-state`
+    is parsed but no-op in P1).
+    """
+    project = load_project(project_dir)
+    syncs_result = load_syncs_safe(project_dir)
+
+    # Source: project.profile is authoritative; type from inline ProjectConfig.source if present,
+    # else "configured" (operator can resolve to a concrete type later via profiles.yml).
+    source_type = project.source.type if project.source else "configured"
+    source = Source(name=project.profile, type=source_type)
+
+    destinations: dict[str, Destination] = {}
+    syncs: list[Sync] = []
+    edges: list[Edge] = []
+
+    for sync_cfg in syncs_result.syncs:
+        dest_id = _destination_id(sync_cfg)
+        if dest_id not in destinations:
+            destinations[dest_id] = Destination(
+                name=dest_id,
+                type=sync_cfg.destination.type,
+                label=sync_cfg.destination.describe(),
+            )
+
+        syncs.append(
+            Sync(
+                name=sync_cfg.name,
+                source=source.name,
+                destination=dest_id,
+                mode=sync_cfg.sync.mode,
+                description=sync_cfg.description,
+                tags=tuple(sync_cfg.tags),
+            )
+        )
+
+        edges.append(Edge(kind="source_to_sync", from_=source.name, to=sync_cfg.name))
+        edges.append(Edge(kind="sync_to_destination", from_=sync_cfg.name, to=dest_id))
+
+    # Heuristic lookup edges: if sync A's destination has lookups pointing at a table
+    # that matches sync B's destination.table, draw a `B -> A` lookup edge (A depends on B).
+    sync_by_dest_table: dict[str, str] = {}
+    for sync_cfg in syncs_result.syncs:
+        table = _destination_table(sync_cfg)
+        if table:
+            sync_by_dest_table[table] = sync_cfg.name
+
+    for sync_cfg in syncs_result.syncs:
+        for lookup_table in _destination_lookup_tables(sync_cfg):
+            producer = sync_by_dest_table.get(lookup_table)
+            if producer and producer != sync_cfg.name:
+                edges.append(Edge(kind="lookup", from_=producer, to=sync_cfg.name))
+
+    return Manifest(
+        schema_version=SCHEMA_VERSION,
+        drt_version=__version__,
+        syncs=syncs,
+        sources=[source],
+        destinations=list(destinations.values()),
+        edges=edges,
+    )

--- a/drt/docs/manifest.py
+++ b/drt/docs/manifest.py
@@ -1,0 +1,55 @@
+"""Manifest dataclasses for `drt docs generate`.
+
+These describe the catalog of a drt project — syncs, sources, destinations,
+and the edges between them. Schema is versioned (`schema_version`) and
+considered a public surface; see ADR-0001 in #500.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+SCHEMA_VERSION = 1
+
+EdgeKind = Literal["source_to_sync", "sync_to_destination", "lookup"]
+
+
+@dataclass(frozen=True)
+class Source:
+    name: str
+    type: str
+
+
+@dataclass(frozen=True)
+class Destination:
+    name: str  # synthesized node id (stable across runs)
+    type: str
+    label: str  # human-readable describe(), e.g. "slack (#alerts)"
+
+
+@dataclass(frozen=True)
+class Sync:
+    name: str
+    source: str  # Source.name
+    destination: str  # Destination.name
+    mode: str  # SyncOptions.mode
+    description: str = ""
+    tags: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Edge:
+    kind: EdgeKind
+    from_: str
+    to: str
+
+
+@dataclass
+class Manifest:
+    schema_version: int
+    drt_version: str
+    syncs: list[Sync] = field(default_factory=list)
+    sources: list[Source] = field(default_factory=list)
+    destinations: list[Destination] = field(default_factory=list)
+    edges: list[Edge] = field(default_factory=list)

--- a/drt/docs/mermaid.py
+++ b/drt/docs/mermaid.py
@@ -1,0 +1,77 @@
+"""Render a `Manifest` as a Mermaid `graph LR` block."""
+
+from __future__ import annotations
+
+import re
+
+from drt.docs.manifest import Manifest
+
+_SLUG_RE = re.compile(r"[^A-Za-z0-9_]+")
+
+
+def _node_id(prefix: str, name: str) -> str:
+    return f"{prefix}_{_SLUG_RE.sub('_', name).strip('_') or 'x'}"
+
+
+def _escape_label(text: str) -> str:
+    """Mermaid label-safe — wrap in quotes and escape inner quotes."""
+    return text.replace('"', "&quot;")
+
+
+def render_mermaid(manifest: Manifest) -> str:
+    """Render a Mermaid `graph LR` block from *manifest*.
+
+    Layout:
+      - Three subgraphs: Sources, Syncs, Destinations
+      - source -> sync: solid arrow, label "extract"
+      - sync -> destination: solid arrow, label "load"
+      - sync -> sync (lookup): dashed arrow, label "lookup"
+    """
+    lines: list[str] = ["graph LR"]
+
+    if not manifest.syncs:
+        lines.append('    empty["No syncs found"]')
+        return "\n".join(lines)
+
+    # Sources subgraph
+    lines.append("    subgraph Sources")
+    for src in manifest.sources:
+        nid = _node_id("src", src.name)
+        label = f"{_escape_label(src.name)}<br/><i>{_escape_label(src.type)}</i>"
+        lines.append(f'        {nid}["{label}"]')
+    lines.append("    end")
+
+    # Syncs subgraph (hexagon shape with mode label)
+    lines.append("    subgraph Syncs")
+    for sync in manifest.syncs:
+        nid = _node_id("sync", sync.name)
+        label = f"{_escape_label(sync.name)}<br/><i>{_escape_label(sync.mode)}</i>"
+        lines.append(f'        {nid}{{{{"{label}"}}}}')
+    lines.append("    end")
+
+    # Destinations subgraph
+    lines.append("    subgraph Destinations")
+    for dst in manifest.destinations:
+        nid = _node_id("dst", dst.label)
+        label = f"{_escape_label(dst.label)}<br/><i>{_escape_label(dst.type)}</i>"
+        lines.append(f'        {nid}["{label}"]')
+    lines.append("    end")
+
+    # Edges
+    dst_by_id = {d.name: d for d in manifest.destinations}
+    for edge in manifest.edges:
+        if edge.kind == "source_to_sync":
+            from_id = _node_id("src", edge.from_)
+            to_id = _node_id("sync", edge.to)
+            lines.append(f"    {from_id} -->|extract| {to_id}")
+        elif edge.kind == "sync_to_destination":
+            from_id = _node_id("sync", edge.from_)
+            dst_match = dst_by_id.get(edge.to)
+            to_id = _node_id("dst", dst_match.label) if dst_match else _node_id("dst", edge.to)
+            lines.append(f"    {from_id} -->|load| {to_id}")
+        elif edge.kind == "lookup":
+            from_id = _node_id("sync", edge.from_)
+            to_id = _node_id("sync", edge.to)
+            lines.append(f"    {from_id} -.lookup.-> {to_id}")
+
+    return "\n".join(lines)

--- a/tests/unit/test_docs_mermaid.py
+++ b/tests/unit/test_docs_mermaid.py
@@ -1,0 +1,157 @@
+"""Tests for `drt docs generate --format mermaid` (P1 of #499)."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from drt.cli.main import app
+from drt.docs.manifest import (
+    SCHEMA_VERSION,
+    Destination,
+    Edge,
+    Manifest,
+    Source,
+    Sync,
+)
+from drt.docs.mermaid import render_mermaid
+
+runner = CliRunner()
+
+
+def _manifest(*, syncs=None, sources=None, destinations=None, edges=None) -> Manifest:
+    return Manifest(
+        schema_version=SCHEMA_VERSION,
+        drt_version="test",
+        syncs=list(syncs or []),
+        sources=list(sources or []),
+        destinations=list(destinations or []),
+        edges=list(edges or []),
+    )
+
+
+class TestRenderMermaid:
+    def test_empty_project_renders_placeholder(self) -> None:
+        out = render_mermaid(_manifest())
+        assert out.startswith("graph LR")
+        assert "No syncs found" in out
+
+    def test_single_sync_has_three_subgraphs_and_two_edges(self) -> None:
+        src = Source(name="bq_prod", type="bigquery")
+        dst = Destination(name="dest_hubspot_hubspot__main", type="hubspot", label="hubspot (main)")
+        sync = Sync(
+            name="users_to_hubspot",
+            source="bq_prod",
+            destination=dst.name,
+            mode="upsert",
+        )
+        m = _manifest(
+            sources=[src],
+            destinations=[dst],
+            syncs=[sync],
+            edges=[
+                Edge(kind="source_to_sync", from_=src.name, to=sync.name),
+                Edge(kind="sync_to_destination", from_=sync.name, to=dst.name),
+            ],
+        )
+        out = render_mermaid(m)
+
+        assert "subgraph Sources" in out
+        assert "subgraph Syncs" in out
+        assert "subgraph Destinations" in out
+        assert "-->|extract|" in out
+        assert "-->|load|" in out
+        assert "upsert" in out
+        assert "bigquery" in out
+
+    def test_shared_source_between_syncs(self) -> None:
+        src = Source(name="bq", type="bigquery")
+        dst1 = Destination(name="dest_slack_a", type="slack", label="slack (#a)")
+        dst2 = Destination(name="dest_slack_b", type="slack", label="slack (#b)")
+        s1 = Sync(name="alpha", source="bq", destination=dst1.name, mode="full")
+        s2 = Sync(name="beta", source="bq", destination=dst2.name, mode="full")
+        m = _manifest(
+            sources=[src],
+            destinations=[dst1, dst2],
+            syncs=[s1, s2],
+            edges=[
+                Edge(kind="source_to_sync", from_="bq", to="alpha"),
+                Edge(kind="source_to_sync", from_="bq", to="beta"),
+                Edge(kind="sync_to_destination", from_="alpha", to=dst1.name),
+                Edge(kind="sync_to_destination", from_="beta", to=dst2.name),
+            ],
+        )
+        out = render_mermaid(m)
+        # Source node appears once; two extract edges fan out
+        assert out.count("src_bq[") == 1
+        assert out.count("-->|extract|") == 2
+
+    def test_lookup_edge_uses_dashed_arrow(self) -> None:
+        src = Source(name="bq", type="bigquery")
+        dst1 = Destination(name="dest_pg_users", type="postgres", label="postgres (users)")
+        dst2 = Destination(name="dest_pg_orders", type="postgres", label="postgres (orders)")
+        s_users = Sync(name="users", source="bq", destination=dst1.name, mode="upsert")
+        s_orders = Sync(name="orders", source="bq", destination=dst2.name, mode="upsert")
+        m = _manifest(
+            sources=[src],
+            destinations=[dst1, dst2],
+            syncs=[s_users, s_orders],
+            edges=[
+                Edge(kind="source_to_sync", from_="bq", to="users"),
+                Edge(kind="source_to_sync", from_="bq", to="orders"),
+                Edge(kind="sync_to_destination", from_="users", to=dst1.name),
+                Edge(kind="sync_to_destination", from_="orders", to=dst2.name),
+                Edge(kind="lookup", from_="users", to="orders"),
+            ],
+        )
+        out = render_mermaid(m)
+        assert "-.lookup.->" in out
+
+    def test_destination_label_with_quotes_is_escaped(self) -> None:
+        dst = Destination(
+            name="dest_slack_with_quotes",
+            type="slack",
+            label='slack (#"weird")',
+        )
+        out = render_mermaid(
+            _manifest(
+                destinations=[dst],
+                syncs=[Sync(name="x", source="s", destination=dst.name, mode="full")],
+                sources=[Source(name="s", type="bq")],
+            )
+        )
+        assert "&quot;" in out
+
+
+class TestDocsGenerateCLI:
+    def test_help_lists_generate_and_serve(self) -> None:
+        result = runner.invoke(app, ["docs", "--help"])
+        assert result.exit_code == 0
+        assert "generate" in result.output
+        assert "serve" in result.output
+
+    def test_serve_raises_not_implemented(self) -> None:
+        result = runner.invoke(app, ["docs", "serve"])
+        # Typer surfaces uncaught exceptions; we just need a non-zero exit + message.
+        assert result.exit_code != 0
+        assert "v0.8.x" in str(result.exception) or "v0.8.x" in (result.output or "")
+
+    def test_generate_html_not_yet_implemented(self) -> None:
+        result = runner.invoke(app, ["docs", "generate", "--format", "html"])
+        assert result.exit_code != 0
+        assert "follow-up phase" in str(result.exception) or "follow-up phase" in (
+            result.output or ""
+        )
+
+    def test_generate_unknown_format_is_bad_param(self) -> None:
+        result = runner.invoke(app, ["docs", "generate", "--format", "xml"])
+        assert result.exit_code != 0
+
+    def test_generate_mermaid_on_empty_project_prints_placeholder(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "drt_project.yml").write_text("name: empty\nprofile: default\n")
+        result = runner.invoke(app, ["docs", "generate", "--format", "mermaid"])
+        assert result.exit_code == 0
+        assert "graph LR" in result.output
+        assert "No syncs found" in result.output


### PR DESCRIPTION
## Summary

First implementation slice of the **sync catalog & lineage primitive** introduced by epic #499.

Closes #501 (P1 sub-issue).

Adds `drt docs generate --format mermaid` which writes a Mermaid `graph LR` to stdout showing every sync as `source → sync → destination`, plus heuristic dashed `lookup` edges between syncs whose destination table is referenced by another sync's `lookups` config.

## Example output

Run against a 3-sync demo project (BigQuery → Postgres+Slack with one cross-table lookup):

```mermaid
graph LR
    subgraph Sources
        src_bq_demo["bq_demo<br/><i>configured</i>"]
    end
    subgraph Syncs
        sync_alerts_to_slack{{"alerts_to_slack<br/><i>full</i>"}}
        sync_orders_to_pg{{"orders_to_pg<br/><i>upsert</i>"}}
        sync_users_to_hubspot{{"users_to_hubspot<br/><i>upsert</i>"}}
    end
    subgraph Destinations
        dst_slack_webhook["slack (webhook)<br/><i>slack</i>"]
        dst_postgres_public_orders["postgres (public.orders)<br/><i>postgres</i>"]
        dst_postgres_public_users["postgres (public.users)<br/><i>postgres</i>"]
    end
    src_bq_demo -->|extract| sync_alerts_to_slack
    sync_alerts_to_slack -->|load| dst_slack_webhook
    src_bq_demo -->|extract| sync_orders_to_pg
    sync_orders_to_pg -->|load| dst_postgres_public_orders
    src_bq_demo -->|extract| sync_users_to_hubspot
    sync_users_to_hubspot -->|load| dst_postgres_public_users
    sync_users_to_hubspot -.lookup.-> sync_orders_to_pg
```

The dashed `-.lookup.->` edge from `users_to_hubspot` → `orders_to_pg` is derived heuristically: `orders_to_pg.destination.lookups` references `public.users`, which matches `users_to_hubspot.destination.table`.

## Changes

- **New package `drt/docs/`** (foundation for the entire epic):
  - `manifest.py` — `Sync`/`Source`/`Destination`/`Edge`/`Manifest` dataclasses (schema_version=1)
  - `builder.py::build_manifest(project_dir)` — loads syncs + project config, dedupes destinations by `describe()`, derives lookup-table heuristic edges
  - `mermaid.py::render_mermaid(manifest)` — pure string assembly, three subgraphs (Sources / Syncs / Destinations), hexagonal sync nodes, dashed lookup edges
- **`drt/cli/main.py`** — new `docs_app` Typer sub-app with `generate` and `serve` subcommands. `--format html` / `--format json` / `docs serve` raise `NotImplementedError` pointing at the tracking issue (P2/P3 of #499 and v0.8.x respectively).
- **`tests/unit/test_docs_mermaid.py`** — 10 unit tests covering empty project, shared source between syncs, lookup edge rendering, destination label escaping, CLI help, and not-yet-implemented stubs.
- **`.gitignore`** — `target/` added (output dir convention follows dbt).
- **`CHANGELOG.md`** — entry under `[Unreleased]`.

## Design notes (relevant to future phases)

- **Lookups heuristic**: epic #499 originally framed `lookups` as cross-sync dependencies, but the actual schema (`drt.config.models.LookupConfig`) makes `lookups.table` a destination-DB-FK reference. The heuristic "lookup.table == another sync's destination.table" correctly captures the common case (FK to a table populated by another drt sync) without false positives in the other direction. I'll update the epic/P1 issue bodies post-merge to make this explicit.
- **Manifest dataclasses are frozen** for now to make round-trip testing trivial. P2 will revisit if mutability is needed for serializer state.
- **`--no-state` and `--output`** are accepted by the CLI but no-op in P1 (state isn't in Mermaid output; mermaid goes to stdout regardless of `--output`). They'll become meaningful in P2/P3.

## Out of scope

- `--format html` (P3 of #499)
- `--format json` / public manifest.json (P2 of #499)
- State injection into manifest (P2 of #499)
- `drt docs serve` (P4 of #499, v0.8.x)
- Theme tokens / palette extraction (P0 ADR — #500)

## Test plan

- [x] `uv run pytest tests/unit/test_docs_mermaid.py -v` — 10/10 pass locally
- [x] `make lint` — ruff + mypy both clean
- [x] Manual dogfood with a 3-sync demo project — output above
- [ ] CI green on PR