### PR TITLE
feat(lookup): warn on ambiguous lookup ordering at sync startup

### DIFF
--- a/drt/destinations/lookup.py
+++ b/drt/destinations/lookup.py
@@ -64,12 +64,70 @@ def build_lookup_map(
     return mapping
 
 
+def detect_ambiguous_lookup_ordering(
+    lookups: dict[str, LookupConfig],
+) -> list[str]:
+    """Detect lookups whose evaluation order changes row fate (#453).
+
+    When multiple lookups share the same source column but have different
+    ``on_miss`` policies, ``apply_lookups`` evaluates them in YAML
+    insertion order and the **first miss wins** — its policy decides the
+    row's fate, and the remaining lookups for that row are not evaluated.
+
+    This means a YAML key reorder can flip the row's outcome (e.g. from
+    ``fail`` to ``skip``) without any other config change, which is
+    surprising. This helper returns one human-readable warning per
+    ambiguous source column so callers can log at sync startup.
+
+    Args:
+        lookups: The destination's ``lookups`` mapping (``target_col -> LookupConfig``).
+
+    Returns:
+        One warning string per source column that participates in
+        multiple lookups with differing policies. Empty when no ambiguity
+        is detected.
+    """
+    if not lookups or len(lookups) < 2:
+        return []
+
+    by_source: dict[str, list[tuple[str, str, bool]]] = {}
+    for target_col, lk in lookups.items():
+        for source_col in lk.match.values():
+            by_source.setdefault(source_col, []).append(
+                (target_col, lk.on_miss, lk.check_only)
+            )
+
+    warnings: list[str] = []
+    for source_col, entries in by_source.items():
+        if len(entries) < 2:
+            continue
+        policies = {(on_miss, check_only) for _, on_miss, check_only in entries}
+        if len(policies) > 1:
+            targets = [t for t, _, _ in entries]
+            warnings.append(
+                f"Lookups {targets} all match on source column '{source_col}' "
+                f"but have differing (on_miss, check_only) policies. "
+                f"apply_lookups uses first-miss-wins in YAML insertion order, "
+                f"so reordering these keys can change row fate. "
+                f"Place check_only lookups first when in doubt — see issue #453."
+            )
+    return warnings
+
+
 def apply_lookups(
     records: list[dict[str, Any]],
     lookup_maps: dict[str, tuple[LookupConfig, dict[tuple[Any, ...], Any]]],
     on_error: str,
 ) -> tuple[list[dict[str, Any]], list[RowError]]:
     """Enrich records with resolved lookup values.
+
+    **Ordering invariant:** lookups are evaluated in YAML insertion order
+    (preserved by ``dict``). For a row that misses on more than one
+    lookup, the **first miss wins** — that lookup's ``on_miss`` policy
+    decides the row's fate, and remaining lookups are not evaluated.
+    When multiple lookups share a source column with different policies,
+    reordering keys can therefore flip outcomes (see #453); use
+    :func:`detect_ambiguous_lookup_ordering` at config-load time to warn.
 
     Args:
         records: Source rows to enrich.

--- a/drt/destinations/lookup.py
+++ b/drt/destinations/lookup.py
@@ -90,23 +90,26 @@ def detect_ambiguous_lookup_ordering(
     if not lookups or len(lookups) < 2:
         return []
 
-    by_source: dict[str, list[tuple[str, str, bool]]] = {}
+    # Row fate on miss is determined solely by on_miss — check_only only
+    # affects the HIT path (whether the resolved value is written). So
+    # `{skip, skip+check_only}` produces identical outcomes and should not
+    # warn; `{skip, fail}` does.
+    by_source: dict[str, list[tuple[str, str]]] = {}
     for target_col, lk in lookups.items():
         for source_col in lk.match.values():
-            by_source.setdefault(source_col, []).append(
-                (target_col, lk.on_miss, lk.check_only)
-            )
+            by_source.setdefault(source_col, []).append((target_col, lk.on_miss))
 
     warnings: list[str] = []
     for source_col, entries in by_source.items():
         if len(entries) < 2:
             continue
-        policies = {(on_miss, check_only) for _, on_miss, check_only in entries}
-        if len(policies) > 1:
-            targets = [t for t, _, _ in entries]
+        on_miss_policies = {on_miss for _, on_miss in entries}
+        if len(on_miss_policies) > 1:
+            targets = [t for t, _ in entries]
             warnings.append(
                 f"Lookups {targets} all match on source column '{source_col}' "
-                f"but have differing (on_miss, check_only) policies. "
+                f"but have differing on_miss policies "
+                f"({sorted(on_miss_policies)}). "
                 f"apply_lookups uses first-miss-wins in YAML insertion order, "
                 f"so reordering these keys can change row fate. "
                 f"Place check_only lookups first when in doubt — see issue #453."

--- a/drt/engine/sync.py
+++ b/drt/engine/sync.py
@@ -18,7 +18,11 @@ from typing import Any
 from drt.config.credentials import ProfileConfig
 from drt.config.models import LookupConfig, SyncConfig
 from drt.destinations.base import Destination, StagedDestination, SyncResult
-from drt.destinations.lookup import apply_lookups, build_lookup_map
+from drt.destinations.lookup import (
+    apply_lookups,
+    build_lookup_map,
+    detect_ambiguous_lookup_ordering,
+)
 from drt.engine.resolver import resolve_model_ref
 from drt.sources.base import Source
 from drt.state.history import HistoryEntry, HistoryManager
@@ -273,6 +277,8 @@ def _run_sync_body(
         None,
     )
     if lookups:
+        for warning in detect_ambiguous_lookup_ordering(lookups):
+            logger.warning("sync='%s' %s", sync.name, warning)
         for col_name, lk_config in lookups.items():
             mapping = build_lookup_map(sync.destination, lk_config)
             lookup_maps[col_name] = (lk_config, mapping)

--- a/tests/unit/test_lookup.py
+++ b/tests/unit/test_lookup.py
@@ -12,7 +12,11 @@ from drt.config.models import (
     PostgresDestinationConfig,
     SyncConfig,
 )
-from drt.destinations.lookup import apply_lookups, build_lookup_map
+from drt.destinations.lookup import (
+    apply_lookups,
+    build_lookup_map,
+    detect_ambiguous_lookup_ordering,
+)
 
 # ---------------------------------------------------------------------------
 # LookupConfig validation
@@ -715,3 +719,98 @@ class TestSyncConfigCheckOnlyParse:
         lk = config.destination.lookups["user_exists"]
         assert lk.check_only is True
         assert lk.select is None
+
+
+# ---------------------------------------------------------------------------
+# detect_ambiguous_lookup_ordering (#453)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectAmbiguousLookupOrdering:
+    """Surface cases where YAML key order can flip row fate (#453)."""
+
+    def test_empty_lookups_returns_no_warnings(self):
+        assert detect_ambiguous_lookup_ordering({}) == []
+
+    def test_single_lookup_returns_no_warnings(self):
+        lookups = {
+            "interviewer_profile_id": LookupConfig(
+                table="interviewer_profiles",
+                match={"user_id": "user_id"},
+                select="id",
+                on_miss="fail",
+            ),
+        }
+        assert detect_ambiguous_lookup_ordering(lookups) == []
+
+    def test_disjoint_source_columns_returns_no_warnings(self):
+        # Two lookups, but no shared source column → order can't matter
+        lookups = {
+            "profile_id": LookupConfig(
+                table="profiles",
+                match={"user_id": "user_id"},
+                select="id",
+                on_miss="fail",
+            ),
+            "team_id": LookupConfig(
+                table="teams",
+                match={"slug": "team_slug"},
+                select="id",
+                on_miss="skip",
+            ),
+        }
+        assert detect_ambiguous_lookup_ordering(lookups) == []
+
+    def test_shared_source_same_policy_returns_no_warnings(self):
+        # Same source column, same on_miss/check_only → order doesn't change fate
+        lookups = {
+            "a": LookupConfig(
+                table="a", match={"user_id": "user_id"}, select="id", on_miss="skip"
+            ),
+            "b": LookupConfig(
+                table="b", match={"user_id": "user_id"}, select="id", on_miss="skip"
+            ),
+        }
+        assert detect_ambiguous_lookup_ordering(lookups) == []
+
+    def test_shared_source_different_on_miss_returns_warning(self):
+        # The exact scenario from #453
+        lookups = {
+            "interviewer_profile_id": LookupConfig(
+                table="interviewer_profiles",
+                match={"user_id": "user_id"},
+                select="id",
+                on_miss="fail",
+            ),
+            "user_exists": LookupConfig(
+                table="users",
+                match={"id": "user_id"},
+                check_only=True,
+                on_miss="skip",
+            ),
+        }
+        warnings = detect_ambiguous_lookup_ordering(lookups)
+        assert len(warnings) == 1
+        assert "user_id" in warnings[0]
+        assert "interviewer_profile_id" in warnings[0]
+        assert "user_exists" in warnings[0]
+        assert "#453" in warnings[0]
+
+    def test_warning_per_ambiguous_source_column(self):
+        # Two different source columns each ambiguous → two warnings
+        lookups = {
+            "a": LookupConfig(
+                table="a", match={"id": "user_id"}, check_only=True, on_miss="skip"
+            ),
+            "b": LookupConfig(
+                table="b", match={"user_id": "user_id"}, select="id", on_miss="fail"
+            ),
+            "c": LookupConfig(
+                table="c", match={"id": "team_id"}, check_only=True, on_miss="skip"
+            ),
+            "d": LookupConfig(
+                table="d", match={"team_id": "team_id"}, select="id", on_miss="fail"
+            ),
+        }
+        warnings = detect_ambiguous_lookup_ordering(lookups)
+        assert len(warnings) == 2

--- a/tests/unit/test_lookup.py
+++ b/tests/unit/test_lookup.py
@@ -729,10 +729,10 @@ class TestSyncConfigCheckOnlyParse:
 class TestDetectAmbiguousLookupOrdering:
     """Surface cases where YAML key order can flip row fate (#453)."""
 
-    def test_empty_lookups_returns_no_warnings(self):
+    def test_empty_lookups_returns_no_warnings(self) -> None:
         assert detect_ambiguous_lookup_ordering({}) == []
 
-    def test_single_lookup_returns_no_warnings(self):
+    def test_single_lookup_returns_no_warnings(self) -> None:
         lookups = {
             "interviewer_profile_id": LookupConfig(
                 table="interviewer_profiles",
@@ -743,7 +743,7 @@ class TestDetectAmbiguousLookupOrdering:
         }
         assert detect_ambiguous_lookup_ordering(lookups) == []
 
-    def test_disjoint_source_columns_returns_no_warnings(self):
+    def test_disjoint_source_columns_returns_no_warnings(self) -> None:
         # Two lookups, but no shared source column → order can't matter
         lookups = {
             "profile_id": LookupConfig(
@@ -761,8 +761,8 @@ class TestDetectAmbiguousLookupOrdering:
         }
         assert detect_ambiguous_lookup_ordering(lookups) == []
 
-    def test_shared_source_same_policy_returns_no_warnings(self):
-        # Same source column, same on_miss/check_only → order doesn't change fate
+    def test_shared_source_same_on_miss_returns_no_warnings(self) -> None:
+        # Same source column, same on_miss → order doesn't change fate
         lookups = {
             "a": LookupConfig(
                 table="a", match={"user_id": "user_id"}, select="id", on_miss="skip"
@@ -773,7 +773,27 @@ class TestDetectAmbiguousLookupOrdering:
         }
         assert detect_ambiguous_lookup_ordering(lookups) == []
 
-    def test_shared_source_different_on_miss_returns_warning(self):
+    def test_shared_source_same_on_miss_different_check_only_returns_no_warnings(self) -> None:
+        # Row fate on miss is determined by on_miss only. check_only only
+        # affects the HIT path, so two skip-policies (one check_only, one
+        # value-resolving) produce identical row outcomes — must NOT warn.
+        lookups = {
+            "user_exists": LookupConfig(
+                table="users",
+                match={"id": "user_id"},
+                check_only=True,
+                on_miss="skip",
+            ),
+            "profile_id": LookupConfig(
+                table="profiles",
+                match={"user_id": "user_id"},
+                select="id",
+                on_miss="skip",
+            ),
+        }
+        assert detect_ambiguous_lookup_ordering(lookups) == []
+
+    def test_shared_source_different_on_miss_returns_warning(self) -> None:
         # The exact scenario from #453
         lookups = {
             "interviewer_profile_id": LookupConfig(
@@ -796,7 +816,7 @@ class TestDetectAmbiguousLookupOrdering:
         assert "user_exists" in warnings[0]
         assert "#453" in warnings[0]
 
-    def test_warning_per_ambiguous_source_column(self):
+    def test_warning_per_ambiguous_source_column(self) -> None:
         # Two different source columns each ambiguous → two warnings
         lookups = {
             "a": LookupConfig(


### PR DESCRIPTION
## Summary

\`apply_lookups\` evaluates lookups in YAML insertion order and the **first miss wins** — that lookup's \`on_miss\` policy decides the row's fate, and the remaining lookups are not evaluated for that row.

When two lookups share a source column with different policies, a YAML key reorder can therefore flip the row's outcome silently. The issue body documents the exact failure:

\`\`\`yaml
# A — value-resolving first → fail wins, sync fails
lookups:
  interviewer_profile_id: { select: id, match: {user_id: user_id}, on_miss: fail }
  user_exists:            { check_only: true, match: {id: user_id}, on_miss: skip }
\`\`\`

\`\`\`yaml
# B — check_only first → skip wins, row silently dropped
lookups:
  user_exists:            { check_only: true, match: {id: user_id}, on_miss: skip }
  interviewer_profile_id: { select: id, match: {user_id: user_id}, on_miss: fail }
\`\`\`

### Approach (option 3-light)

Surface a warning at sync startup so the operator at least sees that ordering matters. Concretely:

- New \`detect_ambiguous_lookup_ordering()\` helper in \`drt/destinations/lookup.py\` — scans the lookups dict for shared source columns with differing \`(on_miss, check_only)\` policies and returns one warning per ambiguous source column
- One-shot warning emitted in \`drt/engine/sync.py\` via the existing \`drt\` logger, so it surfaces in \`--log-format json\` without per-batch noise
- Updated \`apply_lookups\` docstring noting the ordering invariant
- 6 unit tests: empty/single/disjoint/same-policy/ambiguous/multiple-ambiguous

### Why not option 2 (auto-sort)

The issue body and #449's review both noted that auto-sorting \`check_only\` first would silently change behavior for users who deliberately rely on the existing order — trading one surprise for another. Warning + leaving the call to the user keeps semantics explicit.

Closes #453

## Test plan

- [x] 6 new unit tests pass locally
- [x] All 46 existing \`test_lookup.py\` tests still pass
- [x] Ruff passes on changed files
- [x] Pre-existing type-annotation warnings in \`test_lookup.py\` are untouched (out of scope)
- [ ] CHANGELOG entry to be added once the PR # is final

🤖 Generated with [Claude Code](https://claude.com/claude-code)