### PR TITLE
docs(roadmap): note OTel Phase 1 shipped + epic #429 mapped to v0.9

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,6 +105,7 @@ Strict patch release — cherry-pick of PR #514 (MySQL `_quote_ident` applied ac
 **Scope:**
 - **Interfaces** — RBAC interface spec (#298) · audit log hooks (#299) · plugin system for third-party connectors (#297)
 - **Protocol stability** — review and freeze preparation (#300) · config encryption for secrets at rest (#303) — *`drt cloud push` stub (#302) shipped early in v0.7 via PR #409*
+- **Observability** — OpenTelemetry traces + metrics for sync execution (epic #429) — *Phase 1 (config schema + `[otel]` extras) shipped early via PR #527; Phase 2 (NoOpTracer global provider, #531) and Phases 3–4 (engine instrumentation + counter metrics) continue in parallel with v0.8 work*
 - **Performance** — benchmark suite (#280) + I/O vs CPU profiling for Rust migration decision (#301)
 
 **Out of scope:** Implementing RBAC/audit log in OSS, actual Cloud service backend, Rust migration itself.


### PR DESCRIPTION
## Summary

OpenTelemetry epic #429 is milestoned v0.9 but wasn't in the ROADMAP v0.9 scope bullets — documentation drift. Phase 1 just shipped via [PR #527](https://github.com/drt-hub/drt/pull/527), so this PR adds an **Observability** line to v0.9 scope with the shipped-early callout, matching the pattern used for v0.8's REST API source (PR #532) and Snowflake's v0.7 early shipment.

The note also surfaces the remaining sub-issues so contributors picking up the chain can find them:
- Phase 2: NoOpTracer global provider — [#531](https://github.com/drt-hub/drt/issues/531)
- Phases 3–4: engine instrumentation + counter metrics — to be filed once Phase 2 lands

## Why now

[CLAUDE.md](CLAUDE.md) and the [memory I keep across sessions](https://github.com/drt-hub/drt/blob/main/.claude/) both call out ROADMAP.md as SSoT for upcoming releases. Letting it diverge from milestone state defeats that purpose.

## Test plan

- [x] `git diff ROADMAP.md` shows only the one-line scope addition
- [x] PR #527 (Phase 1) is merged on `main`; #429 epic and #531 sub-issue are both linked correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>