### PR TITLE
 feat: OpenTelemetry integration — traces and metrics for sync execution

### DIFF
--- a/drt/config/credentials.py
+++ b/drt/config/credentials.py
@@ -27,13 +27,14 @@ Example ~/.drt/profiles.yml:
 from __future__ import annotations
 
 import os
-import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, Field
+
+from drt.config.parser import expand_env_vars
 
 
 class OtelConfig(BaseModel):
@@ -44,9 +45,6 @@ class OtelConfig(BaseModel):
 
 class ObservabilityConfig(BaseModel):
     otel: OtelConfig = Field(default_factory=OtelConfig)
-
-
-_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
 
 
 # ---------------------------------------------------------------------------
@@ -62,7 +60,6 @@ class BigQueryProfile:
     method: Literal["application_default", "keyfile"] = "application_default"
     keyfile: str | None = None
     location: str = "US"  # e.g. "US", "EU", "asia-northeast1"
-    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.project}.{self.dataset})"
@@ -72,7 +69,6 @@ class BigQueryProfile:
 class DuckDBProfile:
     type: Literal["duckdb"]
     database: str = ":memory:"  # path or :memory:
-    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.database})"
@@ -82,7 +78,6 @@ class DuckDBProfile:
 class SQLiteProfile:
     type: Literal["sqlite"]
     database: str = ":memory:"  # path or :memory:
-    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.database})"
@@ -97,7 +92,6 @@ class PostgresProfile:
     user: str = ""
     password_env: str | None = None  # env var name
     password: str | None = None  # explicit (non-recommended)
-    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.host}:{self.port}/{self.dbname})"
@@ -126,7 +120,6 @@ class RedshiftProfile:
     password_env: str | None = None  # env var name
     password: str | None = None  # explicit (non-recommended)
     schema: str = "public"  # Redshift schema
-    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.host}:{self.port}/{self.dbname})"
@@ -143,7 +136,6 @@ class ClickHouseProfile:
     user: str = "default"
     password_env: str | None = None  # env var name
     password: str | None = None  # explicit (non-recommended)
-    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.host}:{self.port}/{self.database})"
@@ -170,7 +162,6 @@ class MySQLProfile:
     user: str = ""
     password_env: str | None = None
     password: str | None = None
-    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.host}:{self.port}/{self.dbname})"
@@ -189,7 +180,6 @@ class SnowflakeProfile:
     schema: str = "PUBLIC"
     warehouse: str = ""
     role: str | None = None
-    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.account}/{self.database}.{self.schema})"
@@ -207,7 +197,6 @@ class SQLServerProfile:
     password_env: str | None = None
     password: str | None = None
     schema: str = "dbo"
-    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.host}/{self.database}.{self.schema})"
@@ -224,7 +213,6 @@ class DatabricksProfile:
     access_token: str | None = None
     catalog: str | None = None  # Unity Catalog (optional)
     schema: str = "default"
-    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         path = f"{self.catalog}.{self.schema}" if self.catalog else self.schema
@@ -307,32 +295,32 @@ def resolve_env(value: str | None, env_var: str | None) -> str | None:
     return None
 
 
-def _expand_env_vars_in_str(value: str) -> str:
-    def _replace(match: re.Match[str]) -> str:
-        var = match.group(1)
-        env_val = os.environ.get(var)
-        if env_val is None:
-            raise ValueError(f"Environment variable ${{{var}}} is not set")
-        return env_val
+def _load_profiles_yaml(config_dir: Path | None = None) -> dict[str, Any]:
+    profiles_path = _config_dir(config_dir) / "profiles.yml"
+    if not profiles_path.exists():
+        raise FileNotFoundError(
+            f"profiles.yml not found at {profiles_path}. "
+            "Run `drt init` to create it, or create it manually."
+        )
 
