### PR TITLE
feat(cli): ErrorFormatter for `drt run` failures (closes #544)

### DIFF
--- a/drt/cli/errors.py
+++ b/drt/cli/errors.py
@@ -1,0 +1,168 @@
+"""ErrorFormatter — context-rich rendering for ``drt run`` failures.
+
+Wraps a raw exception with **sync name**, **stage** (source / destination /
+engine / state), **error type + message**, and a **suggested next step**
+so users don't have to reverse-engineer "what was happening when this
+broke?" from a single ``Error: connection refused`` line.
+
+Stage detection is a traceback walk today — it inspects each frame's
+``co_filename`` to find which ``drt/<area>/`` module raised. This is a
+heuristic that will be replaced by an engine-emitted ``Stage`` tag
+once #527 (OTel span context) and #548 (engine I/O boundary protocol)
+land; both expose a cleaner observation surface that this module can
+plug into without keeping the traceback walk forever.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+
+
+class Stage(str, Enum):
+    SOURCE = "source"
+    DESTINATION = "destination"
+    ENGINE = "engine"
+    STATE = "state"
+    UNKNOWN = "unknown"
+
+
+# Path fragment → stage. Ordered: state checked before engine so files like
+# ``drt/state/...`` are not swallowed by a future ``drt/engine/state/...``.
+_PATH_TO_STAGE: tuple[tuple[str, Stage], ...] = (
+    (f"{os.sep}drt{os.sep}sources{os.sep}", Stage.SOURCE),
+    (f"{os.sep}drt{os.sep}destinations{os.sep}", Stage.DESTINATION),
+    (f"{os.sep}drt{os.sep}state{os.sep}", Stage.STATE),
+    (f"{os.sep}drt{os.sep}engine{os.sep}", Stage.ENGINE),
+)
+
+
+@dataclass
+class FormattedError:
+    sync_name: str
+    stage: Stage
+    error_type: str
+    message: str
+    suggestion: str | None
+
+    def to_dict(self) -> dict[str, str | None]:
+        """Machine-readable form for ``--format json`` consumers."""
+        return {
+            "sync_name": self.sync_name,
+            "stage": self.stage.value,
+            "error_type": self.error_type,
+            "message": self.message,
+            "suggestion": self.suggestion,
+        }
+
+
+def classify_filename(filename: str) -> Stage:
+    """Map a source filename to its pipeline stage. Pure function for tests."""
+    for fragment, stage in _PATH_TO_STAGE:
+        if fragment in filename:
+            return stage
+    return Stage.UNKNOWN
+
+
+def infer_stage(exc: BaseException) -> Stage:
+    """Walk the exception's traceback to find the deepest drt-owned frame.
+
+    "Deepest" means: the most recent frame inside a ``drt/<area>/`` module.
+    If the exception bubbled through ``drt/sources/postgres.py`` and then
+    ``drt/engine/sync.py``, we return ``SOURCE`` — that's where the actual
+    fault originated. Frames from third-party packages between the two are
+    skipped, never overriding the stage.
+    """
+    stage = Stage.UNKNOWN
+    tb = exc.__traceback__
+    while tb is not None:
+        candidate = classify_filename(tb.tb_frame.f_code.co_filename)
+        if candidate is not Stage.UNKNOWN:
+            stage = candidate
+        tb = tb.tb_next
+    return stage
+
+
+def suggest(stage: Stage, exc: BaseException) -> str | None:
+    """Tiny rule table for actionable next-step hints.
+
+    Conservative on purpose — a misleading suggestion is worse than none.
+    Returns ``None`` when no rule fires; the formatter just omits the
+    "Suggestion:" line in that case.
+    """
+    msg = str(exc).lower()
+
+    if stage is Stage.SOURCE:
+        if any(k in msg for k in ("connection", "refused", "could not connect", "timeout")):
+            return "Verify source connectivity with: drt validate --check-connection"
+        if any(k in msg for k in ("auth", "credential", "401", "403", "permission denied")):
+            return "Check the source profile's auth env vars are set"
+        return "Check the source profile and the query/table reference"
+
+    if stage is Stage.DESTINATION:
+        if any(k in msg for k in ("401", "403", "unauthorized", "forbidden")):
+            return "Check the destination's auth env vars (token / api key)"
+        if any(k in msg for k in ("rate", "429", "too many requests")):
+            return "Reduce sync.rate_limit.requests_per_second or add retry config"
+        if any(k in msg for k in ("timeout", "connection")):
+            return "Check destination network reachability"
+        return "Check the destination config (url, auth, headers)"
+
+    if stage is Stage.STATE:
+        return "Inspect .drt/state.json; if corrupted, delete it to reset (you lose watermarks)"
+
+    # ENGINE / UNKNOWN: usually a programming bug — let the traceback speak.
+    return None
+
+
+def format_error(sync_name: str, exc: BaseException) -> FormattedError:
+    """Build a FormattedError from a sync name and the caught exception."""
+    stage = infer_stage(exc)
+    return FormattedError(
+        sync_name=sync_name,
+        stage=stage,
+        error_type=type(exc).__name__,
+        message=str(exc),
+        suggestion=suggest(stage, exc),
+    )
+
+
+def render_to_console(fe: FormattedError) -> None:
+    """Print a context-rich panel for ``fe`` via the project console.
+
+    Rendered shape::
+
+        ╭─ Sync failed: my_sync ──────────────────────────╮
+        │ Stage: source                                    │
+        │ ConnectionError: connection refused              │
+        │                                                  │
+        │ Suggestion: Verify source connectivity with:     │
+        │   drt validate --check-connection                │
+        ╰──────────────────────────────────────────────────╯
+
+    Suggestion block is omitted when there is no hint, so engine /
+    unknown failures don't carry a misleading "try X" line.
+    """
+    # Local import so this module stays importable without rich (rare in
+    # this repo, but it keeps coupling tight) and so JSON-mode callers
+    # who never invoke this function don't pull rich either.
+    from rich.panel import Panel
+
+    from drt.cli.output import console
+
+    lines: list[str] = [
+        f"[bold]Stage:[/bold] {fe.stage.value}",
+        f"[bold red]{fe.error_type}:[/bold red] {fe.message}",
+    ]
+    if fe.suggestion:
+        lines.extend(["", f"[bold yellow]Suggestion:[/bold yellow] {fe.suggestion}"])
+
+    console.print(
+        Panel(
+            "\n".join(lines),
+            title=f"[bold red]Sync failed:[/bold red] {fe.sync_name}",
+            border_style="red",
+            expand=False,
+        )
+    )

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -154,7 +154,10 @@ def _run_one(
                 diff_limit=ctx.diff_limit,
             )
         except Exception as e:
+            from drt.cli.errors import format_error, render_to_console
+
             elapsed = round(time.monotonic() - t0, 2)
+            fe = format_error(sync.name, e)
             entry: dict[str, object] = {
                 "name": sync.name,
                 "status": "failed",
@@ -162,7 +165,13 @@ def _run_one(
                 "rows_failed": 0,
                 "duration_seconds": elapsed,
                 "dry_run": ctx.dry_run,
+                # Preserve `error` for backwards compatibility with JSON
+                # consumers that already parse it. Add structured siblings
+                # for new consumers (stage, error_type, error_suggestion).
                 "error": str(e),
+                "error_type": fe.error_type,
+                "error_stage": fe.stage.value,
+                "error_suggestion": fe.suggestion,
             }
             if ctx.log_json:
                 logging.error(
@@ -172,10 +181,12 @@ def _run_one(
                         "rows": 0,
                         "duration_ms": round(elapsed * 1000),
                         "status": "failed",
+                        "error_stage": fe.stage.value,
+                        "error_type": fe.error_type,
                     },
                 )
             if not ctx.json_mode:
-                print_error(f"[{sync.name}] Unexpected error: {e}")
+                render_to_console(fe)
             return_value = (sync.name, entry, True)
             return return_value
 

--- a/tests/unit/test_cli_errors.py
+++ b/tests/unit/test_cli_errors.py
@@ -1,0 +1,254 @@
+"""Tests for drt.cli.errors — ErrorFormatter."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from drt.cli.errors import (
+    FormattedError,
+    Stage,
+    classify_filename,
+    format_error,
+    infer_stage,
+    suggest,
+)
+
+# ---------------------------------------------------------------------------
+# classify_filename (pure)
+# ---------------------------------------------------------------------------
+
+
+def _p(*parts: str) -> str:
+    """Build a filename with the OS-native separator."""
+    return os.sep + os.sep.join(parts)
+
+
+@pytest.mark.parametrize(
+    "filename, expected",
+    [
+        (_p("repo", "drt", "sources", "postgres.py"), Stage.SOURCE),
+        (_p("repo", "drt", "destinations", "rest_api.py"), Stage.DESTINATION),
+        (_p("repo", "drt", "engine", "sync.py"), Stage.ENGINE),
+        (_p("repo", "drt", "state", "manager.py"), Stage.STATE),
+        (_p("repo", "drt", "cli", "main.py"), Stage.UNKNOWN),
+        (_p("site-packages", "httpx", "_client.py"), Stage.UNKNOWN),
+        ("", Stage.UNKNOWN),
+    ],
+)
+def test_classify_filename(filename: str, expected: Stage) -> None:
+    assert classify_filename(filename) == expected
+
+
+# ---------------------------------------------------------------------------
+# infer_stage (traceback walk via real raises from drt modules)
+# ---------------------------------------------------------------------------
+
+
+def test_infer_stage_returns_source_when_raised_from_source_module() -> None:
+    """A real exception raised inside drt.sources.duckdb is classified SOURCE.
+
+    Uses the existing AssertionError path in DuckDBSource.extract() when the
+    config type doesn't match — no extra setup needed.
+    """
+    pytest.importorskip("duckdb")
+    from drt.sources.duckdb import DuckDBSource
+
+    class FakeConfig:
+        database = ":memory:"
+
+    try:
+        list(DuckDBSource().extract("SELECT 1", FakeConfig()))  # type: ignore[arg-type]
+    except AssertionError as e:
+        assert infer_stage(e) is Stage.SOURCE
+    else:
+        pytest.fail("Expected AssertionError from DuckDBSource.extract on bad config")
+
+
+def test_infer_stage_falls_back_to_unknown_for_plain_exception() -> None:
+    """An exception raised in a test module (no drt path) lands on UNKNOWN."""
+    try:
+        raise ValueError("plain test failure")
+    except ValueError as e:
+        assert infer_stage(e) is Stage.UNKNOWN
+
+
+def test_infer_stage_picks_deepest_drt_frame() -> None:
+    """When the traceback crosses multiple drt modules, the deepest wins.
+
+    Simulates source code raising → engine catching/re-raising. The
+    re-raise from the engine frame should NOT override the original
+    source attribution.
+    """
+    pytest.importorskip("duckdb")
+    from drt.engine import sync as engine_sync  # noqa: F401 — frame visibility
+    from drt.sources.duckdb import DuckDBSource
+
+    class FakeConfig:
+        database = ":memory:"
+
+    def engine_wrapper() -> None:
+        # Frame inside drt/engine/* re-raising; the inner frame is in drt/sources/*
+        try:
+            list(DuckDBSource().extract("x", FakeConfig()))  # type: ignore[arg-type]
+        except Exception:
+            raise
+
+    # Patch this function into the engine module so its frame's co_filename
+    # claims drt/engine path.
+    engine_wrapper.__code__ = engine_wrapper.__code__.replace(
+        co_filename=engine_sync.__file__
+    )
+
+    try:
+        engine_wrapper()
+    except AssertionError as e:
+        # Deepest drt frame is the source raise — even though the outer
+        # call chain went through engine — so SOURCE wins.
+        assert infer_stage(e) is Stage.SOURCE
+
+
+# ---------------------------------------------------------------------------
+# suggest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stage, message, hint_substring",
+    [
+        (Stage.SOURCE, "connection refused", "drt validate --check-connection"),
+        (Stage.SOURCE, "Could not connect to host", "drt validate --check-connection"),
+        (Stage.SOURCE, "401 Unauthorized", "auth env vars"),
+        (Stage.SOURCE, "permission denied for table users", "auth env vars"),
+        (Stage.DESTINATION, "401 Unauthorized", "token / api key"),
+        (Stage.DESTINATION, "HTTP 429 Too Many Requests", "rate_limit"),
+        (Stage.DESTINATION, "Read timeout", "network reachability"),
+        (Stage.STATE, "anything", ".drt/state.json"),
+    ],
+)
+def test_suggest_returns_actionable_hint(
+    stage: Stage, message: str, hint_substring: str
+) -> None:
+    hint = suggest(stage, RuntimeError(message))
+    assert hint is not None
+    assert hint_substring in hint
+
+
+def test_suggest_returns_none_for_engine_stage() -> None:
+    """Engine errors are usually programming bugs — let the traceback speak."""
+    assert suggest(Stage.ENGINE, RuntimeError("internal engine assertion")) is None
+
+
+def test_suggest_returns_none_for_unknown_stage() -> None:
+    assert suggest(Stage.UNKNOWN, RuntimeError("mystery")) is None
+
+
+def test_suggest_falls_through_to_generic_when_no_keyword_matches() -> None:
+    """SOURCE / DESTINATION return a generic hint even without keyword match."""
+    hint = suggest(Stage.SOURCE, RuntimeError("table 'orders' has no column 'price'"))
+    assert hint is not None
+    assert "source profile" in hint or "query/table" in hint
+
+
+# ---------------------------------------------------------------------------
+# format_error (integration of the pieces)
+# ---------------------------------------------------------------------------
+
+
+def test_format_error_populates_all_fields() -> None:
+    exc = RuntimeError("connection refused")
+    # Manually set stage via classify_filename behaviour — see that fields land.
+    fe = format_error("my_sync", exc)
+
+    assert isinstance(fe, FormattedError)
+    assert fe.sync_name == "my_sync"
+    assert fe.error_type == "RuntimeError"
+    assert fe.message == "connection refused"
+    # Stage is UNKNOWN here (raised from test file), suggestion is therefore None
+    assert fe.stage is Stage.UNKNOWN
+    assert fe.suggestion is None
+
+
+def test_formatted_error_to_dict_round_trip() -> None:
+    fe = FormattedError(
+        sync_name="s",
+        stage=Stage.SOURCE,
+        error_type="ConnectionError",
+        message="refused",
+        suggestion="check it",
+    )
+    d = fe.to_dict()
+    assert d == {
+        "sync_name": "s",
+        "stage": "source",
+        "error_type": "ConnectionError",
+        "message": "refused",
+        "suggestion": "check it",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Integration with cli._run_one: enriched entry fields land on the failed path
+# ---------------------------------------------------------------------------
+
+
+def test_run_one_failed_entry_includes_error_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The JSON entry dict on a failed run carries the new structured fields.
+
+    Locks in the contract for ``drt run --output json`` consumers:
+    ``error`` (str, preserved for back-compat), plus new siblings
+    ``error_type``, ``error_stage``, ``error_suggestion``.
+    """
+    from drt.cli.main import _run_one
+    from drt.engine.sync import SyncResult  # noqa: F401  — type used by patched fn
+
+    def boom(*_a: object, **_k: object) -> SyncResult:
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr("drt.engine.sync.run_sync", boom)
+    monkeypatch.setattr("drt.cli.main.run_sync", boom, raising=False)
+
+    # Minimal sync + ctx + profile — reuse the project's existing helpers
+    # if available, otherwise stub the bare minimum.
+    from tests.unit.test_cli_run_telemetry import _ctx, _fake_profile, _fake_sync
+
+    name, entry, had_err = _run_one(_fake_sync(), _ctx(json_mode=True), _fake_profile())
+
+    assert had_err is True
+    assert entry["status"] == "failed"
+    assert entry["error"] == "connection refused"
+    assert entry["error_type"] == "RuntimeError"
+    # Stage is UNKNOWN here because the exception was raised inside the test
+    # module, not inside drt/<area>/.
+    assert entry["error_stage"] == "unknown"
+    # Suggestion None for UNKNOWN stage
+    assert entry["error_suggestion"] is None
+
+
+def test_render_to_console_does_not_crash() -> None:
+    """Smoke test: the Rich panel renderer is callable end-to-end."""
+    from drt.cli.errors import render_to_console
+
+    fe = FormattedError(
+        sync_name="my_sync",
+        stage=Stage.SOURCE,
+        error_type="ConnectionError",
+        message="refused",
+        suggestion="Verify with: drt validate --check-connection",
+    )
+    render_to_console(fe)  # writes to project console; no return value
+
+
+def test_render_to_console_omits_suggestion_when_none() -> None:
+    """Smoke test: no suggestion line for engine / unknown stages."""
+    from drt.cli.errors import render_to_console
+
+    fe = FormattedError(
+        sync_name="my_sync",
+        stage=Stage.ENGINE,
+        error_type="AssertionError",
+        message="internal invariant",
+        suggestion=None,
+    )
+    render_to_console(fe)


### PR DESCRIPTION
Closes #544. Third slice of the Tech Foundation Hardening epic #538.

## Summary

When `drt run` fails today, the user sees a single line like `Error: connection refused`. No sync name, no stage, no hint of what to try next. This PR wraps that exception with structured context — **sync name + stage (source/destination/engine/state) + error type + actionable suggestion** — rendered as a Rich panel for terminal users and as new JSON fields for `--output json` consumers.

### Before / after

**Before:**
```
Error: [my_sync] Unexpected error: connection refused
```

**After:**
```
╭─ Sync failed: my_sync ──────────────────────────╮
│ Stage: source                                    │
│ ConnectionError: connection refused              │
│                                                  │
│ Suggestion: Verify source connectivity with:     │
│   drt validate --check-connection                │
╰──────────────────────────────────────────────────╯
```

### JSON output (`drt run --output json`)

`entry["error"]` is **preserved** (str) for back-compat. New siblings:

| Field | Type | Example |
|---|---|---|
| `error_type` | str | `"ConnectionError"` |
| `error_stage` | str | `"source"` |
| `error_suggestion` | str \| null | `"Verify source connectivity with: drt validate --check-connection"` |

Structured `log_json` ERROR `sync_complete` log also gains `error_stage` + `error_type` for log-aggregation grouping.

## Files

| File | Change |
|---|---|
| `drt/cli/errors.py` | **New module** — `Stage` enum, `classify_filename`, `infer_stage`, `suggest`, `format_error`, `FormattedError`, `render_to_console` |
| `drt/cli/main.py` | `_run_one` failed-path uses `format_error` + `render_to_console`; entry dict and log_json get new fields |
| `tests/unit/test_cli_errors.py` | **New file** — 26 tests covering pure functions, traceback walk semantics, suggestion rules, and JSON-contract integration |

## Stage detection design note

The traceback-walk implementation of `infer_stage` is a **heuristic** — the deepest `drt/<area>/*` frame wins, so a source-raised exception re-thrown through engine still attributes to SOURCE.

This will be **superseded** by an engine-emitted Stage tag once #527 (OTel span context) and #548 (engine I/O boundary protocol) land. The `SyncObserver` interface that #548 introduces is the natural place for the engine to surface stage info, and OTel's span attributes from #527 cover the same surface. When either lands, swap `infer_stage` for the cleaner read path; the rest of this module (`suggest`, `render_to_console`, `format_error`) is unchanged.

**Deliberately did NOT touch `drt/engine/sync.py` here** to avoid conflicts with open contributor PR #527. Pragmatic middle until the engine-side work catches up.

## Local verification

```
$ pytest tests/                  → 1130 passed, 1 skipped, 1 deselected
$ ruff check drt tests           → All checks passed!
$ mypy drt                       → Success: no issues found in 91 files
```

(The deselected test is a pre-existing console-width-wrapping flake specific to long local worktree paths; passes on CI runners where the path is much shorter.)

## Coordination

- No collision with open PRs (#522 cli/main help examples, #492 destinations, #527 engine OTel) — touches `cli/main.py` only inside the `_run_one` except block, which is far from the command-help docstrings #522 edits
- Aligns with #543 (`drt sources --detailed`) and #545 (init templates) on the UX axis but doesn't pre-empt them

## Test plan

- [x] All new + existing tests pass locally (1130/1131, 1 pre-existing flake unrelated)
- [x] mypy clean
- [x] ruff clean
- [ ] CI Python 3.10–3.13 all green
- [ ] Visual smoke: triggering a real connection failure in a local sandbox renders the panel correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)