### PR TITLE
docs(roadmap): mark REST API source + Zendesk as shipped in v0.8

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,7 +44,8 @@ Strict patch release — cherry-pick of PR #498 (Postgres schema-qualified `Iden
 
 **Scope:**
 - **Cloud destinations** — BigQuery (#165) · Databricks Delta Lake (#167) · S3 Parquet/CSV (#168) · GCS (#169) · Azure Blob (#170) — *Snowflake (#164) shipped early in v0.7 via PR #353*
-- **Lakehouse sources** — Delta Lake (#172) · Apache Iceberg (#173)
+- **SaaS destinations** — *Zendesk (#421) shipped via PR #504 — pattern reference for future SaaS connectors*
+- **Sources** — REST API (#422) ✅ *shipped via PR #474 — first non-database source, pattern reference for future API sources* · Delta Lake (#172) · Apache Iceberg (#173)
 - **Reliability follow-on** — dead letter queue (#278) — *opt-in telemetry (#263) moved up to v0.7*
 - **Correctness epic** — schema-aware serialization via INFORMATION_SCHEMA (#317)
 - **Engine** — `sync.mode: mirror` differential delete (#340)


### PR DESCRIPTION
## Summary

Two v0.8 milestone items shipped recently but the ROADMAP scope bullets didn't reflect it:

- **REST API source** (#422, PR #474) — merged today (2026-05-23). First non-database source; lays the architectural pattern for future API sources (the v0.8 source-diversification slice).
- **Zendesk destination** (#421, PR #504) — merged 2026-05-13. First SaaS destination of this milestone; pattern reference for future SaaS connectors.

This PR adds them to the v0.8 Scope block using the same italic-shipped-via-PR style already used for `Snowflake (#164) shipped early in v0.7 via PR #353`. The "Lakehouse sources" bullet becomes "Sources" so REST API can sit alongside the still-open Delta Lake / Iceberg work.

## Why now

[CLAUDE.md](CLAUDE.md) and a [memory I keep across sessions](https://github.com/drt-hub/drt/blob/main/.claude/CLAUDE.md) both call out ROADMAP.md as SSoT for upcoming releases. Letting it drift from milestone state defeats that purpose — anyone glancing at v0.8 right now would think REST API hadn't started.

## Test plan

- [x] `git diff ROADMAP.md` shows only the two-line scope change
- [x] Linked PRs (#474, #504) are merged on `main` and tagged in their respective CHANGELOG `[Unreleased]` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>