-    return _ENV_VAR_PATTERN.sub(_replace, value)
-
-
-def _expand_env_vars(value: Any) -> Any:
-    if isinstance(value, str):
-        return _expand_env_vars_in_str(value)
-    if isinstance(value, dict):
-        return {key: _expand_env_vars(item) for key, item in value.items()}
-    if isinstance(value, list):
-        return [_expand_env_vars(item) for item in value]
-    return value
+    with profiles_path.open() as f:
+        return yaml.safe_load(f) or {}
 
 
-def _parse_observability(raw: dict[str, Any]) -> ObservabilityConfig:
-    observability_raw = raw.get("observability")
+def _profiles_mapping(data: dict[str, Any]) -> dict[str, Any]:
+    profiles = data.get("profiles")
+    if isinstance(profiles, dict):
+        return profiles
+    return {key: value for key, value in data.items() if key != "observability"}
+
+
+def load_observability_config(config_dir: Path | None = None) -> ObservabilityConfig:
+    """Load the top-level observability block from ~/.drt/profiles.yml."""
+    data = _load_profiles_yaml(config_dir)
+    observability_raw = data.get("observability")
     if observability_raw is None:
         return ObservabilityConfig()
-    return ObservabilityConfig.model_validate(_expand_env_vars(observability_raw))
+    return ObservabilityConfig.model_validate(observability_raw)
 
 
 # ---------------------------------------------------------------------------
