### PR TITLE
docs(roadmap): add v0.7.5 Tech Foundation Hardening section

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,6 +46,22 @@ Strict patch release — cherry-pick of PR #514 (MySQL `_quote_ident` applied ac
 
 ---
 
+## v0.7.5 — Tech Foundation Hardening
+
+**Theme:** Lock in the foundations before v0.8 Cloud Destinations push — CI reach, functional test coverage for the reverse-ETL paths, CLI/UX polish, and targeted refactors of the modules that have grown across v0.6→v0.7.
+
+**Scope:**
+- **CI strengthening** — nightly schedule + publish-time lint/test gate · supply-chain scans (CodeQL, pip-audit, SBOM)
+- **Functional test coverage** — DuckDB Source dedicated test + end-to-end harness (DuckDB → FakeDestination, building on FakeSource #364) · boundary cases (idempotency / large batches / schema evolution / type conversion)
+- **UX** — `drt sources --detailed` / `drt destinations --detailed` (auth method, required env vars, sample YAML) · `ErrorFormatter` for `drt run` failures (sync name, stage, suggested next step) · `drt init --template <connector>` quickstart scaffolds + README → docs/ entry-point
+- **Refactor** (gated on open contributor PRs to avoid rebase churn) — `cli/main.py` handler split (after #522) · `destinations/postgres.py` + `mysql.py` serializer consolidation (after #492) · `engine/sync.py` I/O boundary tightening for the Rust migration (after #527) · `config/models.py` `BaseDestinationConfig` extraction
+
+**Out of scope:** New connectors (→ v0.8), new engine features (`sync.mode: mirror` → v0.8), Open Core interfaces (→ v0.9), Rust migration itself (→ v1.x).
+
+**Target:** 2026-06 · **Progress:** [milestone/11](https://github.com/drt-hub/drt/milestone/11)
+
+---
+
 ## v0.8 — Cloud Destinations & Growth
 
 **Theme:** DWH/Lakehouse destinations + community growth push.


### PR DESCRIPTION
## Summary

Adds a new `v0.7.5 — Tech Foundation Hardening` section to ROADMAP.md between v0.7.4 and v0.8, capturing the foundation-strengthening epic identified during the post-v0.7.4 retrospective.

Per the ROADMAP SSoT rule, this section lands **first** — the epic + child issues will be filed after this PR is reviewed/merged.

## Scope captured in v0.7.5

- **CI strengthening** — nightly schedule + publish-time lint/test gate · supply-chain scans (CodeQL, pip-audit, SBOM)
- **Functional test coverage** — DuckDB Source dedicated test + end-to-end harness · boundary cases (idempotency / large batches / schema evolution / type conversion)
- **UX** — `drt sources --detailed` / `drt destinations --detailed` · `ErrorFormatter` for `drt run` failures · `drt init --template <connector>` quickstart scaffolds + README → docs/ entry-point
- **Refactor** (gated on open PRs) — `cli/main.py` split (after #522) · destinations serializer (after #492) · `engine/sync.py` I/O boundary (after #527) · `config/models.py` base class extraction

**Out of scope:** new connectors (→ v0.8), engine features unrelated to hardening (→ v0.8), Open Core interfaces (→ v0.9), Rust migration itself (→ v1.x).

**Target:** 2026-06 · **Milestone:** [v0.7.5 (#11)](https://github.com/drt-hub/drt/milestone/11)

## Why now

`v0.6 → v0.7.4` has accumulated meaningful surface area: `cli/main.py` ~1.5k LOC, `config/models.py` ~800 LOC, 40+ Destination configs in one file, ~50-100 lines of duplicated `_serialize_value()` between Postgres/MySQL, and engine I/O boundaries that have drifted from the "pure" contract documented in CLAUDE.md. Functional checks for `drt run` end-to-end (DuckDB → destination) are also thin — most coverage is in unit tests with `FakeSource`/mocks. v0.7.5 is the chance to harden these before v0.8 Cloud Destinations multiplies the surface area further.

## Test plan

- [ ] `make check-i18n` (ROADMAP.md is English-only, but sanity check)
- [ ] Verify rendered Markdown anchors on GitHub (the `#v075` link inside the milestone description should resolve)
- [ ] Confirm milestone v0.7.5 (#11) appears in the milestones list after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)