### PR TITLE
feat(mcp): add drt_run_test tool for post-sync validation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: pip install uv
 
       - name: Install dependencies
-        run: uv pip install --system -e ".[dev]"
+        run: uv pip install --system -e ".[dev,mcp]"
 
       - name: Lint (ruff)
         run: ruff check drt tests

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -1165,29 +1165,12 @@ def test_syncs(
 
 
 def _test_display_name(test_def: object) -> str:
-    """Human-readable name for a test definition."""
+    """Backward-compatible private wrapper — delegates to the public helper."""
     from drt.config.models import SyncTest
+    from drt.engine.test_runner import test_display_name
 
     assert isinstance(test_def, SyncTest)
-    if test_def.row_count is not None:
-        parts = []
-        if test_def.row_count.min is not None:
-            parts.append(f"min={test_def.row_count.min}")
-        if test_def.row_count.max is not None:
-            parts.append(f"max={test_def.row_count.max}")
-        return f"row_count({', '.join(parts)})"
-    if test_def.not_null is not None:
-        cols = ", ".join(test_def.not_null.columns)
-        return f"not_null({cols})"
-    if test_def.freshness is not None:
-        return f"freshness({test_def.freshness.column}, max_age={test_def.freshness.max_age})"
-    if test_def.unique is not None:
-        cols = ", ".join(test_def.unique.columns)
-        return f"unique({cols})"
-    if test_def.accepted_values is not None:
-        vals = ", ".join(test_def.accepted_values.values)
-        return f"accepted_values({test_def.accepted_values.column}: {vals})"
-    return "unknown"
+    return test_display_name(test_def)
 
 
 # ---------------------------------------------------------------------------

--- a/drt/engine/test_runner.py
+++ b/drt/engine/test_runner.py
@@ -16,6 +16,33 @@ class TestResult:
     message: str
 
 
+def test_display_name(test_def: SyncTest) -> str:
+    """Human-readable label for a SyncTest definition.
+
+    Shared between the ``drt test`` CLI and the ``drt_run_test`` MCP tool so
+    both render identical labels.
+    """
+    if test_def.row_count is not None:
+        parts = []
+        if test_def.row_count.min is not None:
+            parts.append(f"min={test_def.row_count.min}")
+        if test_def.row_count.max is not None:
+            parts.append(f"max={test_def.row_count.max}")
+        return f"row_count({', '.join(parts)})"
+    if test_def.not_null is not None:
+        cols = ", ".join(test_def.not_null.columns)
+        return f"not_null({cols})"
+    if test_def.freshness is not None:
+        return f"freshness({test_def.freshness.column}, max_age={test_def.freshness.max_age})"
+    if test_def.unique is not None:
+        cols = ", ".join(test_def.unique.columns)
+        return f"unique({cols})"
+    if test_def.accepted_values is not None:
+        vals = ", ".join(test_def.accepted_values.values)
+        return f"accepted_values({test_def.accepted_values.column}: {vals})"
+    return "unknown"
+
+
 def _safe_table(table: str) -> str:
     """Basic table name validation."""
     for ch in table:

--- a/drt/mcp/server.py
+++ b/drt/mcp/server.py
@@ -7,6 +7,7 @@ Start with:
 Tools:
     drt_list_syncs      — list all sync definitions
     drt_run_sync        — run a specific sync (dry_run supported)
+    drt_run_test        — run post-sync validation tests for a sync
     drt_get_status      — get last sync result for a sync
     drt_validate        — validate all sync YAML configs (per-file errors)
     drt_get_schema      — return JSON Schema for drt_project.yml / sync.yml
@@ -112,6 +113,91 @@ def create_server(project_dir: Path | None = None) -> Any:
             "success": result.success,
             "failed": result.failed,
             "errors": result.errors[:10],  # cap at 10 to avoid huge payloads
+        }
+
+    # -----------------------------------------------------------------------
+    # drt_run_test
+    # -----------------------------------------------------------------------
+
+    @mcp.tool()
+    def drt_run_test(sync_name: str | None = None) -> dict[str, Any]:
+        """Run post-sync validation tests for one or all syncs.
+
+        Mirrors the `drt test` CLI: for each sync with `tests:` defined,
+        executes the test queries against the destination and reports
+        per-test pass/fail.
+
+        Args:
+            sync_name: Restrict to one sync. If omitted, runs tests for
+                every sync that has tests defined.
+
+        Returns:
+            Dict with `status` ("passed" | "failed" | "no_tests" | "no_syncs"),
+            and `results` — a list of per-sync result objects, each with:
+                - `sync`: sync name
+                - `tests`: list of {name, passed, value} or {name, passed: false, error}
+                - `skipped` (optional): true when destination type isn't queryable
+                - `reason` (optional): why the sync was skipped
+        """
+        from drt.cli.main import _test_display_name
+        from drt.config.parser import load_syncs
+        from drt.destinations.query import (
+            execute_test_query,
+            get_table_name,
+            is_queryable,
+        )
+        from drt.engine.test_runner import build_test_query
+
+        syncs = load_syncs(_project_dir)
+        if not syncs:
+            return {"status": "no_syncs", "results": []}
+
+        if sync_name is not None:
+            syncs = [s for s in syncs if s.name == sync_name]
+            if not syncs:
+                return {"error": f"No sync named '{sync_name}' found."}
+
+        syncs_with_tests = [s for s in syncs if s.tests]
+        if not syncs_with_tests:
+            return {"status": "no_tests", "results": []}
+
+        had_failures = False
+        results: list[dict[str, Any]] = []
+
+        for sync in syncs_with_tests:
+            sync_result: dict[str, Any] = {"sync": sync.name, "tests": []}
+
+            if not is_queryable(sync.destination):
+                sync_result["skipped"] = True
+                sync_result["reason"] = (
+                    f"tests not supported for {sync.destination.type} destinations"
+                )
+                results.append(sync_result)
+                continue
+
+            table = get_table_name(sync.destination)
+            for test_def in sync.tests:
+                test_name = _test_display_name(test_def)
+                try:
+                    query, check = build_test_query(test_def, table)
+                    result_val = execute_test_query(sync.destination, query)
+                    passed = check(result_val)
+                    sync_result["tests"].append(
+                        {"name": test_name, "passed": passed, "value": str(result_val)}
+                    )
+                    if not passed:
+                        had_failures = True
+                except Exception as e:
+                    sync_result["tests"].append(
+                        {"name": test_name, "passed": False, "error": str(e)}
+                    )
+                    had_failures = True
+
+            results.append(sync_result)
+
+        return {
+            "status": "failed" if had_failures else "passed",
+            "results": results,
         }
 
     # -----------------------------------------------------------------------