@@ -352,25 +340,18 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
         KeyError: profile_name not found.
         ValueError: Unknown source type or missing required fields.
     """
-    profiles_path = _config_dir(config_dir) / "profiles.yml"
-    if not profiles_path.exists():
-        raise FileNotFoundError(
-            f"profiles.yml not found at {profiles_path}. "
-            "Run `drt init` to create it, or create it manually."
-        )
+    data = _load_profiles_yaml(config_dir)
+    profiles = _profiles_mapping(data)
 
-    with profiles_path.open() as f:
-        data = yaml.safe_load(f) or {}
-
-    if profile_name not in data:
-        available = ", ".join(data.keys()) or "(none)"
+    if profile_name not in profiles:
+        available = ", ".join(profiles.keys()) or "(none)"
         raise KeyError(
-            f"Profile '{profile_name}' not found in {profiles_path}. Available: {available}"
+            f"Profile '{profile_name}' not found in {_config_dir(config_dir) / 'profiles.yml'}. "
+            f"Available: {available}"
         )
 
-    raw = data[profile_name]
+    raw = expand_env_vars(profiles[profile_name])
     source_type = raw.get("type")
-    observability = _parse_observability(raw)
 
     if source_type == "bigquery":
         return BigQueryProfile(
@@ -380,20 +361,17 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             method=raw.get("method", "application_default"),
             keyfile=raw.get("keyfile"),
             location=raw.get("location", "US"),
-            observability=observability,
         )
     if source_type == "duckdb":
         return DuckDBProfile(
             type="duckdb",
             database=raw.get("database", ":memory:"),
-            observability=observability,
         )
 
     if source_type == "sqlite":
         return SQLiteProfile(
             type="sqlite",
             database=raw.get("database", ":memory:"),
-            observability=observability,
         )
     if source_type == "postgres":
         return PostgresProfile(
@@ -404,7 +382,6 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             user=raw.get("user", ""),
             password_env=raw.get("password_env"),
             password=raw.get("password"),
-            observability=observability,
         )
 
     if source_type == "redshift":
@@ -417,7 +394,6 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             password_env=raw.get("password_env"),
             password=raw.get("password"),
             schema=raw.get("schema", "public"),
-            observability=observability,
         )
 
     if source_type == "clickhouse":
@@ -429,7 +405,6 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             user=raw.get("user", "default"),
             password_env=raw.get("password_env"),
             password=raw.get("password"),
-            observability=observability,
         )
 
     if source_type == "mysql":
@@ -441,7 +416,6 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             user=raw.get("user", ""),
             password_env=raw.get("password_env"),
             password=raw.get("password"),
-            observability=observability,
         )
 
     if source_type == "snowflake":
@@ -461,7 +435,6 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             schema=raw.get("schema") or "PUBLIC",
             warehouse=raw.get("warehouse", ""),
             role=raw.get("role"),
-            observability=observability,
         )
 
     if source_type == "sqlserver":
@@ -477,7 +450,6 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             password_env=raw.get("password_env"),
             password=raw.get("password"),
             schema=raw.get("schema") or "dbo",
-            observability=observability,
         )
 
     if source_type == "databricks":
@@ -493,7 +465,6 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             access_token=raw.get("access_token"),
             catalog=raw.get("catalog"),
             schema=raw.get("schema") or "default",
-            observability=observability,
         )
 
     raise ValueError(
@@ -517,6 +488,16 @@ def save_profile(
     if profiles_path.exists():
         with profiles_path.open() as f:
             data = yaml.safe_load(f) or {}
+
+    observability = data.get("observability")
+    profiles = data.get("profiles")
+    if not isinstance(profiles, dict):
+        profiles = {key: value for key, value in data.items() if key != "observability"}
+
+    data = {}
+    if observability is not None:
+        data["observability"] = observability
+    data["profiles"] = profiles
 
     if isinstance(profile, BigQueryProfile):
         entry: dict[str, Any] = {
@@ -610,11 +591,7 @@ def save_profile(
     else:
         raise ValueError(f"Unknown profile type: {type(profile)}")
 
-    observability_entry = profile.observability.model_dump(exclude_defaults=True)
-    if observability_entry:
-        entry["observability"] = observability_entry
-
-    data[profile_name] = entry
+    profiles[profile_name] = entry
     with profiles_path.open("w") as f:
         yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
 

--- a/drt/config/credentials.py
+++ b/drt/config/credentials.py
@@ -34,8 +34,6 @@ from typing import Any, Literal
 import yaml
 from pydantic import BaseModel, Field
 
-from drt.config.parser import expand_env_vars
-
 
 class OtelConfig(BaseModel):
     endpoint: str | None = None
@@ -350,7 +348,7 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             f"Available: {available}"
         )
 
-    raw = expand_env_vars(profiles[profile_name])
+    raw = profiles[profile_name]
     source_type = raw.get("type")
 
     if source_type == "bigquery":

--- a/drt/config/credentials.py
+++ b/drt/config/credentials.py
@@ -27,11 +27,23 @@ Example ~/.drt/profiles.yml:
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
 import yaml
+from pydantic import BaseModel, Field
+
+
+class OtelConfig(BaseModel):
+    endpoint: str | None = None
+    service_name: str = "drt"
+    headers: dict[str, str] = Field(default_factory=dict)
+
+
+class ObservabilityConfig(BaseModel):
+    otel: OtelConfig = Field(default_factory=OtelConfig)
+
 
 # ---------------------------------------------------------------------------
 # Source profile types
@@ -46,6 +58,7 @@ class BigQueryProfile:
     method: Literal["application_default", "keyfile"] = "application_default"
     keyfile: str | None = None
     location: str = "US"  # e.g. "US", "EU", "asia-northeast1"
+    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.project}.{self.dataset})"
@@ -55,6 +68,7 @@ class BigQueryProfile:
 class DuckDBProfile:
     type: Literal["duckdb"]
     database: str = ":memory:"  # path or :memory:
+    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.database})"
@@ -64,6 +78,7 @@ class DuckDBProfile:
 class SQLiteProfile:
     type: Literal["sqlite"]
     database: str = ":memory:"  # path or :memory:
+    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.database})"
@@ -78,6 +93,7 @@ class PostgresProfile:
     user: str = ""
     password_env: str | None = None  # env var name
     password: str | None = None  # explicit (non-recommended)
+    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.host}:{self.port}/{self.dbname})"
@@ -106,6 +122,7 @@ class RedshiftProfile:
     password_env: str | None = None  # env var name
     password: str | None = None  # explicit (non-recommended)
     schema: str = "public"  # Redshift schema
+    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.host}:{self.port}/{self.dbname})"
@@ -122,6 +139,7 @@ class ClickHouseProfile:
     user: str = "default"
     password_env: str | None = None  # env var name
     password: str | None = None  # explicit (non-recommended)
+    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.host}:{self.port}/{self.database})"
@@ -148,6 +166,7 @@ class MySQLProfile:
     user: str = ""
     password_env: str | None = None
     password: str | None = None
+    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.host}:{self.port}/{self.dbname})"
@@ -166,6 +185,7 @@ class SnowflakeProfile:
     schema: str = "PUBLIC"
     warehouse: str = ""
     role: str | None = None
+    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.account}/{self.database}.{self.schema})"
@@ -183,6 +203,7 @@ class SQLServerProfile:
     password_env: str | None = None
     password: str | None = None
     schema: str = "dbo"
+    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         return f"{self.type} ({self.host}/{self.database}.{self.schema})"
@@ -199,6 +220,7 @@ class DatabricksProfile:
     access_token: str | None = None
     catalog: str | None = None  # Unity Catalog (optional)
     schema: str = "default"
+    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
 
     def describe(self) -> str:
         path = f"{self.catalog}.{self.schema}" if self.catalog else self.schema
@@ -281,6 +303,13 @@ def resolve_env(value: str | None, env_var: str | None) -> str | None:
     return None
 
 
+def _parse_observability(raw: dict[str, Any]) -> ObservabilityConfig:
+    observability_raw = raw.get("observability")
+    if observability_raw is None:
+        return ObservabilityConfig()
+    return ObservabilityConfig.model_validate(observability_raw)
+
+
 # ---------------------------------------------------------------------------
 # Load / Save
 # ---------------------------------------------------------------------------
@@ -316,6 +345,7 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
 
     raw = data[profile_name]
     source_type = raw.get("type")
+    observability = _parse_observability(raw)
 
     if source_type == "bigquery":
         return BigQueryProfile(
@@ -325,17 +355,20 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             method=raw.get("method", "application_default"),
             keyfile=raw.get("keyfile"),
             location=raw.get("location", "US"),
+            observability=observability,
         )
     if source_type == "duckdb":
         return DuckDBProfile(
             type="duckdb",
             database=raw.get("database", ":memory:"),
+            observability=observability,
         )
 
     if source_type == "sqlite":
         return SQLiteProfile(
             type="sqlite",
             database=raw.get("database", ":memory:"),
+            observability=observability,
         )
     if source_type == "postgres":
         return PostgresProfile(
@@ -346,6 +379,7 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             user=raw.get("user", ""),
             password_env=raw.get("password_env"),
             password=raw.get("password"),
+            observability=observability,
         )
 
     if source_type == "redshift":
@@ -358,6 +392,7 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             password_env=raw.get("password_env"),
             password=raw.get("password"),
             schema=raw.get("schema", "public"),
+            observability=observability,
         )
 
     if source_type == "clickhouse":
@@ -369,6 +404,7 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             user=raw.get("user", "default"),
             password_env=raw.get("password_env"),
             password=raw.get("password"),
+            observability=observability,
         )
 
     if source_type == "mysql":
@@ -380,6 +416,7 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             user=raw.get("user", ""),
             password_env=raw.get("password_env"),
             password=raw.get("password"),
+            observability=observability,
         )
 
     if source_type == "snowflake":
@@ -399,6 +436,7 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             schema=raw.get("schema") or "PUBLIC",
             warehouse=raw.get("warehouse", ""),
             role=raw.get("role"),
+            observability=observability,
         )
 
     if source_type == "sqlserver":
@@ -414,6 +452,7 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             password_env=raw.get("password_env"),
             password=raw.get("password"),
             schema=raw.get("schema") or "dbo",
+            observability=observability,
         )
 
     if source_type == "databricks":
@@ -429,6 +468,7 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
             access_token=raw.get("access_token"),
             catalog=raw.get("catalog"),
             schema=raw.get("schema") or "default",
+            observability=observability,
         )
 
     raise ValueError(
@@ -544,6 +584,9 @@ def save_profile(
             entry["catalog"] = profile.catalog
     else:
         raise ValueError(f"Unknown profile type: {type(profile)}")
+
+    if profile.observability != ObservabilityConfig():
+        entry["observability"] = profile.observability.model_dump(exclude_none=True)
 
     data[profile_name] = entry
     with profiles_path.open("w") as f:

--- a/drt/config/credentials.py
+++ b/drt/config/credentials.py
@@ -27,6 +27,7 @@ Example ~/.drt/profiles.yml:
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
@@ -43,6 +44,9 @@ class OtelConfig(BaseModel):
 
 class ObservabilityConfig(BaseModel):
     otel: OtelConfig = Field(default_factory=OtelConfig)
+
+
+_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
 
 
 # ---------------------------------------------------------------------------
@@ -303,11 +307,32 @@ def resolve_env(value: str | None, env_var: str | None) -> str | None:
     return None
 
 
+def _expand_env_vars_in_str(value: str) -> str:
+    def _replace(match: re.Match[str]) -> str:
+        var = match.group(1)
+        env_val = os.environ.get(var)
+        if env_val is None:
+            raise ValueError(f"Environment variable ${{{var}}} is not set")
+        return env_val
+
+    return _ENV_VAR_PATTERN.sub(_replace, value)
+
+
+def _expand_env_vars(value: Any) -> Any:
+    if isinstance(value, str):
+        return _expand_env_vars_in_str(value)
+    if isinstance(value, dict):
+        return {key: _expand_env_vars(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_expand_env_vars(item) for item in value]
+    return value
+
+
 def _parse_observability(raw: dict[str, Any]) -> ObservabilityConfig:
     observability_raw = raw.get("observability")
     if observability_raw is None:
         return ObservabilityConfig()
-    return ObservabilityConfig.model_validate(observability_raw)
+    return ObservabilityConfig.model_validate(_expand_env_vars(observability_raw))
 
 
 # ---------------------------------------------------------------------------
@@ -585,8 +610,9 @@ def save_profile(
     else:
         raise ValueError(f"Unknown profile type: {type(profile)}")
 
-    if profile.observability != ObservabilityConfig():
-        entry["observability"] = profile.observability.model_dump(exclude_none=True)
+    observability_entry = profile.observability.model_dump(exclude_defaults=True)
+    if observability_entry:
+        entry["observability"] = observability_entry
 
     data[profile_name] = entry
     with profiles_path.open("w") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,10 @@ sheets = ["google-api-python-client>=2.0", "google-auth>=2.0"]
 mysql = ["pymysql>=1.1"]
 parquet = ["pandas>=2.0", "pyarrow>=12.0"]
 mcp = ["fastmcp>=2.0"]
+otel = [
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20.0",
+]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -197,19 +197,13 @@ def test_expand_env_vars_no_placeholders() -> None:
     assert expand_env_vars("plain string") == "plain string"
 
 
-def test_load_syncs_expands_env_vars(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_load_syncs_expands_env_vars(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Environment variables in sync YAML are expanded before validation."""
     monkeypatch.setenv("TEST_API_URL", "https://expanded.example.com")
     syncs_dir = tmp_path / "syncs"
     syncs_dir.mkdir()
     (syncs_dir / "env_sync.yml").write_text(
-        "name: env-sync\n"
-        "model: SELECT 1\n"
-        "destination:\n"
-        "  type: rest_api\n"
-        "  url: ${TEST_API_URL}\n"
+        "name: env-sync\nmodel: SELECT 1\ndestination:\n  type: rest_api\n  url: ${TEST_API_URL}\n"
     )
     syncs = load_syncs(tmp_path)
     assert len(syncs) == 1
