### PR TITLE
fix(cli): escape Rich markup in print_error so [extra] hints aren't dropped

### DIFF
--- a/drt/cli/output.py
+++ b/drt/cli/output.py
@@ -316,7 +316,12 @@ def print_status_verbose(
 
 
 def print_error(message: str) -> None:
-    console.print(f"[bold red]Error:[/bold red] {message}")
+    # Escape Rich markup in the user-supplied message so square-bracket
+    # fragments like ``drt-core[mcp]`` or ``[INFO]`` aren't consumed as
+    # style tags and silently dropped from the rendered output.
+    from rich.markup import escape
+
+    console.print(f"[bold red]Error:[/bold red] {escape(message)}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_commands_smoke.py
+++ b/tests/unit/test_cli_commands_smoke.py
@@ -100,8 +100,7 @@ def test_mcp_run_exits_1_when_extra_missing(monkeypatch: pytest.MonkeyPatch) -> 
 
     result = runner.invoke(app, ["mcp", "run"])
     assert result.exit_code == 1
-    # The hint mentions install path. Note: Rich strips ``[mcp]`` as a
-    # markup tag in the current message (``drt-core[mcp]`` → ``drt-core``);
-    # tracking that as a pre-existing rendering bug separate from #546.
-    assert "MCP server requires" in result.output
-    assert "pip install" in result.output
+    # The hint must include the FULL ``drt-core[mcp]`` install string so
+    # users know which extra to install — Rich must not consume ``[mcp]``
+    # as a markup tag. Guarded by the escape() in drt.cli.output.print_error.
+    assert "drt-core[mcp]" in result.output

--- a/tests/unit/test_cli_output_print_error.py
+++ b/tests/unit/test_cli_output_print_error.py
@@ -1,0 +1,42 @@
+"""Tests for ``drt.cli.output.print_error`` — Rich-markup safety."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "message, must_appear",
+    [
+        # The bug that motivated this guard: ``[mcp]`` got eaten as a Rich
+        # style tag, turning "pip install drt-core[mcp]" into "pip install
+        # drt-core" in the rendered output.
+        ("MCP server requires: pip install drt-core[mcp]", "drt-core[mcp]"),
+        # Bracketed log-level markers similarly.
+        ("[INFO] something happened", "[INFO]"),
+        # Multiple bracket groups in one message.
+        ("install drt-core[postgres,duckdb] for full DB support", "drt-core[postgres,duckdb]"),
+        # Plain messages still work — sanity check that the escape didn't
+        # break the happy path.
+        ("simple error message", "simple error message"),
+    ],
+)
+def test_print_error_preserves_square_brackets(
+    message: str, must_appear: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rich must not consume square-bracket fragments as style tags."""
+    from rich.console import Console
+
+    from drt.cli import output as out
+
+    buf = StringIO()
+    monkeypatch.setattr(out, "console", Console(file=buf, force_terminal=False, no_color=True))
+
+    out.print_error(message)
+    rendered = buf.getvalue()
+
+    assert must_appear in rendered, (
+        f"Expected '{must_appear}' in rendered output. Got: {rendered!r}"
+    )


### PR DESCRIPTION
Small follow-up to #565 / Epic #538. Discovered while writing coverage tests for the cli/main.py split.

## The bug

\`print_error("MCP server requires: pip install drt-core[mcp]")\` was being rendered by Rich, which consumed \`[mcp]\` as a style tag and silently dropped it. Users running \`drt mcp run\` without the optional extra saw:

\`\`\`
Error: MCP server requires: pip install drt-core
\`\`\`

instead of the actually-useful:

\`\`\`
Error: MCP server requires: pip install drt-core[mcp]
\`\`\`

Same trap waits for any future \`print_error\` callsite with bracketed text (Python lists, \`[INFO]\` log markers, \`drt-core[postgres,duckdb]\` style hints, …).

## The fix

\`drt.cli.output.print_error\` now calls \`rich.markup.escape\` on its message argument before interpolating into the styled template. The \`Error:\` prefix retains its red-bold styling; user-supplied content is treated as literal text.

\`\`\`diff
 def print_error(message: str) -> None:
-    console.print(f"[bold red]Error:[/bold red] {message}")
+    from rich.markup import escape
+    console.print(f"[bold red]Error:[/bold red] {escape(message)}")
\`\`\`

Guarding at the helper means we don't have to remember per-callsite.

## Tests

| File | Tests |
|---|---|
| \`tests/unit/test_cli_output_print_error.py\` (new) | 4 parametrized — \`drt-core[mcp]\`, \`drt-core[postgres,duckdb]\`, \`[INFO]\`, plain message regression |
| \`tests/unit/test_cli_commands_smoke.py::test_mcp_run_exits_1_when_extra_missing\` | Tightened from "MCP server requires" / "pip install" loose match to assert the full \`drt-core[mcp]\` string survives rendering |

## Local verification

\`\`\`
$ pytest tests/                  → 1193 passed, 1 skipped, 7 deselected
$ ruff check drt tests           → All checks passed!
$ mypy drt                       → Success: no issues in 104 files
\`\`\`

Manual repro: \`drt mcp run\` without \`drt-core[mcp]\` now correctly prints the full install hint.

## Coordination

- Builds on #565 (cli/main split Phase 1) — uses the smoke test infrastructure introduced there
- No collision with anything open
- Independent of any v0.7.5 release — pure bugfix, can ship with v0.7.5 or as v0.7.5.1 follow-up

## Test plan

- [x] 4 new parametrized tests for the escape behavior
- [x] Existing mcp smoke test tightened to lock in the fix
- [x] 1193 existing tests pass unchanged
- [x] mypy + ruff clean (104 files)
- [ ] CI Python 3.10–3.13 all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)