### PR TITLE
refactor(rest-api): polish follow-ups from PR #474 (closes 4/5 items of #530)

### DIFF
--- a/drt/sources/rest_api.py
+++ b/drt/sources/rest_api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, cast
 
 import httpx
 from pydantic import TypeAdapter
@@ -28,6 +28,13 @@ class RestApiSource(Source):
     """Extract records from a REST API endpoint."""
 
     def extract(self, query: str, config: ProfileConfig) -> Iterator[dict[str, Any]]:
+        """Extract records from the configured REST endpoint.
+
+        The ``query`` argument is part of the ``Source`` Protocol (used by SQL
+        sources for the SELECT statement) and is **ignored** here — for REST,
+        the endpoint URL and pagination strategy come from ``config`` (the
+        ``RestApiProfile`` block in ``profiles.yml``).
+        """
         assert isinstance(config, RestApiProfile)
 
         auth_config: AuthConfig | None = None
@@ -126,14 +133,21 @@ class RestApiSource(Source):
         if not result_path:
             # Default behavior if no result_path:
             if isinstance(data, list):
-                return data  # type: ignore[no-any-return]
+                return cast(list[dict[str, Any]], data)
             if isinstance(data, dict) and "records" in data:
-                return data["records"]  # type: ignore[no-any-return]
+                return cast(list[dict[str, Any]], data["records"])
             if isinstance(data, dict) and "data" in data:
                 items = data["data"]
                 if isinstance(items, list):
-                    return items  # type: ignore[no-any-return]
-            return [data] if isinstance(data, dict) else []
+                    return cast(list[dict[str, Any]], items)
+            if isinstance(data, dict):
+                logger.debug(
+                    "REST source: no records array found in response; "
+                    "wrapping single dict as one record (keys=%s)",
+                    list(data.keys()),
+                )
+                return [data]
+            return []
 
         # Simple dot notation resolution
         current = data
@@ -144,7 +158,7 @@ class RestApiSource(Source):
                 return []
 
         if isinstance(current, list):
-            return current  # type: ignore[no-any-return]
+            return cast(list[dict[str, Any]], current)
         if isinstance(current, dict):
             return [current]
         return []

--- a/tests/unit/test_rest_api_source.py
+++ b/tests/unit/test_rest_api_source.py
@@ -1,8 +1,10 @@
 """Tests for RestApiSource."""
 
+import logging
 from typing import Any
 
 import httpx
+import pytest
 
 from drt.config.credentials import RestApiProfile
 from drt.sources.rest_api import RestApiSource
@@ -35,6 +37,26 @@ def test_rest_api_source_extract_records() -> None:
 
     # With object at path instead of array
     assert source._extract_records(data, "response") == [{"items": [{"id": 1}, {"id": 2}]}]
+
+
+def test_rest_api_source_extract_records_single_dict_fallback_logs_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When a response is a dict with neither 'records' nor 'data' arrays, the source
+    wraps the dict as a single-record list (e.g. `{"error": "..."}` becomes one row).
+    This is easy to miss, so the source emits a debug log noting the fallback shape.
+    """
+    source = RestApiSource()
+
+    with caplog.at_level(logging.DEBUG, logger="drt"):
+        result = source._extract_records({"error": "rate limit exceeded"}, None)
+
+    assert result == [{"error": "rate limit exceeded"}]
+    assert any(
+        "wrapping single dict as one record" in record.message
+        and "error" in record.message  # keys logged
+        for record in caplog.records
+    )
 
 
 def test_rest_api_source_extract_single_page(monkeypatch: Any) -> None:


### PR DESCRIPTION
## Summary

Addresses 4 of the 5 polish items raised in the PR #474 approval review and tracked in #530:

- **Item 2 — Document the `query` parameter on `RestApiSource.extract`.** The Source Protocol passes `query: str` (SQL sources use it for the SELECT statement) but REST gets its URL from `config.url` and silently ignores `query`. A one-line docstring now makes that explicit.
- **Item 3 — Replace `# type: ignore[no-any-return]` with `cast`.** Per [CLAUDE.md](CLAUDE.md), `type: ignore` is reserved for external-library issues, but the four ignores in `_extract_records` were on pure-Python narrowing paths after `isinstance` checks. They now use `cast(list[dict[str, Any]], ...)`.
- **Items 4 + 5 — Wire the module logger to the single-dict fallback.** The module-level `logger = logging.getLogger("drt")` was unreferenced. The `_extract_records` fallback path (`return [data] if isinstance(data, dict) else []`) silently wraps a single dict (e.g. an `{"error": "..."}` error payload) as one record — easy to miss in production. The fallback now emits a debug log noting the wrap and the wrapped dict's keys.

**Item 1 — Lift `_extract_next_link` into a shared HTTP util** is intentionally left in #530 for a community contributor (cross-file refactor with new file creation is the most "good first issue"-shaped of the five).

## What this is NOT

- No runtime behavior change. `_extract_records` returns the same lists/values it did before. The fallback debug log is the only observable difference, and only under `--log-level debug`.
- No new dependencies.
- No public API change (the `extract()` signature and behavior are unchanged; only the docstring is added).

## Test plan

- [x] `make test` — `1057 passed, 1 skipped` (one new test added: `test_rest_api_source_extract_records_single_dict_fallback_logs_debug`)
- [x] `make lint` — ruff + mypy clean (0 issues)
- [x] No `type: ignore` remains in `drt/sources/rest_api.py` (verified by grep)
- [ ] Update #530 to check off items 2 / 3 / 4 / 5 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>