### PR TITLE
test: add DuckDB Source tests + reverse-ETL E2E harness (closes #541)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: pip install uv
 
       - name: Install dependencies
-        run: uv pip install --system -e ".[dev,mcp]"
+        run: uv pip install --system -e ".[dev,mcp,duckdb]"
 
       - name: Lint (ruff)
         run: ruff check drt tests

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,62 @@
+# Integration tests
+
+End-to-end tests that drive the full reverse-ETL pipeline: real Source →
+engine → real Destination process. Unlike the unit suite, these tests do
+not mock `drt.sources.*` or `drt.destinations.*` internals — both ends run
+their real I/O paths (a real `duckdb.connect()`, a real HTTP server, etc.).
+
+## Why this exists
+
+Unit tests are good at catching logic regressions inside a single module,
+but they cannot catch breakage at the seams: a Source whose row dict shape
+silently drifts, a destination that stops honoring `batch_size`, a resolver
+that returns SQL the Source cannot parse. The integration suite is the
+regression net for the seams.
+
+## The harness pattern
+
+Every Source E2E test follows the same three-part shape:
+
+1. **Seed a real Source** — a fixture creates the actual database / file
+   / API state the Source will read from.
+2. **Run `engine.run_sync`** with that Source and a destination wired to a
+   controllable receiver (today: `pytest-httpserver` as a REST endpoint).
+3. **Assert on both sides** — what the engine reports (`SyncResult`) and
+   what the receiver actually saw.
+
+The destination side is the same across every Source. The fixture is the
+only thing that swaps.
+
+## Adding a new Source E2E
+
+To add `test_postgres_e2e.py`, `test_mysql_e2e.py`, `test_snowflake_e2e.py`,
+etc.:
+
+1. Add a `<source>_with_users` fixture in `conftest.py` that:
+   - Creates a real database (use `tmp_path` for file-backed engines;
+     consider `testcontainers` or a docker-compose service for
+     server-backed engines)
+   - Seeds a `users (id, name, email)` table with three rows so the
+     E2E test bodies stay copy-paste compatible
+   - Returns `(source, profile)` — the model field on `SyncConfig` will
+     be `ref('users')`, which the resolver turns into the right dialect's
+     `SELECT * FROM users`
+2. Copy `test_duckdb_e2e.py` and rename the import + fixture name. The
+   destination-side helpers (`_dest_config`, `_sync`) and the four
+   canonical assertions (full pipeline / empty result / value flow /
+   connection test) carry over unchanged.
+3. If the Source driver is an optional extra (e.g. `pip install
+   drt-core[postgres]`), gate the fixture with
+   `pytest.importorskip("<driver_module>")` so dev environments without
+   the extra installed still pass test collection.
+4. Add the driver to the CI install line in `.github/workflows/ci.yml`
+   so the test actually runs in CI rather than skipping silently.
+
+## What does NOT belong here
+
+- Pure logic tests on engine/resolver/state internals — those go in
+  `tests/unit/`
+- Tests that need `FakeSource` for speed and don't need a real Source —
+  use the existing `FakeSource` fixture in this `conftest.py`
+- Tests against a third-party live API (HubSpot, Salesforce, etc.) —
+  those should use recorded fixtures or a stub server, not the live API

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 
-from drt.config.credentials import BigQueryProfile, ProfileConfig
+from drt.config.credentials import BigQueryProfile, DuckDBProfile, ProfileConfig
 
 
 class FakeSource:
@@ -36,3 +37,38 @@ def fake_source() -> FakeSource:
             {"id": 3, "name": "Carol", "email": "carol@example.com"},
         ]
     )
+
+
+@pytest.fixture
+def duckdb_with_users(tmp_path: Path) -> tuple[object, DuckDBProfile]:
+    """Seed a DuckDB file with a `users` table and return (Source, Profile).
+
+    Uses a file path under tmp_path (not `:memory:`) because each
+    `DuckDBSource.extract()` call opens a fresh connection, and `:memory:`
+    databases are not shared across connections.
+
+    The seeded table is `users (id INTEGER, name VARCHAR, email VARCHAR)`
+    with three rows. To drive a sync through the engine, use
+    ``SyncConfig(model="ref('users')", ...)`` — the resolver turns that into
+    ``SELECT * FROM users``.
+    """
+    duckdb = pytest.importorskip("duckdb")
+
+    from drt.sources.duckdb import DuckDBSource
+
+    db_path = str(tmp_path / "test.duckdb")
+    conn = duckdb.connect(db_path)
+    try:
+        conn.execute("CREATE TABLE users (id INTEGER, name VARCHAR, email VARCHAR)")
+        conn.executemany(
+            "INSERT INTO users VALUES (?, ?, ?)",
+            [
+                (1, "Alice", "alice@example.com"),
+                (2, "Bob", "bob@example.com"),
+                (3, "Carol", "carol@example.com"),
+            ],
+        )
+    finally:
+        conn.close()
+
+    return DuckDBSource(), DuckDBProfile(type="duckdb", database=db_path)

