### PR TITLE
refactor(cli): Phase 2a of cli/main.py split — connectors + init + clean + serve + _helpers

### DIFF
--- a/drt/cli/_helpers.py
+++ b/drt/cli/_helpers.py
@@ -1,0 +1,86 @@
+"""Shared CLI helpers — factories + profile resolution.
+
+Extracted from ``drt/cli/main.py`` in Phase 2 of #546 so that per-command
+modules under ``drt/cli/commands/`` can share these utilities without
+pulling the whole main module (and its many import dependencies) into
+their import graph.
+
+Lives at the same level as ``_app.py`` and ``_connector_detail.py`` —
+"underscore-prefixed CLI internals." Not part of the public Python API;
+the only stable surface is the ``drt`` CLI itself.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from drt.config.credentials import ProfileConfig
+    from drt.config.models import SyncConfig
+    from drt.destinations.base import Destination
+    from drt.sources.base import Source
+
+
+def resolve_profile_name(cli_flag: str | None, project_profile: str) -> str:
+    """Resolve which profile to use.
+
+    Precedence: ``--profile`` flag > ``DRT_PROFILE`` env var > drt_project.yml
+    """
+    if cli_flag:
+        return cli_flag
+    env = os.environ.get("DRT_PROFILE")
+    if env:
+        return env
+    return project_profile
+
+
+def get_source(profile: ProfileConfig) -> Source:
+    """Return a Source instance for the given profile configuration.
+
+    Uses the connector registry for automatic connector discovery and
+    instantiation.
+    """
+    from drt.connectors import get_source as _registry_get_source
+
+    return _registry_get_source(profile)
+
+
+def get_destination(sync: SyncConfig) -> Destination:
+    """Return a Destination instance for the given sync configuration.
+
+    Uses the connector registry for automatic connector discovery and
+    instantiation.
+    """
+    from drt.connectors import get_destination as _registry_get_destination
+
+    return _registry_get_destination(sync.destination)
+
+
+def get_watermark_storage(sync: SyncConfig, project_dir: Path) -> Any:
+    """Build watermark storage from sync config, or ``None`` if not configured."""
+    from drt.state.watermark import (
+        BigQueryWatermarkStorage,
+        GCSWatermarkStorage,
+        LocalWatermarkStorage,
+    )
+
+    wm = sync.sync.watermark
+    if wm is None:
+        return None
+
+    if wm.storage == "local":
+        return LocalWatermarkStorage(project_dir)
+    elif wm.storage == "gcs":
+        assert wm.bucket is not None
+        assert wm.key is not None
+        return GCSWatermarkStorage(bucket=wm.bucket, key=wm.key)
+    elif wm.storage == "bigquery":
+        assert wm.project is not None
+        assert wm.dataset is not None
+        return BigQueryWatermarkStorage(
+            project=wm.project,
+            dataset=wm.dataset,
+        )
+    return None

--- a/drt/cli/commands/__init__.py
+++ b/drt/cli/commands/__init__.py
@@ -15,10 +15,14 @@ from __future__ import annotations
 # the command on drt.cli._app.app. Namespace sub-Typers (config, cloud,
 # docs, mcp) sit alongside top-level commands.
 from drt.cli.commands import (
+    clean,  # noqa: F401
     cloud,  # noqa: F401
     config,  # noqa: F401
+    connectors,  # noqa: F401 — registers `drt sources` + `drt destinations`
     docs,  # noqa: F401
     doctor,  # noqa: F401
+    init,  # noqa: F401
     list_syncs,  # noqa: F401
     mcp,  # noqa: F401
+    serve,  # noqa: F401
 )

--- a/drt/cli/commands/clean.py
+++ b/drt/cli/commands/clean.py
@@ -1,0 +1,57 @@
+"""`drt clean` — clean up orphan __drt_swap shadow tables."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from drt.cli._app import app
+from drt.cli._helpers import get_destination
+
+
+@app.command()
+def clean(
+    orphans: bool = typer.Option(
+        False, "--orphans", help="List or drop orphan __drt_swap tables."
+    ),
+    execute: bool = typer.Option(False, "--execute", help="Execute drops (default: dry-run)."),
+    config: str = typer.Option("drt.yml", "--config", "-c", help="Path to config file."),
+) -> None:
+    """Clean up orphan __drt_swap shadow tables left by interrupted swaps.
+
+    Use --orphans to list candidate shadow tables and --execute to drop them.
+    """
+    from drt.config.parser import load_syncs_safe
+    from drt.destinations.base import OrphanCleanup
+
+    if not orphans:
+        return
+
+    config_path = Path(config) if config != "drt.yml" else Path(".")
+    result = load_syncs_safe(config_path)
+
+    for sync in result.syncs:
+        dest = get_destination(sync)
+        if not isinstance(dest, OrphanCleanup):
+            continue
+
+        if not hasattr(sync.destination, "table"):
+            continue
+        base_table = sync.destination.table  # type: ignore[union-attr]
+        orphan_tables = dest.list_orphan_swap_tables(sync.destination, base_table)
+
+        if not orphan_tables:
+            typer.echo("No orphan swap tables found.")
+            continue
+
+        if execute:
+            dropped, failed = dest.drop_orphan_swap_tables(sync.destination, orphan_tables)
+            typer.echo(f"Dropped: {len(dropped)} orphan swap table(s).")
+            if failed:
+                typer.echo(f"Failed: {len(failed)} orphan swap table(s).")
+        else:
+            typer.echo(f"Found {len(orphan_tables)} orphan swap table(s).")
+            for table in orphan_tables:
+                typer.echo(f"[DRY RUN] Would drop: {table}")
+            typer.echo("Run with --execute to apply.")

