### PR TITLE
fix(mysql): apply _quote_ident to all SQL paths (#442 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ConnectionTestable` destination protocol** (#495, PR #497): New runtime-checkable `Protocol` in `drt/destinations/base.py` formalizing the `test_connection()` method introduced by #484. `drt validate --check-connection` now dispatches via `isinstance(dest, ConnectionTestable)` instead of dynamic `getattr`, giving destination implementers (including third-party ones) a typed contract. PostgreSQL / MySQL / ClickHouse / Snowflake destinations are declared `ConnectionTestable`; non-SQL destinations correctly fall through to the skip path. Contributed by @Photon101.
 - **Postgres: qualified `schema.table` identifiers now safely composed** (#442, PR #498): follow-up to PR #452 / PR #485. The row-count, replace, swap, finalize, insert, and upsert SQL paths previously passed `f"{schema}.{table}"` style strings through `psycopg2.sql.Identifier()`, which double-quoted the entire dotted name into a single identifier (`"marketing.email_events"`). The fix splits qualified names into separate schema and relation `Identifier()` components, while keeping swap shadow/old suffixes attached to the relation name only (so `marketing.email_events` becomes `marketing."email_events__drt_swap"`, not a single quoted identifier). Contributed by @Photon101.
 
+### Fixed
+
+- **MySQL destination correctly quotes schema-qualified table names** (#511): `mydb.scores` now produces `` `mydb`.`scores` `` across replace, insert, and upsert paths (was treated as a single identifier).
+
 ## [0.7.2] - 2026-05-11
 
 **Theme: Production Ready follow-up #2.** Opt-in anonymous telemetry, deprecation warnings in `drt validate`, Postgres `psycopg2.sql` hardening — closing out the v0.7 cycle items that didn't make v0.7.1.

--- a/drt/destinations/mysql.py
+++ b/drt/destinations/mysql.py
@@ -344,7 +344,8 @@ class MySQLDestination:
         """Build plain INSERT SQL (no conflict handling)."""
         cols_str = ", ".join(f"`{c}`" for c in columns)
         placeholders = ", ".join(["%s"] * len(columns))
-        return f"INSERT INTO {MySQLDestination._quote_ident(table)} ({cols_str}) VALUES ({placeholders})"
+        table_q = MySQLDestination._quote_ident(table)
+        return f"INSERT INTO {table_q} ({cols_str}) VALUES ({placeholders})"
 
     @staticmethod
     def _build_upsert_sql(
@@ -355,15 +356,16 @@ class MySQLDestination:
         """Build INSERT ... ON DUPLICATE KEY UPDATE SQL."""
         cols_str = ", ".join(f"`{c}`" for c in columns)
         placeholders = ", ".join(["%s"] * len(columns))
+        table_q = MySQLDestination._quote_ident(table)
 
         if update_cols:
             set_clause = ", ".join(f"`{c}` = VALUES(`{c}`)" for c in update_cols)
             return (
-                f"INSERT INTO {MySQLDestination._quote_ident(table)} ({cols_str}) VALUES ({placeholders}) "
+                f"INSERT INTO {table_q} ({cols_str}) VALUES ({placeholders}) "
                 f"ON DUPLICATE KEY UPDATE {set_clause}"
             )
         # All columns are part of the key — just ignore duplicates
-        return f"INSERT IGNORE INTO {MySQLDestination._quote_ident(table)} ({cols_str}) VALUES ({placeholders})"
+        return f"INSERT IGNORE INTO {table_q} ({cols_str}) VALUES ({placeholders})"
 
     @staticmethod
     def _connect(config: MySQLDestinationConfig) -> Any:

--- a/drt/destinations/mysql.py
+++ b/drt/destinations/mysql.py
@@ -140,13 +140,7 @@ class MySQLDestination:
         conn = self._connect(config)
         try:
             cur = conn.cursor()
-            # Escape table name with backticks for safety
-            escaped_table = (
-                "`.`".join(config.table.split("."))
-                if "." in config.table
-                else config.table
-            )
-            cur.execute(f"SELECT COUNT(*) FROM `{escaped_table}`")
+            cur.execute(f"SELECT COUNT(*) FROM {self._quote_ident(config.table)}")
             row = cur.fetchone()
             return row[0] if row else 0
         finally:
@@ -187,7 +181,7 @@ class MySQLDestination:
         result = SyncResult()
 
         if not self._replace_truncated:
-            cur.execute(f"TRUNCATE TABLE `{table}`")
+            cur.execute(f"TRUNCATE TABLE {self._quote_ident(table)}")
             self._replace_truncated = True
 
         sql = self._build_insert_sql(table, columns)
@@ -350,7 +344,7 @@ class MySQLDestination:
         """Build plain INSERT SQL (no conflict handling)."""
         cols_str = ", ".join(f"`{c}`" for c in columns)
         placeholders = ", ".join(["%s"] * len(columns))
-        return f"INSERT INTO `{table}` ({cols_str}) VALUES ({placeholders})"
+        return f"INSERT INTO {MySQLDestination._quote_ident(table)} ({cols_str}) VALUES ({placeholders})"
 
     @staticmethod
     def _build_upsert_sql(
@@ -365,11 +359,11 @@ class MySQLDestination:
         if update_cols:
             set_clause = ", ".join(f"`{c}` = VALUES(`{c}`)" for c in update_cols)
             return (
-                f"INSERT INTO `{table}` ({cols_str}) VALUES ({placeholders}) "
+                f"INSERT INTO {MySQLDestination._quote_ident(table)} ({cols_str}) VALUES ({placeholders}) "
                 f"ON DUPLICATE KEY UPDATE {set_clause}"
             )
         # All columns are part of the key — just ignore duplicates
-        return f"INSERT IGNORE INTO `{table}` ({cols_str}) VALUES ({placeholders})"
+        return f"INSERT IGNORE INTO {MySQLDestination._quote_ident(table)} ({cols_str}) VALUES ({placeholders})"
 
     @staticmethod
     def _connect(config: MySQLDestinationConfig) -> Any:

--- a/tests/unit/test_mysql_destination.py
+++ b/tests/unit/test_mysql_destination.py
@@ -102,6 +102,24 @@ class TestUpsertSql:
         assert "INSERT IGNORE INTO" in sql
         assert "ON DUPLICATE KEY" not in sql
 
+    def test_qualified_table_on_duplicate_key(self) -> None:
+        sql = MySQLDestination._build_upsert_sql(
+            table="mydb.scores",
+            columns=["id", "score"],
+            update_cols=["score"],
+        )
+        assert "INSERT INTO `mydb`.`scores`" in sql
+        assert "`mydb.scores`" not in sql
+
+    def test_qualified_table_all_key_uses_insert_ignore(self) -> None:
+        sql = MySQLDestination._build_upsert_sql(
+            table="mydb.lookup",
+            columns=["id"],
+            update_cols=[],
+        )
+        assert "INSERT IGNORE INTO `mydb`.`lookup`" in sql
+        assert "`mydb.lookup`" not in sql
+
 
 # ---------------------------------------------------------------------------
 # Load behavior
@@ -205,6 +223,24 @@ class TestMySQLDestinationLoad:
         assert values[4] == 0.9
 
     @patch("drt.destinations.mysql.MySQLDestination._connect")
+    def test_get_row_count_with_qualified_table(
+        self, mock_connect: MagicMock
+    ) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        cur.fetchone.return_value = (42,)
+        mock_connect.return_value = conn
+
+        count = MySQLDestination().get_row_count(
+            _config(table="mydb.learning_profiles")
+        )
+
+        assert count == 42
+        sql = cur.execute.call_args.args[0]
+        assert "`mydb`.`learning_profiles`" in sql
+        assert "`mydb.learning_profiles`" not in sql
+
+    @patch("drt.destinations.mysql.MySQLDestination._connect")
     def test_connection_closed_on_error(self, mock_connect: MagicMock) -> None:
         conn = _fake_connection()
         conn.cursor().execute.side_effect = Exception("fail")
@@ -232,6 +268,14 @@ class TestInsertSql:
         assert "INSERT INTO `learning_profiles`" in sql
         assert "ON DUPLICATE KEY" not in sql
         assert "VALUES (%s, %s, %s)" in sql
+
+    def test_qualified_insert_sql(self) -> None:
+        sql = MySQLDestination._build_insert_sql(
+            table="mydb.scores",
+            columns=["id", "score"],
+        )
+        assert "INSERT INTO `mydb`.`scores`" in sql
+        assert "`mydb.scores`" not in sql
 
 
 class TestMySQLReplaceMode:
@@ -294,6 +338,24 @@ class TestMySQLReplaceMode:
         insert_sql = cur.execute.call_args_list[1][0][0]
         assert "ON DUPLICATE KEY" not in insert_sql
         assert "INSERT INTO" in insert_sql
+
+    @patch("drt.destinations.mysql.MySQLDestination._connect")
+    def test_replace_uses_qualified_identifier(
+        self, mock_connect: MagicMock
+    ) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        MySQLDestination().load(
+            [{"user_id": 1, "company_id": 5, "score": 0.5}],
+            _config(table="mydb.learning_profiles"),
+            _options(mode="replace"),
+        )
+
+        sqls = [c[0][0] for c in cur.execute.call_args_list]
+        assert any("TRUNCATE TABLE `mydb`.`learning_profiles`" in s for s in sqls)
+        assert any("INSERT INTO `mydb`.`learning_profiles`" in s for s in sqls)
 
     @patch("drt.destinations.mysql.MySQLDestination._connect")
     def test_replace_serializes_json_values(self, mock_connect: MagicMock) -> None:


### PR DESCRIPTION
Closes #511

## Summary

`MySQLDestination._quote_ident` already exists and correctly handles
schema-qualified table names (\`mydb.scores\` → \`mydb\`.\`scores\`), but
was only used in the swap path. This applies it to the remaining paths.

## Changes

- **`get_row_count`**: Replaced inline split+backtick logic with
  \`self._quote_ident(config.table)\`.
- **`_load_replace`**: Replaced raw \`TRUNCATE TABLE \`{table}\`\` with
  \`self._quote_ident(table)\`.
- **`_build_insert_sql`**: Replaced raw \`\`{table}\`\` with
  \`MySQLDestination._quote_ident(table)\`.
- **`_build_upsert_sql`**: Same change for both the \`INSERT ... ON
  DUPLICATE KEY UPDATE\` and \`INSERT IGNORE\` paths.

Follows the pattern established in PR #498 for Postgres.