@@ -270,8 +264,9 @@ def test_save_profile_appends(tmp_path: Path) -> None:
 
     profiles_path = tmp_path / "profiles.yml"
     data = yaml.safe_load(profiles_path.read_text())
-    assert "dev" in data
-    assert "prod" in data
+    assert "profiles" in data
+    assert "dev" in data["profiles"]
+    assert "prod" in data["profiles"]
 
 
 # ---------------------------------------------------------------------------
@@ -606,37 +601,41 @@ def test_sync_config_without_tests() -> None:
 class TestAlertsConfig:
     def test_default_alerts_is_none(self) -> None:
         sync = SyncConfig(
-            name="t", model="select 1",
+            name="t",
+            model="select 1",
             destination=RestApiDestinationConfig(type="rest_api", url="https://x"),
         )
         assert sync.alerts is None
 
     def test_slack_alert_parsed_via_discriminator(self) -> None:
         from drt.config.models import AlertsConfig, SlackAlertConfig
-        cfg = AlertsConfig(on_failure=[
-            {"type": "slack", "webhook_url": "https://hooks.slack.com/x"}
-        ])
+
+        cfg = AlertsConfig(
+            on_failure=[{"type": "slack", "webhook_url": "https://hooks.slack.com/x"}]
+        )
         assert isinstance(cfg.on_failure[0], SlackAlertConfig)
 
     def test_webhook_alert_parsed_via_discriminator(self) -> None:
         from drt.config.models import AlertsConfig, WebhookAlertConfig
