### PR TITLE
docs(i18n): sync README.ja.md with Zendesk destination (#504)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-sync: base=README.md, hash=088072f66b5441ce899902bdeae46fbce237c611 -->
+<!-- i18n-sync: base=README.md, hash=200d17e173906dc78d97f66bedbb37f653ca6be8 -->
 
 [English](./README.md) | [日本語](./README.ja.md)
 
@@ -256,6 +256,7 @@ Claude Codeの公式スキルをインストールすると、チャットイン
 | Discord Webhook | ✅ v0.4.2 | (core) | Webhook URL |
 | GitHub Actions | ✅ v0.1 | (core) | Token（環境変数） |
 | HubSpot | ✅ v0.1 | (core) | Token（環境変数） |
+| Zendesk | ✅ v0.7 | (core) | Basic（メールアドレス + API トークン） |
 | Google Ads | ✅ v0.6 | (core) | OAuth2 Client Credentials |
 | Google Sheets | ✅ v0.4 | `pip install drt-core[sheets]` | Service Account Keyfile |
 | PostgreSQL (upsert) | ✅ v0.4 | `pip install drt-core[postgres]` | パスワード（環境変数） |


### PR DESCRIPTION
## What

Syncs `README.ja.md` with the Zendesk destination row that #504 added to `README.md`.

- Adds the `Zendesk` row to the destinations table (between HubSpot and Google Ads, matching the English ordering).
- Bumps the `i18n-sync` marker hash to `200d17e` — the merge commit of #504, which is the latest commit to touch `README.md`.

## Why

#504 (Zendesk destination) modified `README.md`, leaving `README.ja.md` stale. `make check-i18n` flags this. The net `README.md` content delta since the previously-recorded hash is exactly the one Zendesk row, so this single row + hash bump fully re-syncs the translation.

## Verification

```
$ bash scripts/check-i18n-sync.sh
OK    CONTRIBUTING.ja.md  (synced with CONTRIBUTING.md)
SKIP  GOVERNANCE.ja.md  (no i18n-sync marker)
OK    README.ja.md  (synced with README.md)
Checked 2 translation(s).
```

Docs-only change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)