--- a/drt/cli/commands/connectors.py
+++ b/drt/cli/commands/connectors.py
@@ -1,0 +1,127 @@
+"""`drt sources` and `drt destinations` — list available connectors.
+
+Both commands share the same Rich-table / Rich-panel / JSON output
+helpers so they live together. Phase 2 of #546 split this pair out
+of ``drt/cli/main.py``.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from drt.cli._app import app
+from drt.cli.output import console
+
+
+def _print_connectors_table(title: str, connectors: list[tuple[str, str]]) -> None:
+    """Print connectors in a rich table."""
+    from rich.table import Table
+
+    console.print(f"\n[bold]{title}[/bold]\n")
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Type", style="cyan")
+    table.add_column("Description", style="green")
+
+    for connector_type, description in connectors:
+        table.add_row(connector_type, description)
+
+    console.print(table)
+    console.print()
+
+
+def _print_connector_details(title: str, connectors: list[tuple[str, str]], kind: str) -> None:
+    """Print one Rich panel per connector with derived field detail."""
+    from rich.panel import Panel
+
+    from drt.cli._connector_detail import (
+        build_destination_detail,
+        build_source_detail,
+    )
+
+    builder = build_source_detail if kind == "source" else build_destination_detail
+    console.print(f"\n[bold]{title}[/bold]")
+    for connector_type, description in connectors:
+        detail = builder(connector_type, description)
+        body_lines: list[str] = []
+        if detail.required_env_vars:
+            joined = ", ".join(detail.required_env_vars)
+            body_lines.append(f"[bold]Required env vars:[/bold] {joined}")
+        if detail.required_fields:
+            joined = ", ".join(detail.required_fields)
+            body_lines.append(f"[bold]Required fields:[/bold] {joined}")
+        if detail.optional_env_vars:
+            joined = ", ".join(detail.optional_env_vars)
+            body_lines.append(f"[bold]Optional env vars:[/bold] {joined}")
+        body_lines.append("")
+        body_lines.append("[bold]Sample YAML:[/bold]")
+        body_lines.append(detail.sample_yaml)
+        console.print(
+            Panel(
+                "\n".join(body_lines),
+                title=f"[cyan]{detail.type}[/cyan] — {detail.display_name}",
+                border_style="cyan",
+                expand=False,
+            )
+        )
+    console.print()
+
+
+def _emit_connectors_json(connectors: list[tuple[str, str]], kind: str, *, detailed: bool) -> None:
+    """Emit machine-readable JSON for ``--format json`` consumers."""
+    import json as _json
+
+    if detailed:
+        from drt.cli._connector_detail import (
+            build_destination_detail,
+            build_source_detail,
+        )
+
+        builder = build_source_detail if kind == "source" else build_destination_detail
+        payload: list[dict[str, object]] = [builder(t, d).to_dict() for t, d in connectors]
+    else:
+        payload = [{"type": t, "display_name": d, "kind": kind} for t, d in connectors]
+    # Use plain print(), not console.print() — Rich wraps long lines at the
+    # terminal width and would corrupt the JSON for machine consumers.
+    print(_json.dumps({"connectors": payload}, indent=2))
+
+
+@app.command()
+def sources(
+    detailed: bool = typer.Option(
+        False, "--detailed", help="Print per-connector fields, env vars, and sample YAML."
+    ),
+    output: str = typer.Option(
+        "table", "--format", "-o", help="Output format: 'table' (default) or 'json'."
+    ),
+) -> None:
+    """List available source connectors."""
+    from drt.config.connectors import SOURCES
+
+    if output == "json":
+        _emit_connectors_json(SOURCES, "source", detailed=detailed)
+        return
+    if detailed:
+        _print_connector_details("Available sources:", SOURCES, "source")
+        return
+    _print_connectors_table("Available sources:", SOURCES)
+
+
+@app.command()
+def destinations(
+    detailed: bool = typer.Option(
+        False, "--detailed", help="Print per-connector fields, env vars, and sample YAML."
+    ),
+    output: str = typer.Option(
+        "table", "--format", "-o", help="Output format: 'table' (default) or 'json'."
+    ),
+) -> None:
+    """List available destination connectors."""
+    from drt.config.connectors import DESTINATIONS
+
+    if output == "json":
+        _emit_connectors_json(DESTINATIONS, "destination", detailed=detailed)
+        return
+    if detailed:
+        _print_connector_details("Available destinations:", DESTINATIONS, "destination")
+        return
+    _print_connectors_table("Available destinations:", DESTINATIONS)

--- a/drt/cli/commands/init.py
+++ b/drt/cli/commands/init.py
@@ -1,0 +1,179 @@
+"""`drt init` — initialize a new drt project.
+
+Three entry modes:
+
+- ``drt init`` — interactive wizard (asks for source type, profile, etc.)
+- ``drt init --template <name>`` — scaffold from a curated static template
+- ``drt init --from-dbt <manifest.json>`` — generate sync YAMLs from
+  a dbt project's manifest
+
+Each mode is implemented as a private helper called from the single
+``init`` Typer command.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from drt.cli._app import app
+from drt.cli.output import console, print_error, print_init_success
+
+
+@app.command()
+def init(
+    from_dbt: str = typer.Option(
+        None,
+        "--from-dbt",
+        help="Path to dbt manifest.json — generate sync YAMLs from dbt models.",
+    ),
+    template: str = typer.Option(
+        None,
+        "--template",
+        help="Scaffold from a curated template. Use 'list' to see available templates.",
+    ),
+) -> None:
+    """Initialize a new drt project in the current directory."""
+    if from_dbt:
+        _init_from_dbt(Path(from_dbt))
+        return
+
+    if template == "list":
+        _list_templates()
+        return
+    if template:
+        _init_from_template(template, Path("."))
+        return
+
+    from drt.cli.init_wizard import run_wizard, scaffold_project
+
+    try:
+        answers = run_wizard()
+        created = scaffold_project(answers, Path("."))
+        print_init_success(created)
+    except (KeyboardInterrupt, typer.Abort):
+        console.print("\n[dim]Aborted.[/dim]")
+        raise typer.Exit(1)
+    except Exception as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+
+def _list_templates() -> None:
+    """Print available ``drt init --template`` choices."""
+    from drt.cli._init_templates import TEMPLATES
+
+    console.print("\n[bold]Available templates:[/bold]\n")
+    for name, info in TEMPLATES.items():
+        console.print(f"  [cyan]{name}[/cyan] — {info.description}")
+    console.print("\nUse: [bold]drt init --template <name>[/bold]\n")
+
+
+def _init_from_template(name: str, project_dir: Path) -> None:
+    """Scaffold a project from a curated template and print next steps."""
+    from drt.cli._init_templates import TEMPLATES, write_template
+
+    if name not in TEMPLATES:
+        print_error(f"Unknown template: {name!r}")
+        console.print("Run [bold]drt init --template list[/bold] to see available templates.")
+        raise typer.Exit(1)
+
+    # Ensure minimal project shell exists so `drt validate` / `drt run` work.
+    created: list[str] = []
+    project_file = project_dir / "drt_project.yml"
+    if not project_file.exists():
+        project_file.write_text(
+            "name: my_drt_project\nprofile: default\n"
+        )
+        created.append(str(project_file))
+
+    drt_dir = project_dir / ".drt"
+    drt_dir.mkdir(exist_ok=True)
+    drt_gitignore = drt_dir / ".gitignore"
+    if not drt_gitignore.exists():
+        drt_gitignore.write_text("*\n")
+        created.append(str(drt_gitignore))
+
+    sync_path = write_template(name, project_dir)
+    created.append(str(sync_path))
+
+    print_init_success(created)
+
+    info = TEMPLATES[name]
+    console.print(f"\n[bold]Next steps for '{name}':[/bold]")
+    for i, step in enumerate(info.next_steps, 1):
+        console.print(f"  {i}. {step}")
+    console.print()
+
+
+def _init_from_dbt(manifest_path: Path) -> None:
+    """Generate sync YAML scaffolds from dbt manifest.json."""
+    import yaml
+
+    from drt.integrations.dbt import list_models_from_manifest
+
+    try:
+        models = list_models_from_manifest(manifest_path)
+    except FileNotFoundError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+    if not models:
+        console.print("[dim]No models found in manifest.[/dim]")
+        return
+
+    console.print(f"\n[bold]Found {len(models)} dbt models:[/bold]\n")
+    for i, m in enumerate(models):
+        desc = f" — {m.description}" if m.description else ""
+        console.print(f"  {i + 1}. {m.name}{desc}")
+
+    console.print("")
+    raw = typer.prompt(
+        "Select models (comma-separated numbers, or 'all')",
+        default="all",
+    )
+
+    if raw.strip().lower() == "all":
+        selected = models
+    else:
+        indices = [int(x.strip()) - 1 for x in raw.split(",") if x.strip().isdigit()]
+        selected = [models[i] for i in indices if 0 <= i < len(models)]
+
+    if not selected:
+        console.print("[dim]No models selected.[/dim]")
+        return
+
+    syncs_dir = Path(".") / "syncs"
+    syncs_dir.mkdir(exist_ok=True)
+    created: list[str] = []
+
+    for model in selected:
+        sync_data = {
+            "name": f"sync_{model.name}",
+            "description": model.description or f"Sync {model.name} to destination",
+            "model": f"ref('{model.name}')",
+            "destination": {
+                "type": "rest_api",
+                "url": "https://example.com/api",
+                "method": "POST",
+            },
+        }
+        path = syncs_dir / f"sync_{model.name}.yml"
+        if path.exists():
+            console.print(f"  [dim]skip[/dim] {path} (already exists)")
+            continue
+        with path.open("w") as f:
+            yaml.dump(sync_data, f, default_flow_style=False, sort_keys=False)
+        created.append(str(path))
+
+    if created:
+        console.print(f"\n[green]Created {len(created)} sync file(s):[/green]")
+        for c in created:
+            console.print(f"  {c}")
+        console.print(
+            "\n[dim]Edit the destination config in each file,"
+            " then run: drt validate && drt run --dry-run[/dim]"
+        )
+    else:
+        console.print("[dim]No new sync files created.[/dim]")

