### PR TITLE
chore(ci): nightly schedule + publish-time lint/test gate (closes #539)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Weekly nightly run (Mon 00:00 UTC) to catch env-drift / flaky tests
+    # against fresh upstream dependencies, independent of PR/push activity.
+    # TODO: wire failure notifications once an alerting convention exists
+    # (see issue #539 follow-up — no slack/issues alert path defined yet).
+    - cron: "0 0 * * 1"
 
 permissions:
   contents: read

--- a/.github/workflows/publish-dagster-drt.yml
+++ b/.github/workflows/publish-dagster-drt.yml
@@ -6,7 +6,37 @@ on:
       - "dagster-drt-v*"
 
 jobs:
+  verify:
+    # Re-run lint/type/tests against the tagged commit before publishing,
+    # so a tag pushed off a stale local can never ship without verification.
+    # Mirrors the .github/workflows/ci.yml `test` job for the primary
+    # Python version; the full matrix runs on PR / push@main / nightly.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install dependencies
+        run: uv pip install --system -e ".[dev,mcp,duckdb]"
+
+      - name: Lint (ruff)
+        run: ruff check drt tests
+
+      - name: Type check (mypy)
+        run: mypy drt
+
+      - name: Test (pytest)
+        run: pytest
+
   publish:
+    needs: verify
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/publish-drt-core.yml
+++ b/.github/workflows/publish-drt-core.yml
@@ -6,7 +6,37 @@ on:
       - "v*"
 
 jobs:
+  verify:
+    # Re-run lint/type/tests against the tagged commit before publishing,
+    # so a tag pushed off a stale local can never ship without verification.
+    # Mirrors the .github/workflows/ci.yml `test` job for the primary
+    # Python version; the full matrix runs on PR / push@main / nightly.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install dependencies
+        run: uv pip install --system -e ".[dev,mcp,duckdb]"
+
+      - name: Lint (ruff)
+        run: ruff check drt tests
+
+      - name: Type check (mypy)
+        run: mypy drt
+
+      - name: Test (pytest)
+        run: pytest
+
   publish:
+    needs: verify
     runs-on: ubuntu-latest
     environment: pypi
     permissions:


### PR DESCRIPTION
## Summary

Closes #539. Part of epic #538 (Tech Foundation Hardening, milestone v0.7.5).

- **Nightly schedule on `ci.yml`** — adds `cron: "0 0 * * 1"` (Mon 00:00 UTC weekly) so env-drift / flaky-test regressions surface independently of PR/push traffic. Existing `push` / `pull_request` triggers untouched.
- **Publish-time `verify` gate** — both `publish-drt-core.yml` and `publish-dagster-drt.yml` now run `ruff check drt tests`, `mypy drt`, `pytest` on Python 3.12 with the same install extras as CI (`.[dev,mcp,duckdb]`) *before* the existing publish/build job, which declares `needs: verify`. A tag pushed off a stale local can no longer ship without re-verification.
- **Notifications** — no slack/issues/alert convention found anywhere in `.github/`, so the nightly job carries a TODO comment for the follow-up rather than inventing a new channel. (Out of scope for #539.)

## Files changed

| File | Change |
| --- | --- |
| `.github/workflows/ci.yml` | + `schedule.cron: "0 0 * * 1"` trigger with TODO for failure notifications |
| `.github/workflows/publish-drt-core.yml` | + `verify` job (ruff/mypy/pytest, Py3.12, `[dev,mcp,duckdb]`); `publish` gains `needs: verify` |
| `.github/workflows/publish-dagster-drt.yml` | + `verify` job (same as above); `publish` gains `needs: verify` |

Total: 3 files, +66 lines. No deletions. Telemetry-key injection step in `publish-drt-core.yml` is untouched.

## Out of scope (deferred)

- CodeQL / pip-audit / SBOM — #540
- Adding Python versions to the matrix
- Changing test or lint commands
- Implementing actual notification channel for nightly failures (TODO in `ci.yml` references this)

## Test plan

- [ ] PR-trigger run of `ci.yml` (matrix on 3.10–3.13) goes green — confirms schedule trigger addition didn't break existing flow.
- [ ] YAML parses (verified locally via `yaml.safe_load` on all three files).
- [ ] Visual trace: `publish` job in each publish workflow has `needs: verify`; verify steps mirror the CI `test` job for Py3.12.
- [ ] Next Monday 00:00 UTC: confirm nightly run kicks off automatically.
- [ ] On next tag push (`v*` or `dagster-drt-v*`): confirm `verify` runs and gates `publish`. If `verify` fails, `publish` must not start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)