--- a/drt/mcp/server.py
+++ b/drt/mcp/server.py
@@ -139,14 +139,13 @@ def create_server(project_dir: Path | None = None) -> Any:
                 - `skipped` (optional): true when destination type isn't queryable
                 - `reason` (optional): why the sync was skipped
         """
-        from drt.cli.main import _test_display_name
         from drt.config.parser import load_syncs
         from drt.destinations.query import (
             execute_test_query,
             get_table_name,
             is_queryable,
         )
-        from drt.engine.test_runner import build_test_query
+        from drt.engine.test_runner import build_test_query, test_display_name
 
         syncs = load_syncs(_project_dir)
         if not syncs:
@@ -177,7 +176,7 @@ def create_server(project_dir: Path | None = None) -> Any:
 
             table = get_table_name(sync.destination)
             for test_def in sync.tests:
-                test_name = _test_display_name(test_def)
+                test_name = test_display_name(test_def)
                 try:
                     query, check = build_test_query(test_def, table)
                     result_val = execute_test_query(sync.destination, query)

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -81,6 +81,7 @@ async def test_server_has_expected_tools() -> None:
     expected = {
         "drt_list_syncs",
         "drt_run_sync",
+        "drt_run_test",
         "drt_get_status",
         "drt_validate",
         "drt_get_schema",
@@ -120,6 +121,56 @@ async def test_validate_returns_valid_syncs(server: FastMCP) -> None:
     result = await call(server, "drt_validate")
     assert "notify" in result["valid"]
     assert result["errors"] == {}
+
+
+# ---------------------------------------------------------------------------
+# drt_run_test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_test_no_syncs(tmp_path: Path) -> None:
+    (tmp_path / "drt_project.yml").write_text("name: empty\nprofile: default\n")
+    (tmp_path / "syncs").mkdir()
+    srv = create_server(tmp_path)
+    result = await call(srv, "drt_run_test")
+    assert result == {"status": "no_syncs", "results": []}
+
+
+@pytest.mark.asyncio
+async def test_run_test_sync_not_found(server: FastMCP) -> None:
+    result = await call(server, "drt_run_test", sync_name="nonexistent")
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_run_test_no_tests_defined(server: FastMCP) -> None:
+    # The default fixture sync has no `tests:` block
+    result = await call(server, "drt_run_test")
+    assert result == {"status": "no_tests", "results": []}
+
+
+@pytest.mark.asyncio
+async def test_run_test_skips_non_queryable_destination(tmp_path: Path) -> None:
+    (tmp_path / "drt_project.yml").write_text("name: test\nprofile: default\n")
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    # rest_api is not queryable — tests should report skipped
+    (syncs_dir / "notify.yml").write_text(
+        "name: notify\n"
+        "model: ref('users')\n"
+        "destination:\n"
+        "  type: rest_api\n"
+        "  url: https://example.com/hook\n"
+        "tests:\n"
+        "  - row_count: { min: 1 }\n"
+    )
+    srv = create_server(tmp_path)
+    result = await call(srv, "drt_run_test", sync_name="notify")
+    assert result["status"] == "passed"
+    assert len(result["results"]) == 1
+    assert result["results"][0]["skipped"] is True
+    assert "rest_api" in result["results"][0]["reason"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds the \`drt_run_test\` MCP tool, mirroring the \`drt test\` CLI. Lets LLMs (Claude Code, Cursor) run a sync's post-sync validation tests without a terminal — important for the MCP-driven workflow where users review data quality through the model rather than shell.

Closes #368

### Behavior

- \`drt_run_test()\` — runs tests for every sync that has \`tests:\` defined
- \`drt_run_test(sync_name=\"users_to_hubspot\")\` — restricts to one sync
- Non-queryable destinations (REST API, Slack, etc.) are reported as \`skipped\` with a reason rather than failing — mirrors the CLI's \`print_test_skip\` path

### Return shape

\`\`\`json
{
  \"status\": \"passed\" | \"failed\" | \"no_tests\" | \"no_syncs\",
  \"results\": [
    {
      \"sync\": \"users_to_hubspot\",
      \"tests\": [{\"name\": \"row_count(min=1)\", \"passed\": true, \"value\": \"42\"}],
      \"skipped\": true,
      \"reason\": \"tests not supported for rest_api destinations\"
    }
  ]
}
\`\`\`

## Test plan

- [x] 4 new unit tests cover: no syncs found, sync not found, no tests defined, non-queryable destination skip path
- [x] All 14 existing MCP tests still pass locally (\`pytest tests/unit/test_mcp.py\`)
- [x] Ruff passes on \`drt/mcp/server.py\` and \`tests/unit/test_mcp.py\`
- [x] Tool listed in \`server.py\` docstring + included in the \`test_server_has_expected_tools\` check
- [ ] CHANGELOG entry to be added once the PR # is final

🤖 Generated with [Claude Code](https://claude.com/claude-code)