--- a/drt/cli/commands/serve.py
+++ b/drt/cli/commands/serve.py
@@ -1,0 +1,33 @@
+"""`drt serve` — HTTP endpoint that triggers syncs on demand."""
+
+from __future__ import annotations
+
+import os
+
+import typer
+
+from drt.cli._app import app
+
+
+@app.command()
+def serve(
+    host: str = typer.Option("127.0.0.1", "--host", help="Host to bind."),
+    port: int = typer.Option(8080, "--port", "-p", help="Port to bind."),
+    token_env: str = typer.Option(
+        "DRT_WEBHOOK_TOKEN",
+        "--token-env",
+        help="Env var holding bearer token for auth. Empty/unset = no auth.",
+    ),
+) -> None:
+    """Start an HTTP endpoint that triggers drt syncs on demand.
+
+    Example:
+        drt serve --port 8080 --token-env DRT_WEBHOOK_TOKEN
+
+        curl -X POST http://localhost:8080/sync/my_sync \\
+          -H "Authorization: Bearer $DRT_WEBHOOK_TOKEN"
+    """
+    from drt.cli.server import serve as serve_impl
+
+    token = os.environ.get(token_env) or None
+    serve_impl(host=host, port=port, token=token, project_dir=".")

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -38,7 +38,6 @@ from drt.cli.output import (
     console,
     print_dry_run_summary,
     print_error,
-    print_init_success,
     print_row_errors,
     print_status_table,
     print_status_verbose,
@@ -327,343 +326,9 @@ def main(
     pass
 
 
-# ---------------------------------------------------------------------------
-# init
-# ---------------------------------------------------------------------------
-
-
-@app.command()
-def init(
-    from_dbt: str = typer.Option(
-        None,
-        "--from-dbt",
-        help="Path to dbt manifest.json — generate sync YAMLs from dbt models.",
-    ),
-    template: str = typer.Option(
-        None,
-        "--template",
-        help="Scaffold from a curated template. Use 'list' to see available templates.",
-    ),
-) -> None:
-    """Initialize a new drt project in the current directory."""
-    if from_dbt:
-        _init_from_dbt(Path(from_dbt))
-        return
-
-    if template == "list":
-        _list_templates()
-        return
-    if template:
-        _init_from_template(template, Path("."))
-        return
-
-    from drt.cli.init_wizard import run_wizard, scaffold_project
-
-    try:
-        answers = run_wizard()
-        created = scaffold_project(answers, Path("."))
-        print_init_success(created)
-    except (KeyboardInterrupt, typer.Abort):
-        console.print("\n[dim]Aborted.[/dim]")
-        raise typer.Exit(1)
-    except Exception as e:
-        print_error(str(e))
-        raise typer.Exit(1)
-
-
-def _list_templates() -> None:
-    """Print available ``drt init --template`` choices."""
-    from drt.cli._init_templates import TEMPLATES
-
-    console.print("\n[bold]Available templates:[/bold]\n")
-    for name, info in TEMPLATES.items():
-        console.print(f"  [cyan]{name}[/cyan] — {info.description}")
-    console.print("\nUse: [bold]drt init --template <name>[/bold]\n")
-
-
-def _init_from_template(name: str, project_dir: Path) -> None:
-    """Scaffold a project from a curated template and print next steps."""
-    from drt.cli._init_templates import TEMPLATES, write_template
-
-    if name not in TEMPLATES:
-        print_error(f"Unknown template: {name!r}")
-        console.print("Run [bold]drt init --template list[/bold] to see available templates.")
-        raise typer.Exit(1)
-
-    # Ensure minimal project shell exists so `drt validate` / `drt run` work.
-    created: list[str] = []
-    project_file = project_dir / "drt_project.yml"
-    if not project_file.exists():
-        project_file.write_text(
-            "name: my_drt_project\nprofile: default\n"
-        )
-        created.append(str(project_file))
-
-    drt_dir = project_dir / ".drt"
-    drt_dir.mkdir(exist_ok=True)
-    drt_gitignore = drt_dir / ".gitignore"
-    if not drt_gitignore.exists():
-        drt_gitignore.write_text("*\n")
-        created.append(str(drt_gitignore))
-
-    sync_path = write_template(name, project_dir)
-    created.append(str(sync_path))
-
-    print_init_success(created)
-
-    info = TEMPLATES[name]
-    console.print(f"\n[bold]Next steps for '{name}':[/bold]")
-    for i, step in enumerate(info.next_steps, 1):
-        console.print(f"  {i}. {step}")
-    console.print()
-
-
-def _init_from_dbt(manifest_path: Path) -> None:
-    """Generate sync YAML scaffolds from dbt manifest.json."""
-    import yaml
-
-    from drt.integrations.dbt import list_models_from_manifest
-
-    try:
-        models = list_models_from_manifest(manifest_path)
-    except FileNotFoundError as e:
-        print_error(str(e))
-        raise typer.Exit(1)
-
-    if not models:
-        console.print("[dim]No models found in manifest.[/dim]")
-        return
-
-    console.print(f"\n[bold]Found {len(models)} dbt models:[/bold]\n")
-    for i, m in enumerate(models):
-        desc = f" — {m.description}" if m.description else ""
-        console.print(f"  {i + 1}. {m.name}{desc}")
-
-    console.print("")
-    raw = typer.prompt(
-        "Select models (comma-separated numbers, or 'all')",
-        default="all",
-    )
-
-    if raw.strip().lower() == "all":
-        selected = models
-    else:
-        indices = [int(x.strip()) - 1 for x in raw.split(",") if x.strip().isdigit()]
-        selected = [models[i] for i in indices if 0 <= i < len(models)]
-
-    if not selected:
-        console.print("[dim]No models selected.[/dim]")
-        return
-
-    syncs_dir = Path(".") / "syncs"
-    syncs_dir.mkdir(exist_ok=True)
-    created: list[str] = []
-
-    for model in selected:
-        sync_data = {
-            "name": f"sync_{model.name}",
-            "description": model.description or f"Sync {model.name} to destination",
-            "model": f"ref('{model.name}')",
-            "destination": {
-                "type": "rest_api",
-                "url": "https://example.com/api",
-                "method": "POST",
-            },
-        }
-        path = syncs_dir / f"sync_{model.name}.yml"
-        if path.exists():
-            console.print(f"  [dim]skip[/dim] {path} (already exists)")
-            continue
-        with path.open("w") as f:
-            yaml.dump(sync_data, f, default_flow_style=False, sort_keys=False)
-        created.append(str(path))
-
-    if created:
-        console.print(f"\n[green]Created {len(created)} sync file(s):[/green]")
-        for c in created:
-            console.print(f"  {c}")
-        console.print(
-            "\n[dim]Edit the destination config in each file,"
-            " then run: drt validate && drt run --dry-run[/dim]"
-        )
-    else:
-        console.print("[dim]No new sync files created.[/dim]")
-
-
-# ---------------------------------------------------------------------------
-# sources
-# ---------------------------------------------------------------------------
-
-
-def _print_connectors_table(title: str, connectors: list[tuple[str, str]]) -> None:
-    """Print connectors in a rich table."""
-    from rich.table import Table
-
-    console.print(f"\n[bold]{title}[/bold]\n")
-    table = Table(show_header=True, header_style="bold magenta")
-    table.add_column("Type", style="cyan")
-    table.add_column("Description", style="green")
-
-    for connector_type, description in connectors:
-        table.add_row(connector_type, description)
-
-    console.print(table)
-    console.print()
-
-
-def _print_connector_details(title: str, connectors: list[tuple[str, str]], kind: str) -> None:
-    """Print one Rich panel per connector with derived field detail."""
-    from rich.panel import Panel
-
-    from drt.cli._connector_detail import (
-        build_destination_detail,
-        build_source_detail,
-    )
-
-    builder = build_source_detail if kind == "source" else build_destination_detail
-    console.print(f"\n[bold]{title}[/bold]")
-    for connector_type, description in connectors:
-        detail = builder(connector_type, description)
-        body_lines: list[str] = []
-        if detail.required_env_vars:
-            joined = ", ".join(detail.required_env_vars)
-            body_lines.append(f"[bold]Required env vars:[/bold] {joined}")
-        if detail.required_fields:
-            joined = ", ".join(detail.required_fields)
-            body_lines.append(f"[bold]Required fields:[/bold] {joined}")
-        if detail.optional_env_vars:
-            joined = ", ".join(detail.optional_env_vars)
-            body_lines.append(f"[bold]Optional env vars:[/bold] {joined}")
-        body_lines.append("")
-        body_lines.append("[bold]Sample YAML:[/bold]")
-        body_lines.append(detail.sample_yaml)
-        console.print(
-            Panel(
-                "\n".join(body_lines),
-                title=f"[cyan]{detail.type}[/cyan] — {detail.display_name}",
-                border_style="cyan",
-                expand=False,
-            )
-        )
-    console.print()
-
-
-def _emit_connectors_json(connectors: list[tuple[str, str]], kind: str, *, detailed: bool) -> None:
-    """Emit machine-readable JSON for ``--format json`` consumers."""
-    import json as _json
-
-    if detailed:
-        from drt.cli._connector_detail import (
-            build_destination_detail,
-            build_source_detail,
-        )
-
-        builder = build_source_detail if kind == "source" else build_destination_detail
-        payload: list[dict[str, object]] = [builder(t, d).to_dict() for t, d in connectors]
-    else:
-        payload = [{"type": t, "display_name": d, "kind": kind} for t, d in connectors]
-    # Use plain print(), not console.print() — Rich wraps long lines at the
-    # terminal width and would corrupt the JSON for machine consumers.
-    print(_json.dumps({"connectors": payload}, indent=2))
-
-
-@app.command()
-def sources(
-    detailed: bool = typer.Option(
-        False, "--detailed", help="Print per-connector fields, env vars, and sample YAML."
-    ),
-    output: str = typer.Option(
-        "table", "--format", "-o", help="Output format: 'table' (default) or 'json'."
-    ),
-) -> None:
-    """List available source connectors."""
-    from drt.config.connectors import SOURCES
-
-    if output == "json":
-        _emit_connectors_json(SOURCES, "source", detailed=detailed)
-        return
-    if detailed:
-        _print_connector_details("Available sources:", SOURCES, "source")
-        return
-    _print_connectors_table("Available sources:", SOURCES)
-
-
-# ---------------------------------------------------------------------------
-# destinations
-# ---------------------------------------------------------------------------
-
-
-@app.command()
-def destinations(
-    detailed: bool = typer.Option(
-        False, "--detailed", help="Print per-connector fields, env vars, and sample YAML."
-    ),
-    output: str = typer.Option(
-        "table", "--format", "-o", help="Output format: 'table' (default) or 'json'."
-    ),
-) -> None:
-    """List available destination connectors."""
-    from drt.config.connectors import DESTINATIONS
-
-    if output == "json":
-        _emit_connectors_json(DESTINATIONS, "destination", detailed=detailed)
-        return
-    if detailed:
-        _print_connector_details("Available destinations:", DESTINATIONS, "destination")
-        return
-    _print_connectors_table("Available destinations:", DESTINATIONS)
-
-
-# ---------------------------------------------------------------------------
-# clean
-# ---------------------------------------------------------------------------
-
-
-@app.command()
-def clean(
-    orphans: bool = typer.Option(
-        False, "--orphans", help="List or drop orphan __drt_swap tables."
-    ),
-    execute: bool = typer.Option(False, "--execute", help="Execute drops (default: dry-run)."),
-    config: str = typer.Option("drt.yml", "--config", "-c", help="Path to config file."),
-) -> None:
-    """Clean up orphan __drt_swap shadow tables left by interrupted swaps.
-
-    Use --orphans to list candidate shadow tables and --execute to drop them.
-    """
-    from drt.config.parser import load_syncs_safe
-    from drt.destinations.base import OrphanCleanup
-
-    if not orphans:
-        return
-
-    config_path = Path(config) if config != "drt.yml" else Path(".")
-    result = load_syncs_safe(config_path)
-
-    for sync in result.syncs:
-        dest = _get_destination(sync)
-        if not isinstance(dest, OrphanCleanup):
-            continue
-
-        if not hasattr(sync.destination, "table"):
-            continue
-        base_table = sync.destination.table  # type: ignore[union-attr]
-        orphan_tables = dest.list_orphan_swap_tables(sync.destination, base_table)
-
-        if not orphan_tables:
-            typer.echo("No orphan swap tables found.")
-            continue
-
-        if execute:
-            dropped, failed = dest.drop_orphan_swap_tables(sync.destination, orphan_tables)
-            typer.echo(f"Dropped: {len(dropped)} orphan swap table(s).")
-            if failed:
-                typer.echo(f"Failed: {len(failed)} orphan swap table(s).")
-        else:
-            typer.echo(f"Found {len(orphan_tables)} orphan swap table(s).")
-            for table in orphan_tables:
-                typer.echo(f"[DRY RUN] Would drop: {table}")
-            typer.echo("Run with --execute to apply.")
+# `drt init` lives in drt/cli/commands/init.py (#546 Phase 2)
+# `drt sources` / `drt destinations` live in drt/cli/commands/connectors.py
+# `drt clean` lives in drt/cli/commands/clean.py
 
 
 # ---------------------------------------------------------------------------
@@ -1374,33 +1039,7 @@ def _test_display_name(test_def: object) -> str:
     return test_display_name(test_def)
 
 
-# ---------------------------------------------------------------------------
-# serve (webhook trigger)
-# ---------------------------------------------------------------------------
-
-
-@app.command()
-def serve(
-    host: str = typer.Option("127.0.0.1", "--host", help="Host to bind."),
-    port: int = typer.Option(8080, "--port", "-p", help="Port to bind."),
-    token_env: str = typer.Option(
-        "DRT_WEBHOOK_TOKEN",
-        "--token-env",
-        help="Env var holding bearer token for auth. Empty/unset = no auth.",
-    ),
-) -> None:
-    """Start an HTTP endpoint that triggers drt syncs on demand.
-
-    Example:
-        drt serve --port 8080 --token-env DRT_WEBHOOK_TOKEN
-
-        curl -X POST http://localhost:8080/sync/my_sync \\
-          -H "Authorization: Bearer $DRT_WEBHOOK_TOKEN"
-    """
-    from drt.cli.server import serve as serve_impl
-
-    token = os.environ.get(token_env) or None
-    serve_impl(host=host, port=port, token=token, project_dir=".")
+# `drt serve` lives in drt/cli/commands/serve.py (#546 Phase 2)
 
 
 # Sub-Typer namespaces — each one lives in its own module under
@@ -1414,55 +1053,31 @@ def serve(
 
 
 # ---------------------------------------------------------------------------
-# Source / Destination factories
+# Source / Destination factories — backward-compat shims
 # ---------------------------------------------------------------------------
+#
+# The real implementations now live in ``drt/cli/_helpers.py``. These thin
+# wrappers preserve the legacy ``from drt.cli.main import _get_source`` /
+# ``_get_destination`` import path that several tests rely on (see #565
+# back-compat note). New callers should import directly from _helpers.
 
 
 def _get_source(profile: ProfileConfig) -> Source:
-    """Get a source instance for the profile configuration.
-
-    Uses the connector registry for automatic connector discovery and instantiation.
-    """
-    from drt.connectors import get_source
+    """Back-compat shim — see ``drt.cli._helpers.get_source``."""
+    from drt.cli._helpers import get_source
 
     return get_source(profile)
 
 
-def _get_watermark_storage(
-    sync: SyncConfig,
-    project_dir: Path,
-) -> Any:
-    """Build watermark storage from sync config, or None if not configured."""
-    from drt.state.watermark import (
-        BigQueryWatermarkStorage,
-        GCSWatermarkStorage,
-        LocalWatermarkStorage,
-    )
+def _get_watermark_storage(sync: SyncConfig, project_dir: Path) -> Any:
+    """Back-compat shim — see ``drt.cli._helpers.get_watermark_storage``."""
+    from drt.cli._helpers import get_watermark_storage
 
-    wm = sync.sync.watermark
-    if wm is None:
-        return None
+    return get_watermark_storage(sync, project_dir)
 
-    if wm.storage == "local":
-        return LocalWatermarkStorage(project_dir)
-    elif wm.storage == "gcs":
-        assert wm.bucket is not None
-        assert wm.key is not None
-        return GCSWatermarkStorage(bucket=wm.bucket, key=wm.key)
-    elif wm.storage == "bigquery":
-        assert wm.project is not None
-        assert wm.dataset is not None
-        return BigQueryWatermarkStorage(
-            project=wm.project,
-            dataset=wm.dataset,
-        )
-    return None
 
 def _get_destination(sync: SyncConfig) -> Destination:
-    """Get a destination instance for the sync configuration.
+    """Back-compat shim — see ``drt.cli._helpers.get_destination``."""
+    from drt.cli._helpers import get_destination
 
-    Uses the connector registry for automatic connector discovery and instantiation.
-    """
-    from drt.connectors import get_destination
-
-    return get_destination(sync.destination)
+    return get_destination(sync)

--- a/tests/unit/test_clean_command.py
+++ b/tests/unit/test_clean_command.py
@@ -48,7 +48,7 @@ class TestCleanCommand:
         )
 
         with mock.patch("drt.config.parser.load_syncs_safe") as mock_load, \
-             mock.patch("drt.cli.main._get_destination") as mock_get_dest:
+             mock.patch("drt.cli.commands.clean.get_destination") as mock_get_dest:
             mock_load.return_value = mock.Mock(syncs=[mock_sync])
             mock_get_dest.return_value = fake_dest
             result = runner.invoke(app, ["clean", "--orphans"])
@@ -72,7 +72,7 @@ class TestCleanCommand:
         )
 
         with mock.patch("drt.config.parser.load_syncs_safe") as mock_load, \
-             mock.patch("drt.cli.main._get_destination") as mock_get_dest:
+             mock.patch("drt.cli.commands.clean.get_destination") as mock_get_dest:
             mock_load.return_value = mock.Mock(syncs=[mock_sync])
             mock_get_dest.return_value = fake_dest
             result = runner.invoke(app, ["clean", "--orphans", "--execute"])
@@ -108,7 +108,7 @@ class TestCleanCommand:
         )
 
         with mock.patch("drt.config.parser.load_syncs_safe") as mock_load, \
