### PR TITLE
refactor(cli): retrofit ErrorFormatter stage detection to engine-emitted attr (#544 follow-up)

### DIFF
--- a/drt/cli/errors.py
+++ b/drt/cli/errors.py
@@ -66,14 +66,38 @@ def classify_filename(filename: str) -> Stage:
 
 
 def infer_stage(exc: BaseException) -> Stage:
-    """Walk the exception's traceback to find the deepest drt-owned frame.
+    """Return the pipeline stage that produced ``exc``.
 
-    "Deepest" means: the most recent frame inside a ``drt/<area>/`` module.
-    If the exception bubbled through ``drt/sources/postgres.py`` and then
-    ``drt/engine/sync.py``, we return ``SOURCE`` — that's where the actual
-    fault originated. Frames from third-party packages between the two are
-    skipped, never overriding the stage.
+    Resolution order:
+
+    1. **Engine-emitted ``_drt_stage`` attribute** (#544 retrofit). The
+       engine wraps each phase call in a ``_stage_ctx`` context manager
+       (``drt.engine.sync._stage_ctx``) that attaches a string tag
+       (``"source"`` / ``"destination"`` / ``"state"`` / ``"engine"``)
+       to any exception bubbling through. First writer wins so a source-
+       raised error tagged at the source site survives intermediate
+       destination/engine frames. This is the authoritative signal —
+       prefer it over the heuristic when present.
+
+    2. **Traceback walk fallback**. For exceptions raised outside any
+       engine ``_stage_ctx`` block (library callers using ``run_sync``
+       directly, future code paths not yet wrapped) we walk the
+       traceback for the deepest ``drt/<area>/`` frame. Same heuristic
+       as before #544 — preserves back-compat for the 26 ErrorFormatter
+       tests that depend on it.
     """
+    # 1. Engine-emitted tag (preferred)
+    tag = getattr(exc, "_drt_stage", None)
+    if tag is not None:
+        try:
+            # Stage subclasses str so Stage("source") round-trips fine.
+            return Stage(tag) if not isinstance(tag, Stage) else tag
+        except ValueError:
+            # Unknown tag string (e.g. drifted between engine and cli) —
+            # fall through to the traceback walk rather than crash.
+            pass
+
+    # 2. Traceback walk fallback
     stage = Stage.UNKNOWN
     tb = exc.__traceback__
     while tb is not None:

--- a/drt/engine/sync.py
+++ b/drt/engine/sync.py
@@ -12,7 +12,7 @@ import time
 from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from drt.config.credentials import ProfileConfig
 from drt.config.models import LookupConfig, SyncConfig
@@ -68,6 +68,61 @@ def batch(iterable: Iterator[Any], size: int) -> Iterator[list[Any]]:
             chunk = []
     if chunk:
         yield chunk
+
+
+class _stage_ctx:
+    """Tag any exception raised within the block with ``_drt_stage = <stage>``.
+
+    Retrofit for #544 (ErrorFormatter): supersedes the traceback-walk
+    heuristic in ``drt.cli.errors.infer_stage`` with an engine-emitted
+    string tag. ``infer_stage`` reads ``getattr(exc, '_drt_stage', None)``
+    first, falls back to the walk if absent (preserving back-compat for
+    exceptions raised outside any ``_stage_ctx`` block).
+
+    Stages are strings (``"source"`` / ``"destination"`` / ``"state"`` /
+    ``"engine"``) rather than the ``drt.cli.errors.Stage`` enum so the
+    engine module stays free of CLI imports — ``Stage`` has ``str`` as
+    its base so ``Stage(tag)`` round-trips cleanly on the reader side.
+
+    First writer wins. Nested blocks don't overwrite the outer-most
+    attribution — if a source-raised exception bubbles up through a
+    destination-stage block, the SOURCE tag set by the inner block
+    stays. (Engine sites that wrap source iteration are themselves
+    inside the for-loop that destination calls live in; the inner
+    ``_stage_ctx("source")`` runs first.)
+    """
+
+    __slots__ = ("_stage",)
+
+    def __init__(self, stage: str) -> None:
+        self._stage = stage
+
+    def __enter__(self) -> _stage_ctx:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, tb: Any) -> Literal[False]:
+        if exc_val is not None and getattr(exc_val, "_drt_stage", None) is None:
+            try:
+                exc_val._drt_stage = self._stage
+            except (AttributeError, TypeError):
+                # Some C-level exception types reject attribute setting.
+                # Silent skip — the traceback-walk fallback still works.
+                pass
+        return False  # propagate
+
+
+def _staged_source_iter(
+    source: Source, query: str, profile: ProfileConfig
+) -> Iterator[dict[str, Any]]:
+    """Wrap ``source.extract`` so iteration errors get tagged with stage="source".
+
+    ``source.extract`` returns an iterator. Errors that fire during the
+    initial call OR during subsequent ``__next__`` invocations both bubble
+    through this generator's frame, which means ``_stage_ctx`` catches
+    them whether the source materialises eagerly or lazily.
+    """
+    with _stage_ctx("source"):
+        yield from source.extract(query, profile)
 
 
 def run_sync(
@@ -265,7 +320,9 @@ def _run_sync_body(
 
     query = resolve_model_ref(sync.model, project_dir, profile, cursor_field, last_cursor_value)
 
-    records_iter = source.extract(query, profile)
+    # Source extraction wrapped via generator helper so exceptions raised
+    # during iteration (not just the initial call) carry stage="source" (#544).
+    records_iter = _staged_source_iter(source, query, profile)
     new_cursor_value: str | None = last_cursor_value
     is_staged = isinstance(destination, StagedDestination)
     staged_count = 0
@@ -274,7 +331,9 @@ def _run_sync_body(
     # the diff engine after extraction completes (#413).
     dry_run_records: list[dict[str, Any]] = []
 
-    # Build lookup maps (one query per lookup, before the batch loop)
+    # Build lookup maps (one query per lookup, before the batch loop).
+    # The build_lookup_map() call hits the destination, so tag failures
+    # accordingly (#544).
     lookup_maps: dict[str, tuple[LookupConfig, dict[tuple[Any, ...], Any]]] = {}
     lookups: dict[str, LookupConfig] | None = getattr(
         sync.destination,
@@ -285,7 +344,8 @@ def _run_sync_body(
         for warning in detect_ambiguous_lookup_ordering(lookups):
             observer.on_warning(sync.name, warning)
         for col_name, lk_config in lookups.items():
-            mapping = build_lookup_map(sync.destination, lk_config)
+            with _stage_ctx("destination"):
+                mapping = build_lookup_map(sync.destination, lk_config)
             lookup_maps[col_name] = (lk_config, mapping)
 
     for record_batch in batch(records_iter, sync.sync.batch_size):
@@ -331,11 +391,13 @@ def _run_sync_body(
 
         if is_staged:
             assert isinstance(destination, StagedDestination)
-            destination.stage(record_batch, sync.destination, sync.sync)
+            with _stage_ctx("destination"):
+                destination.stage(record_batch, sync.destination, sync.sync)
             staged_count += len(record_batch)
         else:
             assert isinstance(destination, Destination)
-            result = destination.load(record_batch, sync.destination, sync.sync)
+            with _stage_ctx("destination"):
+                result = destination.load(record_batch, sync.destination, sync.sync)
             total_result.success += result.success
             total_result.failed += result.failed
             total_result.skipped += result.skipped
@@ -352,7 +414,8 @@ def _run_sync_body(
     # stage() only buffers, so records aren't "successful" until finalize.
     if is_staged and not dry_run and staged_count > 0:
         assert isinstance(destination, StagedDestination)
-        finalize_result = destination.finalize(sync.destination, sync.sync)
+        with _stage_ctx("destination"):
+            finalize_result = destination.finalize(sync.destination, sync.sync)
         total_result.success += finalize_result.success
         total_result.failed += finalize_result.failed
         total_result.errors.extend(finalize_result.errors)
@@ -365,7 +428,8 @@ def _run_sync_body(
     if not is_staged and not dry_run:
         finalizer = getattr(destination, "finalize_sync", None)
         if callable(finalizer):
-            finalize_result = finalizer(sync.destination, sync.sync)
+            with _stage_ctx("destination"):
+                finalize_result = finalizer(sync.destination, sync.sync)
             if finalize_result is not None:
                 total_result.success += finalize_result.success
                 total_result.failed += finalize_result.failed

--- a/tests/unit/test_cli_errors.py
+++ b/tests/unit/test_cli_errors.py
@@ -252,3 +252,123 @@ def test_render_to_console_omits_suggestion_when_none() -> None:
         suggestion=None,
     )
     render_to_console(fe)
+
+
+# ---------------------------------------------------------------------------
+# #544 retrofit: infer_stage prefers engine-emitted ``_drt_stage`` attr
+# over the traceback-walk heuristic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tag, expected",
+    [
+        ("source", Stage.SOURCE),
+        ("destination", Stage.DESTINATION),
+        ("engine", Stage.ENGINE),
+        ("state", Stage.STATE),
+    ],
+)
+def test_infer_stage_uses_drt_stage_attr_when_present(tag: str, expected: Stage) -> None:
+    """An exception carrying ``_drt_stage = "<tag>"`` returns the matching enum."""
+    exc = RuntimeError("boom")
+    exc._drt_stage = tag  # type: ignore[attr-defined]
+    assert infer_stage(exc) is expected
+
+
+def test_infer_stage_attr_overrides_traceback_walk() -> None:
+    """The attr is authoritative — even when traceback would say otherwise.
+
+    Raises from inside drt.sources.duckdb (which the walk classifies as
+    SOURCE) but pre-tags with "destination". infer_stage must trust the
+    explicit tag, not re-derive from the traceback.
+    """
+    pytest.importorskip("duckdb")
+    from drt.sources.duckdb import DuckDBSource
+
+    class FakeConfig:
+        database = ":memory:"
+
+    try:
+        list(DuckDBSource().extract("SELECT 1", FakeConfig()))  # type: ignore[arg-type]
+    except AssertionError as e:
+        e._drt_stage = "destination"  # type: ignore[attr-defined]
+        # Without the attr this would return SOURCE (proven by an existing test);
+        # with the attr it must return DESTINATION.
+        assert infer_stage(e) is Stage.DESTINATION
+
+
+def test_infer_stage_falls_back_to_walk_for_unknown_attr_value() -> None:
+    """Unknown tag strings shouldn't crash — fall through to the walk."""
+    exc = RuntimeError("boom")
+    exc._drt_stage = "not-a-real-stage"  # type: ignore[attr-defined]
+    # Raised in this test module → no drt path → UNKNOWN from walk
+    assert infer_stage(exc) is Stage.UNKNOWN
+
+
+def test_infer_stage_accepts_stage_enum_as_attr_value() -> None:
+    """Future-proofing: if engine ever attaches the enum directly, accept it."""
+    exc = RuntimeError("boom")
+    exc._drt_stage = Stage.DESTINATION  # type: ignore[attr-defined]
+    assert infer_stage(exc) is Stage.DESTINATION
+
+
+def test_infer_stage_no_attr_uses_walk_unchanged() -> None:
+    """Back-compat: exceptions raised outside any _stage_ctx block (library
+    callers using run_sync directly without going through engine wrapping)
+    still get the walk-based classification.
+    """
+    pytest.importorskip("duckdb")
+    from drt.sources.duckdb import DuckDBSource
+
+    class FakeConfig:
+        database = ":memory:"
+
+    try:
+        list(DuckDBSource().extract("SELECT 1", FakeConfig()))  # type: ignore[arg-type]
+    except AssertionError as e:
+        # No _drt_stage attr → walk fallback finds drt/sources/duckdb.py frame
+        assert not hasattr(e, "_drt_stage")
+        assert infer_stage(e) is Stage.SOURCE
+
+
+# ---------------------------------------------------------------------------
+# Engine _stage_ctx: attaches the right tag on raise
+# ---------------------------------------------------------------------------
+
+
+def test_engine_stage_ctx_attaches_tag_first_writer_wins() -> None:
+    """The context manager attaches ``_drt_stage`` and does NOT overwrite a
+    previously-set value (so inner blocks take precedence over outer ones,
+    which is what gives a source-raised error the SOURCE tag even when it
+    bubbles through a destination-stage block).
+    """
+    from drt.engine.sync import _stage_ctx
+
+    try:
+        with _stage_ctx("destination"):
+            with _stage_ctx("source"):
+                raise RuntimeError("from source")
+    except RuntimeError as e:
+        # Inner block (source) wins — first writer
+        assert e._drt_stage == "source"  # type: ignore[attr-defined]
+
+
+def test_engine_stage_ctx_tags_uncaught_exception() -> None:
+    """A plain raise inside the block gets tagged with the stage."""
+    from drt.engine.sync import _stage_ctx
+
+    try:
+        with _stage_ctx("destination"):
+            raise ValueError("kaboom")
+    except ValueError as e:
+        assert e._drt_stage == "destination"  # type: ignore[attr-defined]
+
+
+def test_engine_stage_ctx_does_not_swallow_exception() -> None:
+    """``_stage_ctx`` is tagging-only; the exception still propagates."""
+    from drt.engine.sync import _stage_ctx
+
+    with pytest.raises(RuntimeError, match="propagated"):
+        with _stage_ctx("source"):
+            raise RuntimeError("propagated")


### PR DESCRIPTION
Round 2 of post-v0.7.5 follow-ups. Supersedes the traceback-walk heuristic in \`drt.cli.errors.infer_stage\` with an engine-emitted \`_drt_stage\` string attr — the planned follow-up mentioned in #559's commit message.

## Why

The traceback walk introduced in #544 was a temporary heuristic. It works most of the time (each Source / Destination lives in a \`drt/<area>/\` module so the deepest frame disambiguates), but it has two failure modes:

1. **Re-raise loses attribution** when intermediate layers wrap exceptions.
2. **Engine vs Source ambiguity** when source iterators fail mid-iteration — the deepest drt frame can end up being \`drt/engine/sync.py\`'s for-loop, mis-classifying as ENGINE.

The retrofit makes the engine the source of truth: it knows which phase it's in, so it attaches a string tag at the call site before the exception leaves the block.

## What ships

### New in \`drt/engine/sync.py\`

\`\`\`python
class _stage_ctx:
    """Tag exceptions raised inside this block with _drt_stage = <stage>.
    First writer wins so nested blocks don't overwrite outer attribution.
    Returns Literal[False] — never swallows.
    """

def _staged_source_iter(source, query, profile):
    """Wrap source.extract so iteration errors get stage='source' too,
    not just the initial extract() call."""
    with _stage_ctx("source"):
        yield from source.extract(query, profile)
\`\`\`

Wrapped sites in \`run_sync\`'s body:

| Call | Stage tag |
|---|---|
| \`source.extract\` + iteration (via \`_staged_source_iter\`) | \`"source"\` |
| \`build_lookup_map\` (queries destination) | \`"destination"\` |
| \`destination.stage\` | \`"destination"\` |
| \`destination.load\` | \`"destination"\` |
| \`destination.finalize\` (staged) | \`"destination"\` |
| \`destination.finalize_sync\` (duck-typed swap) | \`"destination"\` |

### Updated in \`drt/cli/errors.py\`

\`\`\`python
def infer_stage(exc):
    # 1. Engine-emitted tag (preferred, authoritative)
    tag = getattr(exc, "_drt_stage", None)
    if tag is not None:
        try:
            return Stage(tag) if not isinstance(tag, Stage) else tag
        except ValueError:
            pass  # unknown tag → fall through to walk
    # 2. Traceback walk fallback (unchanged from #544)
    ...
\`\`\`

## Design notes

- **Stage values are strings on the wire** (not the \`Stage\` enum) so \`drt/engine/sync.py\` doesn't have to import from \`drt/cli/errors\` — that would reverse the dependency direction. \`Stage\` subclasses \`str\` so \`Stage("source") == Stage.SOURCE\` round-trips cleanly at the reader side.
- **First writer wins** — a source-raised exception bubbling up through a destination block keeps its SOURCE tag (the actual fault site is what users want).
- **Out of MVR scope**: cursor-read fallback chain wrapping (\`watermark_storage.get\` / \`state_manager.get_last_sync\`). Already wrapped by the outer run_sync try/except; traceback walk classifies state errors accurately when no attr is set.
- **\`Literal[False]\` return on \`__exit__\`** — explicit contract that the manager never swallows.

## Tests

\`tests/unit/test_cli_errors.py\` — **11 new tests**:

| Test | Covers |
|---|---|
| \`test_infer_stage_uses_drt_stage_attr_when_present\` (× 4 params) | Happy path for source / destination / engine / state |
| \`test_infer_stage_attr_overrides_traceback_walk\` | Explicit tag wins over walk's classification |
| \`test_infer_stage_falls_back_to_walk_for_unknown_attr_value\` | Unknown tag → walk (no crash) |
| \`test_infer_stage_accepts_stage_enum_as_attr_value\` | Future-proofing — engine could pass enum directly |
| \`test_infer_stage_no_attr_uses_walk_unchanged\` | Back-compat: library callers still get walk |
| \`test_engine_stage_ctx_attaches_tag_first_writer_wins\` | Nested source-in-destination → SOURCE survives |
| \`test_engine_stage_ctx_tags_uncaught_exception\` | Basic tagging |
| \`test_engine_stage_ctx_does_not_swallow_exception\` | \`Literal[False]\` contract |

**Existing 26 ErrorFormatter tests pass unchanged** — walk fallback is the same code path as before for un-tagged exceptions.

## Local verification

\`\`\`
$ pytest tests/                  → 1218 passed, 1 skipped, 7 deselected
$ ruff check drt tests           → All checks passed!
$ mypy drt                       → Success: no issues in 104 files
\`\`\`

## Coordination

- Builds on #558 (ErrorFormatter, the original PR that added the heuristic) and #559 (SyncObserver — same design principle: make engine the source of truth for runtime metadata)
- No collision with anything open
- The engine API is unchanged (no new parameters); only adds the side-effect of tagging exceptions before they leave the engine

## Test plan

- [x] 11 new + 26 existing ErrorFormatter tests pass
- [x] All 1218 tests pass (no regression in engine or integration tests)
- [x] ruff + mypy clean
- [x] First-writer-wins semantics tested with nested \`_stage_ctx\`
- [x] Unknown tag value gracefully falls through to traceback walk
- [ ] CI Python 3.10–3.13 all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)