### PR TITLE
chore(ci): supply-chain scans — CodeQL + pip-audit + SBOM (closes #540)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,24 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -e ".[dev,mcp,duckdb]"
 
+      - name: Dependency vulnerability scan (pip-audit)
+        # Pinned version for reproducibility; bump in lockstep with Dependabot.
+        # OSV is the vulnerability service used by GitHub Advisory DB and is
+        # broader than PyPI-only sources for the Python ecosystem.
+        # `--strict` makes pip-audit exit non-zero on warnings (e.g. skipped
+        # packages) so silent gaps in coverage surface as CI failures.
+        # Run on a single matrix entry (3.12) to avoid 4x duplicated work —
+        # vuln data is python-version-independent.
+        if: matrix.python-version == '3.12'
+        run: |
+          pip install "pip-audit==2.10.0"
+          # Allow-list: pass `--ignore-vuln GHSA-xxxx` here when a finding is
+          # triaged as a known false positive. Keep this list empty by default
+          # and document each entry in SECURITY.md.
+          pip-audit \
+            --strict \
+            --vulnerability-service osv
+
       - name: Lint (ruff)
         run: ruff check drt tests
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly scan (Mon 03:00 UTC) — offset from ci.yml nightly (00:00 UTC)
+    # so the two scheduled runs don't compete for runner capacity.
+    # TODO: wire failure notifications once an alerting convention exists
+    # (see issue #539 follow-up — no slack/issues alert path defined yet).
+    - cron: "0 3 * * 1"
+
+permissions:
+  contents: read
+  security-events: write  # required to upload CodeQL results
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["python"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # `security-extended` adds higher-signal queries beyond the default
+          # set; `security-and-quality` is too noisy for a small codebase.
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/publish-dagster-drt.yml
+++ b/.github/workflows/publish-dagster-drt.yml
@@ -41,6 +41,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write  # for Trusted Publishing (no API token needed)
+      contents: write  # for uploading SBOM to the GitHub Release
 
     steps:
       - uses: actions/checkout@v6
@@ -53,6 +54,20 @@ jobs:
       - name: Install uv
         run: pip install uv
 
+      - name: Install dagster-drt (for SBOM scope)
+        # Install the package itself so the SBOM captures its actual runtime
+        # closure (dagster + drt-core + transitive deps), not the dev env.
+        run: uv pip install --system ./integrations/dagster-drt
+
+      - name: Generate CycloneDX SBOM
+        run: |
+          pip install "cyclonedx-bom==7.3.0"
+          cyclonedx-py environment \
+            --output-format JSON \
+            --output-file dagster-drt-sbom.cdx.json \
+            --pyproject integrations/dagster-drt/pyproject.toml
+          python -c "import json; d=json.load(open('dagster-drt-sbom.cdx.json')); assert d.get('components'), 'SBOM has no components'"
+
       - name: Build dagster-drt
         working-directory: integrations/dagster-drt
         run: uv build
@@ -61,3 +76,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: integrations/dagster-drt/dist/
+
+      - name: Attach SBOM to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dagster-drt-sbom.cdx.json
+          fail_on_unmatched_files: true

--- a/.github/workflows/publish-drt-core.yml
+++ b/.github/workflows/publish-drt-core.yml
@@ -41,6 +41,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write  # for Trusted Publishing (no API token needed)
+      contents: write  # for uploading SBOM to the GitHub Release
 
     steps:
       - uses: actions/checkout@v6
@@ -52,6 +53,22 @@ jobs:
 
       - name: Install uv
         run: pip install uv
+
+      - name: Install dependencies (for SBOM scope)
+        # SBOM must reflect what users actually install. Mirror the extras
+        # set used by `verify` so optional integrations shipped to PyPI are
+        # represented in the bill of materials.
+        run: uv pip install --system -e ".[dev,mcp,duckdb]"
+
+      - name: Generate CycloneDX SBOM
+        run: |
+          pip install "cyclonedx-bom==7.3.0"
+          cyclonedx-py environment \
+            --output-format JSON \
+            --output-file drt-core-sbom.cdx.json \
+            --pyproject pyproject.toml
+          # Sanity-check the SBOM is non-empty JSON with a components list.
+          python -c "import json; d=json.load(open('drt-core-sbom.cdx.json')); assert d.get('components'), 'SBOM has no components'"
 
       - name: Inject telemetry API key
         env:
@@ -89,3 +106,12 @@ jobs:
 
       - name: Publish drt-core to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Attach SBOM to GitHub Release
+        # `softprops/action-gh-release` creates the Release if missing and
+        # uploads the SBOM as an asset. Only runs for tag pushes (which is
+        # the only trigger for this workflow anyway).
+        uses: softprops/action-gh-release@v2
+        with:
+          files: drt-core-sbom.cdx.json
+          fail_on_unmatched_files: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,28 @@
 | 0.3.x   | ✅        |
 | 0.2.x   | ✅        |
 
+## Supply-Chain Scanning
+
+The repository runs the following automated scans:
+
+| Scan          | Trigger                          | Workflow                                |
+|---------------|----------------------------------|-----------------------------------------|
+| Dependabot    | Weekly                           | (GitHub-native, no workflow file)       |
+| CodeQL        | PR + push to `main` + weekly     | `.github/workflows/codeql.yml`          |
+| `pip-audit`   | PR + push to `main` + weekly     | `.github/workflows/ci.yml` (`test` job) |
+| CycloneDX SBOM| On release tag (`v*` / `dagster-drt-v*`) | `.github/workflows/publish-*.yml` |
+
+`pip-audit` runs against the OSV vulnerability database and fails CI on any
+known advisory. False positives can be triaged via `--ignore-vuln <GHSA-id>`
+flags in `.github/workflows/ci.yml`; any entry added there must be documented
+in this file with a link to the upstream advisory and a justification.
+
+**Current allow-list entries:** none.
+
+A CycloneDX-format SBOM (`*-sbom.cdx.json`) is generated and attached to each
+GitHub Release as an asset. Downstream consumers can use it to feed their own
+vulnerability tooling (Grype, Trivy, Dependency-Track, etc.).
+
 ## Branch Protection
 
 The `main` branch enforces the following rules to mitigate supply chain attacks (e.g., [GlassWorm/ForceMemo](https://socket.dev/blog/glassworm-forcememo-github-supply-chain-attack)):


### PR DESCRIPTION
## Summary

Adds three supply-chain scanning layers on top of the existing Dependabot weekly:

- **CodeQL** — new workflow `.github/workflows/codeql.yml` (PR + push@main + weekly Mon 03:00 UTC, offset from `ci.yml`'s 00:00 UTC nightly). Python only, `security-extended` query pack.
- **pip-audit** — step in `ci.yml` `test` job between `Install dependencies` and `Lint (ruff)`, scoped to the 3.12 matrix entry (vuln data is python-version-independent). Uses OSV; pinned to `pip-audit==2.10.0`.
- **CycloneDX SBOM** — generated in both publish workflows via `cyclonedx-bom==7.3.0` and attached to the GitHub Release via `softprops/action-gh-release@v2`.

Parent epic: #538 — Tech Foundation Hardening.

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/codeql.yml` | **new** — CodeQL python scan |
| `.github/workflows/ci.yml` | + `pip-audit` step (3.12 only) |
| `.github/workflows/publish-drt-core.yml` | + SBOM gen + Release attach (`contents: write`) |
| `.github/workflows/publish-dagster-drt.yml` | + SBOM gen + Release attach (`contents: write`) |
| `SECURITY.md` | + Supply-Chain Scanning section + allow-list policy |

## SBOM scoping rationale

- **drt-core SBOM**: installed against `.[dev,mcp,duckdb]` to mirror the `verify` job extras added by #553, so the bill of materials reflects what's actually shipped via the release pipeline.
- **dagster-drt SBOM**: installs the integration package itself (`uv pip install ./integrations/dagster-drt`) to capture its real runtime closure (`dagster` + `drt-core` + transitives), not the drt-core dev environment.

## Pre-existing findings

`pip-audit` run locally against a fresh venv with `.[dev,mcp,duckdb]` reports **no known vulnerabilities**. Allow-list (`--ignore-vuln`) is therefore empty by default; the SECURITY.md section documents how to add entries with upstream advisory links.

## Out of scope

- Nightly schedule + publish-time verify gates — already landed in #553.
- Test/lint matrix changes — separate concern.
- Slack/Discord/email alerting — left as `TODO` in workflow comments referencing #539's follow-up; no alerting convention is defined yet.
- New runtime extras or dependencies.
- ROADMAP.md / CHANGELOG.md updates — per scope.

## Test plan

- [ ] CodeQL workflow runs on this PR and uploads results to the Security tab
- [ ] `pip-audit` step executes on the 3.12 matrix entry and passes (no high-severity findings)
- [ ] All 4 modified workflows parse as valid YAML (verified locally)
- [ ] Next release tag (`v*`) attaches `drt-core-sbom.cdx.json` to the GitHub Release
- [ ] Next release tag (`dagster-drt-v*`) attaches `dagster-drt-sbom.cdx.json` to the GitHub Release

Closes #540. Milestone: v0.7.5. Epic: #538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)