### PR TITLE
feat(cli): drt init --template <connector> + README quickstart rewrite (closes #545)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-sync: base=README.md, hash=200d17e173906dc78d97f66bedbb37f653ca6be8 -->
+<!-- i18n-sync: base=README.md, hash=09dc2779fcc2b439690c8e6d57ed60443831720f -->
 
 [English](./README.md) | [日本語](./README.ja.md)
 
@@ -54,24 +54,16 @@ drt init && drt run
 
 ## クイックスタート
 
-クラウドアカウントは不要です。DuckDBを使って、ローカル環境で約5分で実行できます。
-
-### 1. インストール
+クラウドアカウントは不要 — DuckDB と httpbin.org でコマンド3つから。
 
 ```bash
 pip install drt-core
-```
-
-> クラウドソースの場合：`pip install drt-core[bigquery]`、`drt-core[postgres]` など。
-
-### 2. プロジェクトのセットアップ
-
-```bash
 mkdir my-drt-project && cd my-drt-project
-drt init   # select "duckdb" as source
+drt init --template duckdb_to_rest
 ```
 
-### 3. サンプルデータの作成
+実行可能な `syncs/duckdb_to_rest.yml` がスキャフォールドされます。DuckDB
+に小さなテーブルをシードして実行:
 
 ```bash
 python -c "
@@ -84,38 +76,36 @@ c.execute('''CREATE TABLE IF NOT EXISTS users AS SELECT * FROM (VALUES
 ) t(id, name, email)''')
 c.close()
 "
+drt run --dry-run   # プレビュー、データは送信されない
+drt run             # httpbin.org に各行を POST
+drt status          # 結果を確認
 ```
 
-### 4. 同期の作成
-
-```yaml
-# syncs/post_users.yml
-name: post_users
-description: "POST user records to an API"
-model: ref('users')
-destination:
-  type: rest_api
-  url: "https://httpbin.org/post"
-  method: POST
-  headers:
-    Content-Type: "application/json"
-  body_template: |
-    { "id": {{ row.id }}, "name": "{{ row.name }}", "email": "{{ row.email }}" }
-sync:
-  mode: full
-  batch_size: 1
-  on_error: fail
-```
-
-### 5. 実行
+### その他のスタータテンプレート
 
 ```bash
-drt run --dry-run   # preview, no data sent
-drt run             # run for real
-drt status          # check results
+drt init --template list             # 利用可能なテンプレート一覧
+drt init --template postgres_to_slack
+drt init --template duckdb_to_hubspot
 ```
 
-> 詳細は [examples/](examples/) を参照してください（Slack、Google Sheets、HubSpot、GitHub Actions など）。
+各テンプレートは必要な環境変数 / ソースデータの次のステップを表示します。
+完全なコレクションは [examples/](examples/) (Discord、Google Sheets、
+GitHub Actions、MySQL、ClickHouse、BigQuery …)、コネクタ別リファレンスは
+[docs/connectors/](docs/connectors/) を参照。
+
+### 同期のカスタマイズ
+
+プロファイル + プロジェクトのセットアップを案内するウィザードが必要な場合:
+
+```bash
+drt init   # 対話形式 — ソース選択、プロファイル設定、プロジェクトスキャフォールド
+```
+
+どちらのフローも同じプロジェクト構造 (`drt_project.yml`、`syncs/`、
+`.drt/`) を生成します。`drt sources --detailed` と
+`drt destinations --detailed` は各コネクタの必要な環境変数とサンプル
+YAML スタンザを表示します — テンプレートを超えて手で書くときに便利です。
 
 ---
 
@@ -231,6 +221,8 @@ Claude Codeの公式スキルをインストールすると、チャットイン
 ---
 
 ## コネクタ
+
+> コネクタ別リファレンス: [docs/connectors/](docs/connectors/) · CLI からも辿れます: `drt sources --detailed` / `drt destinations --detailed`
 
 ### ソース
 

--- a/README.md
+++ b/README.md
@@ -52,24 +52,16 @@ drt init && drt run
 
 ## Quickstart
 
-No cloud accounts needed — runs locally with DuckDB in about 5 minutes.
-
-### 1. Install
+No cloud accounts needed — DuckDB + httpbin.org, three commands.
 
 ```bash
 pip install drt-core
-```
-
-> For cloud sources: `pip install drt-core[bigquery]`, `drt-core[postgres]`, etc.
-
-### 2. Set up a project
-
-```bash
 mkdir my-drt-project && cd my-drt-project
-drt init   # select "duckdb" as source
+drt init --template duckdb_to_rest
 ```
 
-### 3. Create sample data
+That scaffolds a runnable `syncs/duckdb_to_rest.yml`. Seed a tiny
+DuckDB table and run:
 
 ```bash
 python -c "
@@ -82,38 +74,36 @@ c.execute('''CREATE TABLE IF NOT EXISTS users AS SELECT * FROM (VALUES
 ) t(id, name, email)''')
 c.close()
 "
-```
-
-### 4. Create a sync
-
-```yaml
-# syncs/post_users.yml
-name: post_users
-description: "POST user records to an API"
-model: ref('users')
-destination:
-  type: rest_api
-  url: "https://httpbin.org/post"
-  method: POST
-  headers:
-    Content-Type: "application/json"
-  body_template: |
-    { "id": {{ row.id }}, "name": "{{ row.name }}", "email": "{{ row.email }}" }
-sync:
-  mode: full
-  batch_size: 1
-  on_error: fail
-```
-
-### 5. Run
-
-```bash
 drt run --dry-run   # preview, no data sent
-drt run             # run for real
+drt run             # POST each row to httpbin.org
 drt status          # check results
 ```
 
-> See [examples/](examples/) for more: Slack, Google Sheets, HubSpot, GitHub Actions, etc.
+### Other starter templates
+
+```bash
+drt init --template list             # see all available templates
+drt init --template postgres_to_slack
+drt init --template duckdb_to_hubspot
+```
+
+Each template prints next-steps for the env vars / source data it needs.
+See [examples/](examples/) for the full collection (Discord, Google
+Sheets, GitHub Actions, MySQL, ClickHouse, BigQuery, …) and
+[docs/connectors/](docs/connectors/) for per-connector reference.
+
+### Customizing your sync
+
+For a guided wizard that walks you through profile + project setup:
+
+```bash
+drt init   # interactive — picks a source, configures profile, scaffolds project
+```
+
+Both flows produce the same project shape (`drt_project.yml`, `syncs/`,
+`.drt/`). `drt sources --detailed` and `drt destinations --detailed`
+print every connector's required env vars and a sample YAML stanza —
+useful when hand-authoring beyond the templates.
 
 ---
 
@@ -257,6 +247,8 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 ---
 
 ## Connectors
+
+> Per-connector reference: [docs/connectors/](docs/connectors/) · Discoverable from the CLI: `drt sources --detailed` / `drt destinations --detailed`
 
 ### Sources
 

--- a/drt/cli/_init_templates.py
+++ b/drt/cli/_init_templates.py
@@ -1,0 +1,95 @@
+"""Curated starter templates for ``drt init --template <name>`` (#545).
+
+Each template is a static, self-contained sync YAML that lands in
+``syncs/<name>.yml`` and passes ``drt validate`` immediately. Per-
+template next-steps text tells the user exactly which env vars / source
+tables they need to set up before ``drt run`` will actually transmit
+data.
+
+Templates are deliberately *not* Jinja2-rendered at init time — the
+file on disk is the file the user gets. Edits are then the user's
+domain. This keeps the scaffolding step boring and predictable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib.resources import files
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class TemplateInfo:
+    """One curated sync template registered for ``drt init --template``."""
+
+    name: str
+    description: str
+    next_steps: tuple[str, ...]
+
+    def read_yaml(self) -> str:
+        """Load the template's YAML content from the packaged templates dir.
+
+        Anchored at ``drt.cli`` so we don't depend on ``templates/`` being a
+        package — it's a data directory included via hatch's wheel target.
+        """
+        # ``Traversable.joinpath`` only accepts one segment per call (per typing
+        # stubs); chain to walk into the syncs subdir.
+        return (
+            files("drt.cli")
+            .joinpath("templates")
+            .joinpath("syncs")
+            .joinpath(f"{self.name}.yml")
+            .read_text()
+        )
+
+
+TEMPLATES: dict[str, TemplateInfo] = {
+    "duckdb_to_rest": TemplateInfo(
+        name="duckdb_to_rest",
+        description="DuckDB → REST API POST (httpbin.org for testing — no accounts needed)",
+        next_steps=(
+            "No env vars required — works out of the box once you have a DuckDB table.",
+            "Seed sample data: `python -c \"import duckdb; "
+            "c=duckdb.connect('warehouse.duckdb'); "
+            "c.execute('CREATE TABLE users AS SELECT * FROM "
+            "(VALUES (1,\\'a\\',\\'a@x.com\\'),(2,\\'b\\',\\'b@x.com\\')) t(id,name,email)')\"`",
+            "Dry-run: `drt run --dry-run`",
+            "Run for real: `drt run`",
+        ),
+    ),
+    "postgres_to_slack": TemplateInfo(
+        name="postgres_to_slack",
+        description="PostgreSQL → Slack webhook (operational alerts)",
+        next_steps=(
+            "Set the Slack webhook env var: `export SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...`",
+            "Configure a `postgres` profile in ~/.drt/profiles.yml — see `drt sources --detailed`",
+            "Make sure your DB has an `alerts` table "
+            "(or edit `model: ref('alerts')` in the sync file)",
+            "Dry-run: `drt run --dry-run`",
+        ),
+    ),
+    "duckdb_to_hubspot": TemplateInfo(
+        name="duckdb_to_hubspot",
+        description="DuckDB → HubSpot contacts upsert",
+        next_steps=(
+            "Create a HubSpot private app token and: `export HUBSPOT_TOKEN=pat-...`",
+            "Seed a DuckDB `contacts` table with at least: email, firstname, lastname",
+            "Dry-run: `drt run --dry-run`",
+        ),
+    ),
+}
+
+
+def write_template(name: str, project_dir: Path) -> Path:
+    """Write the template's YAML to ``<project_dir>/syncs/<name>.yml``.
+
+    Raises ``KeyError`` if ``name`` is not a registered template (let the
+    CLI handler turn that into a user-facing error with the available
+    list).
+    """
+    tmpl = TEMPLATES[name]
+    syncs_dir = project_dir / "syncs"
+    syncs_dir.mkdir(exist_ok=True)
+    out_path = syncs_dir / f"{name}.yml"
+    out_path.write_text(tmpl.read_yaml())
+    return out_path

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -340,10 +340,22 @@ def init(
         "--from-dbt",
         help="Path to dbt manifest.json — generate sync YAMLs from dbt models.",
     ),
+    template: str = typer.Option(
+        None,
+        "--template",
+        help="Scaffold from a curated template. Use 'list' to see available templates.",
+    ),
 ) -> None:
     """Initialize a new drt project in the current directory."""
     if from_dbt:
         _init_from_dbt(Path(from_dbt))
+        return
+
+    if template == "list":
+        _list_templates()
+        return
+    if template:
+        _init_from_template(template, Path("."))
         return
 
     from drt.cli.init_wizard import run_wizard, scaffold_project
@@ -358,6 +370,53 @@ def init(
     except Exception as e:
         print_error(str(e))
         raise typer.Exit(1)
+
+
+def _list_templates() -> None:
+    """Print available ``drt init --template`` choices."""
+    from drt.cli._init_templates import TEMPLATES
+
+    console.print("\n[bold]Available templates:[/bold]\n")
+    for name, info in TEMPLATES.items():
+        console.print(f"  [cyan]{name}[/cyan] — {info.description}")
+    console.print("\nUse: [bold]drt init --template <name>[/bold]\n")
+
+
+def _init_from_template(name: str, project_dir: Path) -> None:
+    """Scaffold a project from a curated template and print next steps."""
+    from drt.cli._init_templates import TEMPLATES, write_template
+
+    if name not in TEMPLATES:
+        print_error(f"Unknown template: {name!r}")
+        console.print("Run [bold]drt init --template list[/bold] to see available templates.")
+        raise typer.Exit(1)
+
+    # Ensure minimal project shell exists so `drt validate` / `drt run` work.
+    created: list[str] = []
+    project_file = project_dir / "drt_project.yml"
+    if not project_file.exists():
+        project_file.write_text(
+            "name: my_drt_project\nprofile: default\n"
+        )
+        created.append(str(project_file))
+
+    drt_dir = project_dir / ".drt"
+    drt_dir.mkdir(exist_ok=True)
+    drt_gitignore = drt_dir / ".gitignore"
+    if not drt_gitignore.exists():
+        drt_gitignore.write_text("*\n")
+        created.append(str(drt_gitignore))
+
+    sync_path = write_template(name, project_dir)
+    created.append(str(sync_path))
+
+    print_init_success(created)
+
+    info = TEMPLATES[name]
+    console.print(f"\n[bold]Next steps for '{name}':[/bold]")
+    for i, step in enumerate(info.next_steps, 1):
+        console.print(f"  {i}. {step}")
+    console.print()
 
 
 def _init_from_dbt(manifest_path: Path) -> None:

--- a/drt/cli/templates/syncs/duckdb_to_hubspot.yml
+++ b/drt/cli/templates/syncs/duckdb_to_hubspot.yml
@@ -1,0 +1,29 @@
+# DuckDB → HubSpot contacts upsert.
+# Requires:
+#   export HUBSPOT_TOKEN=pat-xxx   # HubSpot private app token
+# DuckDB source needs a `contacts` table with at least: email, firstname, lastname.
+name: duckdb_to_hubspot
+description: "Upsert DuckDB contacts into HubSpot by email"
+
+model: ref('contacts')
+
+destination:
+  type: hubspot
+  object_type: contacts
+  id_property: email
+  properties_template: |
+    {
+      "email": "{{ row.email }}",
+      "firstname": "{{ row.firstname }}",
+      "lastname": "{{ row.lastname }}"
+    }
+  auth:
+    type: bearer
+    token_env: HUBSPOT_TOKEN
+
+sync:
+  mode: full
+  batch_size: 100
+  rate_limit:
+    requests_per_second: 10  # HubSpot allows ~100/10s; conservative default
+  on_error: skip

--- a/drt/cli/templates/syncs/duckdb_to_rest.yml
+++ b/drt/cli/templates/syncs/duckdb_to_rest.yml
@@ -1,0 +1,26 @@
+# DuckDB → REST API (httpbin.org) — no cloud accounts needed.
+# Edit `model` to point at your table, then run `drt run --dry-run`.
+name: duckdb_to_rest
+description: "POST each row from a local DuckDB table to a REST endpoint"
+
+model: ref('users')
+
+destination:
+  type: rest_api
+  url: "https://httpbin.org/post"
+  method: POST
+  headers:
+    Content-Type: "application/json"
+  body_template: |
+    {
+      "id": {{ row.id }},
+      "name": "{{ row.name }}",
+      "email": "{{ row.email }}"
+    }
+
+sync:
+  mode: full
+  batch_size: 5
+  rate_limit:
+    requests_per_second: 5
+  on_error: skip

--- a/drt/cli/templates/syncs/postgres_to_slack.yml
+++ b/drt/cli/templates/syncs/postgres_to_slack.yml
@@ -1,0 +1,21 @@
+# PostgreSQL → Slack webhook — typical "operational alert" shape.
+# Requires:
+#   export SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T.../B.../...
+# Plus a `postgres` profile in ~/.drt/profiles.yml pointing at your DB.
+name: postgres_to_slack
+description: "Notify Slack when new high-priority rows appear in Postgres"
+
+model: ref('alerts')
+
+destination:
+  type: slack
+  webhook_url_env: SLACK_WEBHOOK_URL
+  message_template: ":rotating_light: {{ row.severity }} — {{ row.message }} (id={{ row.id }})"
+
+sync:
+  mode: incremental
+  cursor_field: created_at
+  batch_size: 50
+  rate_limit:
+    requests_per_second: 1  # Slack incoming-webhook limit
+  on_error: skip

--- a/tests/unit/test_cli_init_templates.py
+++ b/tests/unit/test_cli_init_templates.py
@@ -1,0 +1,95 @@
+"""Tests for ``drt init --template`` (#545)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from drt.cli._init_templates import TEMPLATES
+from drt.cli.main import app
+from drt.config.models import SyncConfig
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# --template list
+# ---------------------------------------------------------------------------
+
+
+def test_template_list_exits_zero_and_lists_all_templates() -> None:
+    result = runner.invoke(app, ["init", "--template", "list"])
+    assert result.exit_code == 0
+    assert "Available templates:" in result.output
+    for name in TEMPLATES:
+        assert name in result.output
+
+
+# ---------------------------------------------------------------------------
+# --template <name> scaffolding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("template_name", list(TEMPLATES))
+def test_template_creates_sync_file_and_project_shell(
+    template_name: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Invoking ``--template <name>`` in an empty dir produces a runnable shell:
+    ``drt_project.yml``, ``.drt/.gitignore``, and ``syncs/<name>.yml``.
+    """
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "--template", template_name])
+    assert result.exit_code == 0
+
+    sync_file = tmp_path / "syncs" / f"{template_name}.yml"
+    assert sync_file.exists(), f"Expected {sync_file} to be created"
+    assert (tmp_path / "drt_project.yml").exists()
+    assert (tmp_path / ".drt" / ".gitignore").exists()
+
+    # Next-steps block from the registry must surface to the user
+    assert "Next steps" in result.output
+
+
+def test_template_does_not_overwrite_existing_drt_project_yml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "drt_project.yml").write_text("name: existing\nprofile: prod\n")
+
+    result = runner.invoke(app, ["init", "--template", "duckdb_to_rest"])
+    assert result.exit_code == 0
+    # Original content preserved (no clobber on the project shell)
+    assert (tmp_path / "drt_project.yml").read_text() == "name: existing\nprofile: prod\n"
+
+
+def test_template_invalid_name_exits_one_and_directs_to_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "--template", "made_up_name"])
+    assert result.exit_code == 1
+    assert "Unknown template" in result.output
+    assert "drt init --template list" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Every template file must parse as a valid SyncConfig
+# (this is the "ready to run drt validate" bar from #545)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("template_name", list(TEMPLATES))
+def test_every_template_parses_as_a_valid_sync_config(template_name: str) -> None:
+    """Locks the contract: shipping a template that fails Pydantic validation
+    would mean ``drt init --template <name> && drt validate`` errors out —
+    not the "ready to run" experience the issue promises.
+    """
+    info = TEMPLATES[template_name]
+    raw = info.read_yaml()
+    parsed = yaml.safe_load(raw)
+    # Pydantic raises ValidationError on shape mismatch — failing this test
+    # surfaces it with the offending file name.
+    SyncConfig.model_validate(parsed)


### PR DESCRIPTION
Closes #545. Eighth slice of the Tech Foundation Hardening epic #538. Closes the last UX gap on the v0.7.5 Wave 1 list.

## Why

The README's old 5-step quickstart had users (1) install (2) run the interactive wizard (3) seed sample DuckDB data (4) hand-author a sync YAML (5) run. Steps 2 and 4 were the friction — every newcomer typed something different and roughly half mistyped. This PR collapses the path to a single command:

\`\`\`bash
$ drt init --template duckdb_to_rest
\`\`\`

## Three curated starter templates

| Name | Use case | Cloud accounts needed |
|---|---|---|
| \`duckdb_to_rest\` | DuckDB → REST API POST (httpbin.org) | None |
| \`postgres_to_slack\` | PostgreSQL → Slack webhook (operational alerts) | Slack webhook + Postgres profile |
| \`duckdb_to_hubspot\` | DuckDB → HubSpot contacts upsert | HubSpot private app token |

Each is a static, self-contained sync YAML under \`drt/cli/templates/syncs/\`. \`drt init --template list\` enumerates them; \`drt init --template <name>\` writes \`syncs/<name>.yml\` plus a minimal \`drt_project.yml\` + \`.drt/.gitignore\` shell and prints per-template next-steps text (env vars, sample tables).

## Design notes

- **Static files, not Jinja-rendered.** The on-disk template is what the user gets — no per-invocation substitution. Keeps scaffolding boring and predictable.
- **Project shell created if missing, never overwritten.** Running \`--template <name>\` in a directory with an existing \`drt_project.yml\` appends only the new sync file.
- **Registry at \`drt/cli/_init_templates.py\`.** Each \`TemplateInfo\` carries name + description + next-steps tuple, so \`--template list\` and the post-scaffold guidance read from one source of truth.

## README rewrite

- New Quickstart fits in one \`bash\` block: install + \`init --template\` + seed + run
- "Other starter templates" subsection points at \`--template list\`
- "Customizing your sync" subsection demotes the interactive wizard to advanced usage
- \`docs/connectors/\` link + \`drt sources/destinations --detailed\` discovery hint added above the Connectors table

README.ja.md mirrored in a second commit with the i18n-sync marker updated.

## Tests

\`tests/unit/test_cli_init_templates.py\` — **9 tests**:

- \`--template list\` exits 0 and surfaces every registered template
- Per-template (parameterized × 3): scaffolds the expected project shell, sync file lands under \`syncs/\`, next-steps text prints
- \`--template\` does not overwrite an existing \`drt_project.yml\`
- \`--template invalid_name\` exits 1 with a pointer to \`list\`
- **Validation parity (parameterized × 3)**: each shipped template YAML parses as a \`SyncConfig\` via Pydantic — fails fast if a template that \`drt validate\` would reject is ever shipped

## Files

| File | Type |
|---|---|
| \`drt/cli/_init_templates.py\` | new — registry + loader |
| \`drt/cli/templates/syncs/duckdb_to_rest.yml\` | new |
| \`drt/cli/templates/syncs/postgres_to_slack.yml\` | new |
| \`drt/cli/templates/syncs/duckdb_to_hubspot.yml\` | new |
| \`drt/cli/main.py\` | modified — \`init\` gains \`--template\` flag + \`_list_templates\` / \`_init_from_template\` helpers |
| \`tests/unit/test_cli_init_templates.py\` | new — 9 tests |
| \`README.md\` | Quickstart rewrite + docs/connectors link |
| \`README.ja.md\` | mirrored + i18n-sync marker bumped |

## Local verification

\`\`\`
$ pytest tests/                  → 1185 passed, 1 skipped, 7 deselected
$ ruff check drt tests           → All checks passed!
$ mypy drt                       → Success: no issues in 96 files
$ make check-i18n                → OK
\`\`\`

## Out of scope (follow-ups)

- **Quickstart GIF / asciinema** (#282) lives in v0.8. This PR rewrites the text that the GIF will eventually record
- **Template contribution doc** for users to add their own templates — defer until usage shows demand
- **\`drt init --template <name> --no-shell\`** to skip drt_project.yml / .drt creation for users adding a sync to an existing project — easy follow-up

## Coordination

- Builds on #543 (\`--detailed\` flags) — the new "Customizing" subsection points at them
- Establishes the registry pattern that v0.9 plugin authors (#297) can use to register third-party templates
- No collision with anything open

## Test plan

- [x] 9 new tests cover \`--template list\` / scaffolding (3 templates) / no-overwrite / invalid-name / Pydantic-parse parity
- [x] 1185 existing tests pass unchanged
- [x] \`make check-i18n\` clean
- [x] ruff + mypy clean (96 files)
- [ ] CI Python 3.10–3.13 all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)