### PR TITLE
docs(changelog): expand v0.7.3 entry to include PR #485 cherry-pick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,11 +49,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Theme: Patch release for Postgres schema-qualified identifier handling.**
 
-Cherry-pick of the Postgres fix above onto the v0.7.2 release line — so users on `drt-core~=0.7.2` get the fix without the v0.8.0 feature set. No new features, no breaking changes.
+Cherry-pick of PR #485 + PR #498 onto the v0.7.2 release line — so users on `drt-core~=0.7.2` get the fix without the v0.8.0 feature set. PR #485 completes the `psycopg2.sql` migration in the swap path (prerequisite); PR #498 then fixes the actual user-facing bug. No new features, no breaking changes.
 
 ### Fixed
 
-- **Postgres: qualified `schema.table` identifiers now safely composed** (#442, PR #498): follow-up to PR #452 / PR #485 (both in v0.7.2). The row-count, replace, swap, finalize, insert, and upsert SQL paths previously passed `f"{schema}.{table}"` style strings through `psycopg2.sql.Identifier()`, which double-quoted the entire dotted name into a single identifier (`"marketing.email_events"`) — so any Postgres destination configured with a schema-qualified table name failed at SQL execution. The fix splits qualified names into separate schema and relation `Identifier()` components, while keeping swap shadow/old suffixes attached to the relation name only (so `marketing.email_events` becomes `marketing."email_events__drt_swap"`, not a single quoted identifier). Contributed by @Photon101.
+- **Postgres: qualified `schema.table` identifiers now safely composed** (#442, PR #498): the row-count, replace, swap, finalize, insert, and upsert SQL paths previously passed `f"{schema}.{table}"` style strings through `psycopg2.sql.Identifier()`, which double-quoted the entire dotted name into a single identifier (`"marketing.email_events"`) — so any Postgres destination configured with a schema-qualified table name failed at SQL execution. The fix splits qualified names into separate schema and relation `Identifier()` components, while keeping swap shadow/old suffixes attached to the relation name only (so `marketing.email_events` becomes `marketing."email_events__drt_swap"`, not a single quoted identifier). Contributed by @Photon101.
+- **Postgres: swap path fully migrated to `psycopg2.sql` composition** (PR #485, fixes #483): prerequisite for the qualified-identifier fix above. The swap-path SQL (DROP TABLE IF EXISTS, CREATE TABLE LIKE, INSERT, ALTER TABLE RENAME, cleanup DROP) was still using f-string formatting; this commit migrates it to `psycopg2.sql.SQL` + `Identifier` for safe composition. Originally queued for v0.7.2 but landed post-release (#485's CLA signature was in v0.7.2 but the commit itself was not); bundled into this patch because PR #498 depends on it. Contributed by @Photon101.
 
 ## [0.7.2] - 2026-05-11
 


### PR DESCRIPTION
## Summary

Quick CHANGELOG accuracy fix discovered while preparing the \`release/0.7.3\` branch.

### What happened

PR #523 (just merged) added a v0.7.3 \`[0.7.3]\` section to \`CHANGELOG.md\` listing only PR #498 (the user-facing Postgres qualified identifier fix). When I cherry-picked PR #498 onto \`v0.7.2\` to build the release branch, it **conflicted on the swap path** because v0.7.2 does NOT actually contain PR #485 (despite v0.7.2's CHANGELOG entry claiming it does — the CLA signature for #485 was in v0.7.2 but the commit itself landed post-release).

PR #498 was built on top of PR #485's \`psycopg2.sql\` migration in the swap path, so the cherry-pick chain had to be:

1. PR #485 (\`chore: compose Postgres swap SQL safely\`, fixes #483) — prerequisite
2. PR #498 (\`fix: quote qualified Postgres table identifiers\`, closes #442) — the user-facing fix

Both are now on \`release/0.7.3\`. This PR updates \`main\`'s \`[0.7.3]\` section to reflect that reality.

### Changes

- \`CHANGELOG.md\` \`[0.7.3]\` section: header sentence updated from \"Cherry-pick of the Postgres fix above\" to \"Cherry-pick of PR #485 + PR #498\"; added a second \`### Fixed\` bullet documenting PR #485 with an explanation of why it's bundled

### Why not fix v0.7.2's CHANGELOG entry too?

Out of scope. The v0.7.2 entry's mention of #485 is historically inaccurate but the v0.7.2 PyPI wheel is already published and immutable. Adding a footnote would create more noise than value. The accurate record going forward starts at v0.7.3.

## Test plan

- [x] CHANGELOG renders correctly (markdown preview)
- [x] No source/test changes
- [x] \`make check-i18n\` not affected (CHANGELOG isn't translated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)