-             mock.patch("drt.cli.main._get_destination") as mock_get_dest:
+             mock.patch("drt.cli.commands.clean.get_destination") as mock_get_dest:
             mock_load.return_value = mock.Mock(syncs=[mock_sync1, mock_sync2])
             mock_get_dest.side_effect = [fake_dest, fake_dest]
             result = runner.invoke(app, ["clean", "--orphans"])
@@ -130,7 +130,7 @@ class TestCleanCommand:
         fake_dest = FakeOrphanCleanup({"public.users": []})
 
         with mock.patch("drt.config.parser.load_syncs_safe") as mock_load, \
-             mock.patch("drt.cli.main._get_destination") as mock_get_dest:
+             mock.patch("drt.cli.commands.clean.get_destination") as mock_get_dest:
             mock_load.return_value = mock.Mock(syncs=[mock_sync])
             mock_get_dest.return_value = fake_dest
             result = runner.invoke(app, ["clean", "--orphans"])


### PR DESCRIPTION
Round 3 of post-v0.7.5 follow-ups. Continues the cli/main.py split started in #565 (Phase 1 — doctor / list_syncs / config / cloud / docs / mcp).

## What ships

| New | Purpose |
|---|---|
| \`drt/cli/_helpers.py\` | Shared CLI internals (\`resolve_profile_name\`, \`get_source\`, \`get_destination\`, \`get_watermark_storage\`) |
| \`drt/cli/commands/connectors.py\` | \`drt sources\` + \`drt destinations\` (paired — share Rich-table / Rich-panel / JSON output helpers from #543) |
| \`drt/cli/commands/clean.py\` | \`drt clean --orphans\` |
| \`drt/cli/commands/serve.py\` | \`drt serve\` (HTTP webhook trigger) |
| \`drt/cli/commands/init.py\` | \`drt init\` with all three modes (interactive wizard / \`--template <name>\` / \`--from-dbt <manifest>\`) and their private helpers |

## main.py changes

- Removes the five migrated commands + their inline helpers (~385 LOC); replaced with one-line pointer comments
- \`_get_source\` / \`_get_destination\` / \`_get_watermark_storage\` become **thin back-compat shims** delegating to \`drt.cli._helpers.*\` so the legacy \`from drt.cli.main import _get_destination\` import path stays working

\`cli/main.py\`: **1468 → 1083 LOC** (-385, -26%). Cumulative since Phase 1: **1706 → 1083 (-36%)**.

## Test impact

\`tests/unit/test_clean_command.py\` — 4 patch sites updated from \`drt.cli.main._get_destination\` to \`drt.cli.commands.clean.get_destination\`. The clean command now imports the factory from \`_helpers\` directly, so the old patch target no longer intercepts the call. All other tests pass unchanged (back-compat shims cover them).

## Out of scope (Phase 2b — separate follow-up)

Heavier commands stay in main.py for a dedicated PR with focused review attention:

| Command | LOC | Why deferred |
|---|---|---|
| \`run\` + \`_RunContext\` + \`_run_one\` | ~450 | The riskiest — signal handling, threading, observer composition, error formatting integration. Wants its own PR |
| \`validate\` | ~190 | Secrets scan + connection check |
| \`status\` | ~120 | StateManager interplay |
| \`test\` + \`_SyncTestResult\` | ~130 | Sync test framework |
| \`_JsonFormatter\` + \`_configure_json_logging\` | ~25 | JSON logging infrastructure shared by \`run\` — extracts alongside it |

The pattern is fully proven now across 11 moved commands (6 from Phase 1 + 5 in this PR). Phase 2b can land as one PR or be split further by command — I'll file a follow-up issue.

## Local verification

\`\`\`
$ pytest tests/                  → 1218 passed, 1 skipped, 7 deselected
$ ruff check drt tests           → All checks passed!
$ mypy drt                       → Success: no issues in 109 files
\`\`\`

## Coordination

- Builds on #565 (Phase 1) — same pattern, same package, same Typer wiring
- Builds on #543 (connector \`--detailed\` flags) — the printer helpers it added move into \`commands/connectors.py\`
- Builds on #571 (\`_stage_ctx\` retrofit) — no overlap; both touch engine but at different sites
- Back-compat shims in main.py preserve every existing \`from drt.cli.main import _get_*\` import; the only required test update is the clean-command patch path

## Test plan

- [x] 1214 existing tests pass unchanged (4 clean tests patched to new path)
- [x] All five moved commands callable via CLI (\`drt init\`, \`drt sources\`, \`drt destinations\`, \`drt clean\`, \`drt serve\`)
- [x] \`_get_source\` / \`_get_destination\` / \`_get_watermark_storage\` shims work (covered by existing engine + connector tests)
- [x] ruff + mypy clean (109 files)
- [ ] CI Python 3.10–3.13 all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)