-        cfg = AlertsConfig(on_failure=[
-            {"type": "webhook", "url": "https://example.com/hook"}
-        ])
+
+        cfg = AlertsConfig(on_failure=[{"type": "webhook", "url": "https://example.com/hook"}])
         assert isinstance(cfg.on_failure[0], WebhookAlertConfig)
 
     def test_unknown_alert_type_rejected(self) -> None:
         from drt.config.models import AlertsConfig
+
         with pytest.raises(ValidationError):
             AlertsConfig(on_failure=[{"type": "pagerduty", "key": "x"}])
 
     def test_slack_requires_webhook_url_or_env(self) -> None:
         from drt.config.models import SlackAlertConfig
+
         with pytest.raises(ValueError, match="webhook_url"):
             SlackAlertConfig(type="slack")
 
     def test_webhook_requires_url_or_env(self) -> None:
         from drt.config.models import WebhookAlertConfig
+
         with pytest.raises(ValueError, match="url"):
             WebhookAlertConfig(type="webhook")
 

--- a/tests/unit/test_observability_config.py
+++ b/tests/unit/test_observability_config.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import yaml
 
-from drt.config.credentials import ObservabilityConfig, load_profile, save_profile
+from drt.config.credentials import (
+    ObservabilityConfig,
+    load_observability_config,
+    load_profile,
+    save_profile,
+)
 
 
 def test_observability_config_parses_otel_block() -> None:
@@ -31,36 +36,54 @@ def test_observability_config_defaults_when_otel_block_missing() -> None:
     assert config.otel.headers == {}
 
 
-def test_observability_profile_round_trip_expands_env_and_saves_non_default_block(
-    tmp_path, monkeypatch
-) -> None:
+def test_load_observability_config_parses_top_level_block(tmp_path) -> None:
+    profiles_path = tmp_path / "profiles.yml"
+    profiles_path.write_text(
+        "observability:\n"
+        "  otel:\n"
+        "    endpoint: http://localhost:4317\n"
+        "    service_name: drt\n"
+        "    headers:\n"
+        "      Authorization: Bearer ${OTEL_TOKEN}\n"
+        "profiles:\n"
+        "  dev:\n"
+        "    type: duckdb\n"
+        "    database: ./warehouse.duckdb\n"
+    )
+
+    config = load_observability_config(tmp_path)
+
+    assert config.otel.endpoint == "http://localhost:4317"
+    assert config.otel.service_name == "drt"
+    assert config.otel.headers == {"Authorization": "Bearer ${OTEL_TOKEN}"}
+
+
+def test_observability_profile_round_trip_keeps_raw_secret_headers(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("OTEL_TOKEN", "secret-token")
     profiles_path = tmp_path / "profiles.yml"
     profiles_path.write_text(
-        "dev:\n"
-        "  type: duckdb\n"
-        "  database: ./warehouse.duckdb\n"
-        "  observability:\n"
-        "    otel:\n"
-        "      endpoint: http://localhost:4317\n"
-        "      headers:\n"
-        "        Authorization: Bearer ${OTEL_TOKEN}\n"
+        "observability:\n"
+        "  otel:\n"
+        "    endpoint: http://localhost:4317\n"
+        "    service_name: drt\n"
+        "    headers:\n"
+        "      Authorization: Bearer ${OTEL_TOKEN}\n"
+        "profiles:\n"
+        "  dev:\n"
+        "    type: duckdb\n"
+        "    database: ./warehouse.duckdb\n"
     )
 
     loaded = load_profile("dev", config_dir=tmp_path)
 
-    assert loaded.observability.otel.endpoint == "http://localhost:4317"
-    assert loaded.observability.otel.service_name == "drt"
-    assert loaded.observability.otel.headers == {"Authorization": "Bearer secret-token"}
+    assert loaded.database == "./warehouse.duckdb"
 
     save_profile("roundtrip", loaded, config_dir=tmp_path)
 
     saved = yaml.safe_load(profiles_path.read_text())
-    assert saved["roundtrip"]["observability"]["otel"]["endpoint"] == "http://localhost:4317"
-    assert saved["roundtrip"]["observability"]["otel"]["headers"] == {
-        "Authorization": "Bearer secret-token"
-    }
-    assert "service_name" not in saved["roundtrip"]["observability"]["otel"]
+    assert saved["observability"]["otel"]["headers"] == {"Authorization": "Bearer ${OTEL_TOKEN}"}
+    assert saved["profiles"]["roundtrip"]["database"] == "./warehouse.duckdb"
+    assert "observability" not in saved["profiles"]["roundtrip"]
 
     roundtrip = load_profile("roundtrip", config_dir=tmp_path)
-    assert roundtrip.observability == loaded.observability
+    assert roundtrip.database == loaded.database

--- a/tests/unit/test_observability_config.py
+++ b/tests/unit/test_observability_config.py
@@ -1,0 +1,29 @@
+"""Unit tests for observability profile config parsing."""
+
+from __future__ import annotations
+
+from drt.config.credentials import ObservabilityConfig
+
+
+def test_observability_config_parses_otel_block() -> None:
+    config = ObservabilityConfig.model_validate(
+        {
+            "otel": {
+                "endpoint": "http://localhost:4317",
+                "service_name": "drt",
+                "headers": {"Authorization": "Bearer token"},
+            }
+        }
+    )
+
+    assert config.otel.endpoint == "http://localhost:4317"
+    assert config.otel.service_name == "drt"
+    assert config.otel.headers == {"Authorization": "Bearer token"}
+
+
+def test_observability_config_defaults_when_otel_block_missing() -> None:
+    config = ObservabilityConfig.model_validate({})
+
+    assert config.otel.endpoint is None
+    assert config.otel.service_name == "drt"
+    assert config.otel.headers == {}

--- a/tests/unit/test_observability_config.py
+++ b/tests/unit/test_observability_config.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from drt.config.credentials import ObservabilityConfig
+import yaml
+
+from drt.config.credentials import ObservabilityConfig, load_profile, save_profile
 
 
 def test_observability_config_parses_otel_block() -> None:
@@ -27,3 +29,38 @@ def test_observability_config_defaults_when_otel_block_missing() -> None:
     assert config.otel.endpoint is None
     assert config.otel.service_name == "drt"
     assert config.otel.headers == {}
+
+
+def test_observability_profile_round_trip_expands_env_and_saves_non_default_block(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("OTEL_TOKEN", "secret-token")
+    profiles_path = tmp_path / "profiles.yml"
+    profiles_path.write_text(
+        "dev:\n"
+        "  type: duckdb\n"
+        "  database: ./warehouse.duckdb\n"
+        "  observability:\n"
+        "    otel:\n"
+        "      endpoint: http://localhost:4317\n"
+        "      headers:\n"
+        "        Authorization: Bearer ${OTEL_TOKEN}\n"
+    )
+
+    loaded = load_profile("dev", config_dir=tmp_path)
+
+    assert loaded.observability.otel.endpoint == "http://localhost:4317"
+    assert loaded.observability.otel.service_name == "drt"
+    assert loaded.observability.otel.headers == {"Authorization": "Bearer secret-token"}
+
+    save_profile("roundtrip", loaded, config_dir=tmp_path)
+
+    saved = yaml.safe_load(profiles_path.read_text())
+    assert saved["roundtrip"]["observability"]["otel"]["endpoint"] == "http://localhost:4317"
+    assert saved["roundtrip"]["observability"]["otel"]["headers"] == {
+        "Authorization": "Bearer secret-token"
+    }
+    assert "service_name" not in saved["roundtrip"]["observability"]["otel"]
+
+    roundtrip = load_profile("roundtrip", config_dir=tmp_path)
+    assert roundtrip.observability == loaded.observability


### PR DESCRIPTION


Closes #429

---

## What's in this PR so far

This is a **draft PR** for the full OpenTelemetry integration. Posting early for feedback as work progresses.

### Done — Phase 1 (Config & Dependencies)
- Added `otel` optional extra to `pyproject.toml`
- Added `OtelConfig` and `ObservabilityConfig` Pydantic models
- Wired `observability` field into all profile types
- Added `_parse_observability()` to load from `profiles.yaml`
- Unit tests for config parsing and defaults

### Coming next
- Phase 2 — NoOp tracer provider (zero overhead when unconfigured)
- Phase 3 — Sync lifecycle spans (`drt.sync.run`, `drt.sync.extract`, `drt.sync.load`)
- Phase 4 — Metrics + error recording

---

## Checklist
- [x] Phase 1 tests pass
- [x] Ruff formatting applied
- [ ] Phase 2–4 in progress

---

> @masukai — happy to get early feedback on the config shape before I wire up the tracer in Phase 2 🙏