### PR TITLE
docs(roadmap): trim v0.8 scope and create v0.8.1 for diff polish

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,13 +40,28 @@ Followup items continue in their own issues (#482 telemetry retention cleanup, #
 - **Reliability follow-on** — dead letter queue (#278) — *opt-in telemetry (#263) moved up to v0.7*
 - **Correctness epic** — schema-aware serialization via INFORMATION_SCHEMA (#317)
 - **Engine** — `sync.mode: mirror` differential delete (#340)
-- **Growth / README** — hero section redesign (#281) · Quickstart GIF/asciinema (#282) · "Why OSS Reverse ETL" blog (#284) · production use case blog (#285) · Discord (#378) · X account link (#379) · Awesome lists (#290) · Reddit/HN launch (#289) — *Codespaces devcontainer (#283) and PyPI keywords (#307) shipped early in v0.7*
+- **Growth / README** — hero section redesign (#281) · Quickstart GIF/asciinema (#282) · "Why OSS Reverse ETL" blog (#284) · production use case blog (#285) · Discord (#378) · X account link (#379) · Awesome lists (#290) — *Codespaces devcontainer (#283) and PyPI keywords (#307) shipped early in v0.7; Reddit/HN launch (#289) deferred to opportunistic timing post-v0.8*
 - **Ecosystem** — GitHub Action (#292) · VS Code extension (#293)
 - **Dev tooling** — FakeSource (#364) · `drt_run_test` MCP tool (#368) · `/drt-troubleshoot` skill (#369) · `/drt-changelog` repo skill (#372) · connection test in `drt validate` (#367)
 
 **Out of scope:** Enterprise boundary (RBAC / audit log / plugin system → v0.9), Rust engine work (→ v1.x).
 
 **Target:** 2026-07 · **Progress:** [milestone/5](https://github.com/drt-hub/drt/milestone/5)
+
+---
+
+## v0.8.1 — Diff Polish
+
+**Theme:** Polish and follow-ups for the `--diff` feature shipped in v0.7.1.
+
+**Scope:**
+- **Diff UX** — `--diff-fields` column filter (#471) · API-based diff for upsert-keyed SaaS destinations (#472)
+- **Diff perf** — batch lookup queries for large diff sets (#470)
+- **Lookup correctness** — first-miss-wins YAML order semantics (#453)
+
+**Out of scope:** New destinations, engine features unrelated to `--diff`.
+
+**Target:** Cut from v0.8 once Cloud Destinations land · **Progress:** [milestone/10](https://github.com/drt-hub/drt/milestone/10)
 
 ---
 


### PR DESCRIPTION
## Summary

v0.8 was carrying 52 open issues against the 2026-07 target — significantly over budget. This PR trims v0.8 to ~40 by deferring follow-ups and tactical GTM work.

### Changes

- **New v0.8.1 milestone** ([milestone/10](https://github.com/drt-hub/drt/milestone/10)) — captures \`--diff\` feature polish that emerged after #413 shipped:
  - #471 \`--diff-fields\` column filter
  - #472 API-based diff for upsert-keyed SaaS destinations
  - #470 batch lookup queries for large diff sets
  - #453 lookup ordering correctness follow-up
- **9 GTM items moved to no-milestone** — opportunistic-timing tactical work that doesn't gate v0.8 ship:
  - #74, #75, #115, #116, #117, #121, #289, #294, #296
- **ROADMAP v0.8 Growth line** updated to note that Reddit/HN launch (#289) is deferred to opportunistic timing post-v0.8

### What stays in v0.8

The core theme — **Cloud Destinations + Growth** — is intact:

- Cloud destinations: BigQuery (#165), Databricks (#167), S3 (#168), GCS (#169), Azure Blob (#170)
- Lakehouse sources: Delta Lake (#172), Apache Iceberg (#173)
- Growth/README: hero redesign (#281), "Why OSS RETL" blog (#284), Discord link (#378), X link (#379), Awesome lists (#290)
- Ecosystem: GitHub Action (#292), VS Code extension (#293)
- Dev tooling: FakeSource (#364), drt_run_test MCP (#368), /drt-troubleshoot (#369), /drt-changelog (#372)

## Test plan

- [x] Milestone moves verified — v0.8 went 52 → 40, v0.8.1 created with 4, no-milestone gained 9
- [x] ROADMAP.md renders correctly (markdown preview)
- [x] Cross-references in ROADMAP intact (milestone URLs point to correct numbers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)