--- a/tests/integration/test_duckdb_e2e.py
+++ b/tests/integration/test_duckdb_e2e.py
@@ -1,0 +1,116 @@
+"""End-to-end integration test for the DuckDB Source.
+
+Drives the full reverse-ETL pipeline: real DuckDB (seeded by the
+``duckdb_with_users`` fixture) → engine → pytest-httpserver REST destination.
+No mocks of `drt.sources.duckdb` internals — a real `duckdb.connect()` runs
+inside `DuckDBSource.extract()` and a real HTTP server receives the writes.
+
+This file is the canonical template for Source E2E tests. To add
+``test_postgres_e2e.py`` or ``test_mysql_e2e.py``, copy this file and swap
+the seed fixture; the destination side stays the same.
+See tests/integration/README.md for the full harness pattern.
+"""
+
+from __future__ import annotations
+
+import json
+
+from drt.config.models import RestApiDestinationConfig, SyncConfig, SyncOptions
+from drt.destinations.rest_api import RestApiDestination
+from drt.engine.sync import run_sync
+
+
+def _dest_config(httpserver, path: str = "/users") -> RestApiDestinationConfig:
+    return RestApiDestinationConfig(
+        type="rest_api",
+        url=httpserver.url_for(path),
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+
+
+def _sync(dest: RestApiDestinationConfig, model: str = "ref('users')") -> SyncConfig:
+    return SyncConfig(
+        name="duckdb_to_rest",
+        model=model,
+        destination=dest,
+        sync=SyncOptions(batch_size=10),
+    )
+
+
+def test_full_pipeline_three_seeded_rows_reach_destination(
+    httpserver, duckdb_with_users, tmp_path
+):
+    """Happy path: 3 seeded rows in DuckDB → 3 POSTs received."""
+    source, profile = duckdb_with_users
+    received: list[dict] = []
+
+    def handler(request):
+        received.append(json.loads(request.data))
+        from werkzeug.wrappers import Response
+
+        return Response("OK", status=200)
+
+    httpserver.expect_request("/users", method="POST").respond_with_handler(handler)
+
+    sync = _sync(_dest_config(httpserver))
+    result = run_sync(sync, source, RestApiDestination(), profile, tmp_path)
+
+    assert result.success == 3
+    assert result.failed == 0
+    assert len(received) == 3
+    assert {r["id"] for r in received} == {1, 2, 3}
+    assert {r["name"] for r in received} == {"Alice", "Bob", "Carol"}
+
+
+def test_empty_query_yields_no_destination_requests(
+    httpserver, duckdb_with_users, tmp_path
+):
+    """Empty result set: 0 rows extracted → 0 POSTs sent."""
+    source, profile = duckdb_with_users
+    received: list[dict] = []
+
+    def handler(request):  # pragma: no cover — assertion is len==0
+        received.append(json.loads(request.data))
+        from werkzeug.wrappers import Response
+
+        return Response("OK", status=200)
+
+    httpserver.expect_request("/users", method="POST").respond_with_handler(handler)
+
+    # Inline SQL bypasses ref() resolution and runs the WHERE-false query directly.
+    sync = _sync(_dest_config(httpserver), model="SELECT * FROM users WHERE id > 1000")
+    result = run_sync(sync, source, RestApiDestination(), profile, tmp_path)
+
+    assert result.success == 0
+    assert result.failed == 0
+    assert received == []
+
+
+def test_extracted_column_values_flow_into_request_body(
+    httpserver, duckdb_with_users, tmp_path
+):
+    """Values read from DuckDB appear unchanged in the destination request body."""
+    source, profile = duckdb_with_users
+    received: list[dict] = []
+
+    def handler(request):
+        received.append(json.loads(request.data))
+        from werkzeug.wrappers import Response
+
+        return Response("OK", status=200)
+
+    httpserver.expect_request("/users", method="POST").respond_with_handler(handler)
+
+    sync = _sync(_dest_config(httpserver))
+    run_sync(sync, source, RestApiDestination(), profile, tmp_path)
+
+    alice = next(r for r in received if r["id"] == 1)
+    assert alice["name"] == "Alice"
+    assert alice["email"] == "alice@example.com"
+
+
+def test_real_duckdb_connection_test_succeeds(duckdb_with_users):
+    """`test_connection` against the seeded DuckDB file returns True."""
+    source, profile = duckdb_with_users
+    assert source.test_connection(profile) is True

--- a/tests/unit/test_duckdb.py
+++ b/tests/unit/test_duckdb.py
@@ -1,0 +1,136 @@
+"""Tests for DuckDB source connector.
+
+Mirrors the SQLite test surface (extract / empty / column names / connection /
+invalid config) and adds DuckDB-specific type coverage: BIGINT, DOUBLE,
+DATE, TIMESTAMP, NULL.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+duckdb = pytest.importorskip("duckdb")
+
+from drt.config.credentials import DuckDBProfile  # noqa: E402
+from drt.sources.duckdb import DuckDBSource  # noqa: E402
+
+
+@pytest.fixture
+def seeded_db(tmp_path: Path) -> str:
+    """Path to a DuckDB file with a small `users` table seeded."""
+    db_path = str(tmp_path / "users.duckdb")
+    conn = duckdb.connect(db_path)
+    try:
+        conn.execute("CREATE TABLE users (id INTEGER, name VARCHAR, age INTEGER)")
+        conn.executemany(
+            "INSERT INTO users VALUES (?, ?, ?)",
+            [(1, "Alice", 30), (2, "Bob", 25), (3, "Charlie", 35)],
+        )
+    finally:
+        conn.close()
+    return db_path
+
+
+@pytest.fixture
+def source() -> DuckDBSource:
+    return DuckDBSource()
+
+
+@pytest.fixture
+def profile(seeded_db: str) -> DuckDBProfile:
+    return DuckDBProfile(type="duckdb", database=seeded_db)
+
+
+def test_extract_returns_all_rows(source: DuckDBSource, profile: DuckDBProfile) -> None:
+    rows = list(source.extract("SELECT id, name, age FROM users ORDER BY id", profile))
+
+    assert len(rows) == 3
+    assert rows[0] == {"id": 1, "name": "Alice", "age": 30}
+    assert rows[1] == {"id": 2, "name": "Bob", "age": 25}
+    assert rows[2] == {"id": 3, "name": "Charlie", "age": 35}
+
+
+def test_extract_empty_result(source: DuckDBSource, profile: DuckDBProfile) -> None:
+    rows = list(source.extract("SELECT * FROM users WHERE age > 100", profile))
+
+    assert rows == []
+
+
+def test_extract_column_names(source: DuckDBSource, profile: DuckDBProfile) -> None:
+    row = next(source.extract("SELECT id, name FROM users LIMIT 1", profile))
+
+    assert set(row.keys()) == {"id", "name"}
+
+
+def test_extract_null_values(source: DuckDBSource, tmp_path: Path) -> None:
+    db_path = str(tmp_path / "nulls.duckdb")
+    conn = duckdb.connect(db_path)
+    try:
+        conn.execute("CREATE TABLE t (id INTEGER, label VARCHAR)")
+        conn.execute("INSERT INTO t VALUES (1, NULL), (2, 'present')")
+    finally:
+        conn.close()
+
+    profile = DuckDBProfile(type="duckdb", database=db_path)
+    rows = list(source.extract("SELECT id, label FROM t ORDER BY id", profile))
+
+    assert rows == [{"id": 1, "label": None}, {"id": 2, "label": "present"}]
+
+
+def test_extract_numeric_extremes(source: DuckDBSource, tmp_path: Path) -> None:
+    db_path = str(tmp_path / "nums.duckdb")
+    conn = duckdb.connect(db_path)
+    try:
+        conn.execute("CREATE TABLE t (big BIGINT, dbl DOUBLE)")
+        # BIGINT range: -9223372036854775808 .. 9223372036854775807
+        conn.execute("INSERT INTO t VALUES (9223372036854775807, 1.7976931348623157e308)")
+        conn.execute("INSERT INTO t VALUES (-9223372036854775808, -1.7976931348623157e308)")
+    finally:
+        conn.close()
+
+    profile = DuckDBProfile(type="duckdb", database=db_path)
+    rows = list(source.extract("SELECT big, dbl FROM t ORDER BY big", profile))
+
+    assert rows[0]["big"] == -9223372036854775808
+    assert rows[1]["big"] == 9223372036854775807
+    assert rows[0]["dbl"] == -1.7976931348623157e308
+    assert rows[1]["dbl"] == 1.7976931348623157e308
+
+
+def test_extract_date_and_timestamp(source: DuckDBSource, tmp_path: Path) -> None:
+    db_path = str(tmp_path / "times.duckdb")
+    conn = duckdb.connect(db_path)
+    try:
+        conn.execute("CREATE TABLE t (d DATE, ts TIMESTAMP)")
+        conn.execute("INSERT INTO t VALUES (DATE '2026-05-24', TIMESTAMP '2026-05-24 12:00:00')")
+    finally:
+        conn.close()
+
+    profile = DuckDBProfile(type="duckdb", database=db_path)
+    row = next(source.extract("SELECT d, ts FROM t", profile))
+
+    assert row["d"] == dt.date(2026, 5, 24)
+    assert row["ts"] == dt.datetime(2026, 5, 24, 12, 0, 0)
+
+
+def test_test_connection_success(source: DuckDBSource, profile: DuckDBProfile) -> None:
+    assert source.test_connection(profile) is True
+
+
+def test_test_connection_failure_on_bad_path(source: DuckDBSource) -> None:
+    bad = DuckDBProfile(type="duckdb", database="/nonexistent/dir/db.duckdb")
+    assert source.test_connection(bad) is False
+
+
+def test_invalid_config_type_rejected(source: DuckDBSource) -> None:
+    class FakeConfig:
+        database = ":memory:"
+
+    # NOTE: current impl uses `assert isinstance(...)`, which raises
+    # AssertionError (and is suppressed under `python -O`). Tracked as a
+    # follow-up — see PR description. Mirror current behavior for now.
+    with pytest.raises(AssertionError):
+        list(source.extract("SELECT 1", FakeConfig()))  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #541. First slice of the Tech Foundation Hardening epic #538.

## Summary

- 9 unit tests for `DuckDBSource` (happy path, empty, NULL, BIGINT/DOUBLE extremes, DATE/TIMESTAMP, connection, invalid config)
- 4 end-to-end tests driving real DuckDB → engine → real HTTP server (no mocks of `drt.sources.duckdb` internals)
- New `duckdb_with_users` fixture in integration `conftest.py` that seeds a `users` table in a tmp-path DuckDB file
- New `tests/integration/README.md` documenting the harness pattern so future `test_postgres_e2e.py` / `test_mysql_e2e.py` are copy-swap-extra-gate
- CI install line gains the `duckdb` extra so the new tests actually run (not silently skip)

## Why

DuckDB had no dedicated test module despite being a headline Source, and the only existing E2E test (`tests/integration/test_rest_api_e2e.py`) used `FakeSource` — leaving the real reverse-ETL path (Source read → engine batching → Destination write) without a regression net.

This is also the foundation for #542 (boundary tests: idempotency, large batches, schema evolution, type conversion), which will reuse the `duckdb_with_users` fixture pattern.

## Files touched

| File | Change |
|---|---|
| `tests/unit/test_duckdb.py` | New — 9 unit tests, module-gated with `pytest.importorskip("duckdb")` |
| `tests/integration/test_duckdb_e2e.py` | New — 4 E2E tests (canonical Source-E2E template) |
| `tests/integration/conftest.py` | Adds `duckdb_with_users` fixture (file-backed DB, not `:memory:`, because each `DuckDBSource.extract()` opens a fresh connection) |
| `tests/integration/README.md` | New — harness pattern doc + copy-paste recipe for adding Postgres/MySQL/Snowflake E2E |
| `.github/workflows/ci.yml` | Install line: `".[dev,mcp]"` → `".[dev,mcp,duckdb]"` |

## Local verification

```
$ pytest tests/unit/test_duckdb.py tests/integration/
20 passed in 1.99s

$ ruff check tests/unit/test_duckdb.py tests/integration/test_duckdb_e2e.py tests/integration/conftest.py
All checks passed!
```

## Deliberately out of scope (follow-ups)

- `DuckDBSource.extract()` uses `assert isinstance(...)` which raises `AssertionError` (and is silenced under `python -O`). Should be a proper `TypeError`. Not bundled here to keep PR scope tight — will file a separate small PR.
- FakeSource promotion to a shared module — that's #364 (v0.8 dev tooling).
- Postgres / MySQL / Snowflake E2E modules — separate issues, each a copy-paste of this harness following the README recipe.

## Coordination

- Touches `.github/workflows/ci.yml` (install line, one line). #539 (nightly + publish gate) will rebase on top trivially.
- No code changes under `drt/` — purely additive tests + one CI install extra + docs.

## Test plan

- [x] All new tests pass locally (20/20)
- [x] No regressions in `tests/integration/test_rest_api_e2e.py` (still 7/7)
- [x] Lint clean on new files
- [ ] CI Python 3.10–3.13 all green on this PR
- [ ] Verify `duckdb` extra installs cleanly on the CI runners (small wheel, expected ~1s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)