### PR TITLE
feat: add amplitude destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Amplitude destination**: Sync DWH rows to Amplitude Identify API (user properties) or HTTP V2 API (events). No extra dependencies. 18 unit tests.
+
 ## [0.7.5] - 2026-05-25
 
 **Theme: Production Ready follow-up #3 + Tech Foundation Hardening.** Two streams shipping together: (1) the accumulated work since v0.7.4 — REST API polish, sync catalog (#499 P1+P2), MCP test tool, OTel Phase 1 config, hardcoded secret detection, lookup ambiguity warning, orphan shadow cleanup, `drt init` "Next steps:" block — and (2) the **Tech Foundation Hardening epic** ([#538](https://github.com/drt-hub/drt/issues/538), 11 child issues, all closed) which locks in the foundations before v0.8 Cloud Destinations: CI reach (nightly + publish gate + CodeQL + pip-audit + SBOM), functional E2E coverage for the reverse-ETL paths (DuckDB harness + boundary cases), CLI/UX polish (`ErrorFormatter`, `--detailed`, `--template`), and load-bearing refactors (`SyncObserver` engine seam, destinations serializer + config base class consolidation, cli/main split Phase 1). No breaking changes — drop-in upgrade from v0.7.2 (v0.7.3 / v0.7.4 were patch-only cherry-picks).

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 | GitHub Actions          | ✅ v0.1   | (core)                             | Token (env var)                   |
 | HubSpot                 | ✅ v0.1   | (core)                             | Token (env var)                   |
 | Zendesk                 | ✅ v0.7   | (core)                             | Basic (email + API token)         |
+| Amplitude               | ✅ v0.7   | (core)                             | Project API key (env var)         |
 | Google Ads              | ✅ v0.6   | (core)                             | OAuth2 Client Credentials         |
 | Google Sheets           | ✅ v0.4   | `pip install drt-core[sheets]`     | Service Account Keyfile           |
 | PostgreSQL (upsert)     | ✅ v0.4   | `pip install drt-core[postgres]`   | Password (env var)                |

--- a/docs/connectors/amplitude.md
+++ b/docs/connectors/amplitude.md
@@ -1,0 +1,105 @@
+# Amplitude Destination
+
+> Sync user properties or events from your warehouse to Amplitude via the Identify API or HTTP V2 API.
+
+## YAML Example — user properties (Identify)
+
+```yaml
+destination:
+  type: amplitude
+  api_key_env: AMPLITUDE_API_KEY
+  endpoint: identify
+  user_id_field: user_id
+  properties_template: |
+    {
+      "ltv_segment": "{{ row.ltv_segment }}",
+      "plan": "{{ row.plan }}"
+    }
+```
+
+## YAML Example — events (HTTP V2)
+
+```yaml
+destination:
+  type: amplitude
+  api_key_env: AMPLITUDE_API_KEY
+  endpoint: event
+  user_id_field: user_id
+  event_type_field: event_name
+  time_field: event_time
+```
+
+## Configuration
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `type` | `"amplitude"` | — | Required |
+| `api_key` | string \| null | null | Amplitude project API key (direct value) |
+| `api_key_env` | string \| null | `AMPLITUDE_API_KEY` | Env var containing API key |
+| `region` | `default\|eu` | `default` | API region (`api2.amplitude.com` vs `api.eu.amplitude.com`) |
+| `endpoint` | `identify\|event` | `identify` | Identify API or HTTP V2 events API |
+| `user_id_field` | string | `user_id` | Source column for Amplitude `user_id` |
+| `device_id_field` | string \| null | null | Source column for Amplitude `device_id` |
+| `event_type_field` | string \| null | null | Source column for `event_type` (required for `endpoint: event` unless `event_type` set) |
+| `event_type` | string \| null | null | Constant event name (alternative to `event_type_field`) |
+| `time_field` | string \| null | null | Source column for event `time` (milliseconds) |
+| `insert_id_field` | string \| null | null | Source column for deduplication `insert_id` |
+| `properties_template` | string \| null | null | Jinja2 template rendering a JSON object merged into `user_properties` or `event_properties` |
+| `batch_size` | int | `1000` | Records per API request (clamped to 1–1000) |
+| `min_id_length` | int \| null | null | Passed to Amplitude `options.min_id_length` when set |
+| `retry` | RetryConfig \| null | null | Destination-level retry override |
+
+## Authentication
+
+Copy your project API key from Amplitude **Settings → Projects**, then:
+
+```bash
+export AMPLITUDE_API_KEY="your-api-key"
+```
+
+The API key is sent in the JSON request body (Amplitude does not use Bearer auth).
+
+## Common Patterns
+
+**Sync LTV segments and plan tier (user properties):**
+
+```yaml
+destination:
+  type: amplitude
+  api_key_env: AMPLITUDE_API_KEY
+  endpoint: identify
+  user_id_field: user_id
+```
+
+Warehouse columns not mapped to identity fields become `user_properties` automatically.
+
+**Backfill historical events from SQL:**
+
+```yaml
+destination:
+  type: amplitude
+  endpoint: event
+  event_type: warehouse_backfill
+  user_id_field: user_id
+  time_field: event_timestamp_ms
+sync:
+  rate_limit:
+    requests_per_second: 10
+```
+
+**EU data residency:**
+
+```yaml
+destination:
+  type: amplitude
+  region: eu
+  api_key_env: AMPLITUDE_API_KEY_EU
+```
+
+## Notes
+
+- Use separate sync YAMLs for identify vs events (one `endpoint` per destination config).
+- Amplitude requires `user_id` or `device_id` on each row; `user_id` defaults to minimum 5 characters unless `min_id_length` is set.
+- `insert_id` is auto-generated from row content when not provided, enabling safe retries without duplicate events.
+- For large backfills, set `rate_limit.requests_per_second` conservatively (e.g. 10) to avoid 429 throttling.
+- See [HTTP V2 API](https://amplitude.com/docs/apis/analytics/http-v2) and [Identify API](https://amplitude.com/docs/apis/analytics/identify) for payload details.

--- a/drt/cli/_connector_detail.py
+++ b/drt/cli/_connector_detail.py
@@ -46,6 +46,7 @@ SOURCE_CONFIG_CLASSES: dict[str, type] = {
 
 
 DESTINATION_CONFIG_CLASSES: dict[str, type[BaseModel]] = {
+    "amplitude": _models.AmplitudeDestinationConfig,
     "clickhouse": _models.ClickHouseDestinationConfig,
     "discord": _models.DiscordDestinationConfig,
     "email_smtp": _models.EmailSmtpDestinationConfig,

--- a/drt/config/connectors.py
+++ b/drt/config/connectors.py
@@ -23,6 +23,7 @@ SOURCES = [
 
 # Available destination connectors: (type, display_name)
 DESTINATIONS = [
+    ("amplitude", "Amplitude"),
     ("clickhouse", "ClickHouse"),
     ("discord", "Discord"),
     ("email_smtp", "Email"),

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # ---------------------------------------------------------------------------
 # Auth (shared across destination types)
@@ -249,6 +249,46 @@ class ZendeskDestinationConfig(BaseModel):
 
     def describe(self) -> str:
         return f"{self.type} ({self.object})"
+
+
+class AmplitudeDestinationConfig(BaseModel):
+    type: Literal["amplitude"]
+    api_key: str | None = None
+    api_key_env: str | None = "AMPLITUDE_API_KEY"
+    region: Literal["default", "eu"] = "default"
+    endpoint: Literal["identify", "event"] = "identify"
+    user_id_field: str = "user_id"
+    device_id_field: str | None = None
+    event_type_field: str | None = None
+    event_type: str | None = None
+    time_field: str | None = None
+    insert_id_field: str | None = None
+    properties_template: str | None = None
+    batch_size: int = 1000
+    min_id_length: int | None = None
+    retry: RetryConfig | None = None
+
+    def describe(self) -> str:
+        return f"{self.type} ({self.endpoint}, {self.region})"
+
+    @model_validator(mode="after")
+    def _check_api_key(self) -> AmplitudeDestinationConfig:
+        if not self.api_key and not self.api_key_env:
+            raise ValueError("api_key or api_key_env is required.")
+        return self
+
+    @model_validator(mode="after")
+    def _check_event_endpoint(self) -> AmplitudeDestinationConfig:
+        if self.endpoint == "event" and not self.event_type and not self.event_type_field:
+            raise ValueError(
+                "event_type or event_type_field is required when endpoint is 'event'."
+            )
+        return self
+
+    @field_validator("batch_size", mode="after")
+    @classmethod
+    def _clamp_batch_size(cls, value: int) -> int:
+        return max(1, min(value, 1000))
 
 
 class IntercomDestinationConfig(BaseModel):
@@ -647,6 +687,7 @@ DestinationConfig = Annotated[
     | GitHubActionsDestinationConfig
     | HubSpotDestinationConfig
     | ZendeskDestinationConfig
+    | AmplitudeDestinationConfig
     | SendGridDestinationConfig
     | LinearDestinationConfig
     | GoogleSheetsDestinationConfig

--- a/drt/connectors/registry.py
+++ b/drt/connectors/registry.py
@@ -141,6 +141,7 @@ def _register_all_connectors() -> None:
         SQLServerProfile,
     )
     from drt.config.models import (
+        AmplitudeDestinationConfig,
         ClickHouseDestinationConfig,
         DiscordDestinationConfig,
         EmailSmtpDestinationConfig,
@@ -168,6 +169,7 @@ def _register_all_connectors() -> None:
     )
 
     # Import destination classes
+    from drt.destinations.amplitude import AmplitudeDestination
     from drt.destinations.clickhouse import ClickHouseDestination
     from drt.destinations.discord import DiscordDestination
     from drt.destinations.email_smtp import EmailSmtpDestination
@@ -213,6 +215,7 @@ def _register_all_connectors() -> None:
     register_destination("discord", DiscordDestinationConfig, DiscordDestination)
     register_destination("github_actions", GitHubActionsDestinationConfig, GitHubActionsDestination)
     register_destination("hubspot", HubSpotDestinationConfig, HubSpotDestination)
+    register_destination("amplitude", AmplitudeDestinationConfig, AmplitudeDestination)
     register_destination("zendesk", ZendeskDestinationConfig, ZendeskDestination)
     register_destination("jira", JiraDestinationConfig, JiraDestination)
     register_destination("sendgrid", SendGridDestinationConfig, SendGridDestination)

--- a/drt/destinations/amplitude.py
+++ b/drt/destinations/amplitude.py
@@ -1,0 +1,384 @@
+"""Amplitude destination — sync user properties and events via HTTP APIs.
+
+Uses Amplitude Identify API for user properties and HTTP V2 API for events.
+No extra dependencies beyond core httpx.
+
+Example sync YAML — identify (user properties):
+
+    destination:
+      type: amplitude
+      api_key_env: AMPLITUDE_API_KEY
+      endpoint: identify
+      user_id_field: user_id
+      properties_template: |
+        {"ltv_segment": "{{ row.ltv_segment }}", "plan": "{{ row.plan }}"}
+
+Example sync YAML — events:
+
+    destination:
+      type: amplitude
+      api_key_env: AMPLITUDE_API_KEY
+      endpoint: event
+      user_id_field: user_id
+      event_type_field: event_name
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterator
+from typing import Any
+
+import httpx
+
+from drt.config.credentials import resolve_env
+from drt.config.models import (
+    AmplitudeDestinationConfig,
+    DestinationConfig,
+    RetryConfig,
+    SyncOptions,
+)
+from drt.destinations.base import SyncResult
+from drt.destinations.rate_limiter import RateLimiter
+from drt.destinations.retry import resolve_retry, with_retry
+from drt.destinations.row_errors import RowError
+from drt.templates.renderer import render_template
+
+_AMPLITUDE_HOSTS = {
+    "default": "https://api2.amplitude.com",
+    "eu": "https://api.eu.amplitude.com",
+}
+
+_RESERVED_ROW_KEYS = frozenset(
+    {
+        "user_id",
+        "device_id",
+        "event_type",
+        "time",
+        "insert_id",
+        "event_id",
+        "event_properties",
+        "user_properties",
+        "groups",
+        "group_properties",
+        "app_version",
+        "platform",
+        "os_name",
+        "os_version",
+        "device_brand",
+        "device_manufacturer",
+        "device_model",
+        "carrier",
+        "country",
+        "region",
+        "city",
+        "dma",
+        "language",
+        "price",
+        "quantity",
+        "revenue",
+        "productId",
+        "revenueType",
+        "location_lat",
+        "location_lng",
+        "ip",
+        "idfa",
+        "idfv",
+        "adid",
+        "android_id",
+        "event_id",
+    }
+)
+
+
+class AmplitudeDestination:
+    """Send sync records to Amplitude Identify or HTTP V2 event APIs."""
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, AmplitudeDestinationConfig)
+        if not records:
+            return SyncResult()
+
+        api_key = resolve_env(config.api_key, config.api_key_env)
+        if not api_key:
+            raise ValueError(
+                "Amplitude destination: provide api_key or set the env var "
+                f"named in api_key_env ({config.api_key_env!r})."
+            )
+
+        base_url = _AMPLITUDE_HOSTS[config.region]
+        if config.endpoint == "identify":
+            url = f"{base_url}/identify"
+        else:
+            url = f"{base_url}/2/httpapi"
+
+        retry_config = resolve_retry(config.retry, sync_options)
+        rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
+        result = SyncResult()
+
+        indexed_payloads: list[tuple[int, dict[str, Any], dict[str, Any]]] = []
+        for index, record in enumerate(records):
+            try:
+                payload = _build_payload(record, config)
+                indexed_payloads.append((index, record, payload))
+            except Exception as e:
+                _add_row_error(result, index, record, None, str(e))
+                if sync_options.on_error == "fail":
+                    return result
+
+        if not indexed_payloads:
+            return result
+
+        request_options: dict[str, Any] | None = None
+        if config.min_id_length is not None:
+            request_options = {"min_id_length": config.min_id_length}
+
+        with httpx.Client(timeout=30.0) as client:
+            for chunk in _chunks(indexed_payloads, config.batch_size):
+                payloads = [payload for _, _, payload in chunk]
+                try:
+                    rate_limiter.acquire()
+                    if config.endpoint == "identify":
+                        _post_identify(
+                            client,
+                            url,
+                            api_key,
+                            payloads,
+                            retry_config,
+                        )
+                    else:
+                        _post_events(
+                            client,
+                            url,
+                            api_key,
+                            payloads,
+                            retry_config,
+                            request_options,
+                        )
+                    result.success += len(chunk)
+                except httpx.HTTPStatusError as e:
+                    for index, record, _ in chunk:
+                        _add_row_error(
+                            result,
+                            index,
+                            record,
+                            e.response.status_code,
+                            e.response.text[:500],
+                        )
+                    if sync_options.on_error == "fail":
+                        break
+                except Exception as e:
+                    for index, record, _ in chunk:
+                        _add_row_error(result, index, record, None, str(e))
+                    if sync_options.on_error == "fail":
+                        break
+
+        return result
+
+
+def _build_payload(record: dict[str, Any], config: AmplitudeDestinationConfig) -> dict[str, Any]:
+    user_id = _field_value(record, config.user_id_field)
+    device_id = _field_value(record, config.device_id_field) if config.device_id_field else None
+
+    if not _has_value(user_id) and not _has_value(device_id):
+        raise ValueError("Row must include user_id or device_id.")
+
+    payload: dict[str, Any] = {}
+    if _has_value(user_id):
+        payload["user_id"] = str(user_id)
+    if _has_value(device_id):
+        payload["device_id"] = str(device_id)
+
+    if config.endpoint == "event":
+        event_type = config.event_type
+        if config.event_type_field:
+            event_type = record.get(config.event_type_field)
+        if not _has_value(event_type):
+            raise ValueError("Row must include event_type.")
+        payload["event_type"] = str(event_type)
+
+        if config.time_field:
+            time_value = record.get(config.time_field)
+            if _has_value(time_value):
+                payload["time"] = time_value
+
+        insert_id = _resolve_insert_id(record, config, str(event_type))
+        if insert_id:
+            payload["insert_id"] = insert_id
+
+        properties_key = "event_properties"
+    else:
+        properties_key = "user_properties"
+
+    properties = _row_properties(record, config)
+    if properties:
+        payload[properties_key] = properties
+
+    if config.properties_template:
+        template_data = _render_properties_template(config.properties_template, record)
+        _merge_template_into_payload(payload, template_data, properties_key)
+
+    return payload
+
+
+def _merge_template_into_payload(
+    payload: dict[str, Any],
+    template_data: dict[str, Any],
+    properties_key: str,
+) -> None:
+    other_key = "event_properties" if properties_key == "user_properties" else "user_properties"
+    extra = dict(template_data)
+    nested = extra.pop(properties_key, None)
+    if isinstance(nested, dict):
+        existing = payload.get(properties_key)
+        if isinstance(existing, dict):
+            payload[properties_key] = {**existing, **nested}
+        else:
+            payload[properties_key] = nested
+    other_nested = extra.pop(other_key, None)
+    if isinstance(other_nested, dict):
+        existing = payload.get(other_key)
+        if isinstance(existing, dict):
+            payload[other_key] = {**existing, **other_nested}
+        else:
+            payload[other_key] = other_nested
+    if extra:
+        existing = payload.get(properties_key)
+        if isinstance(existing, dict):
+            payload[properties_key] = {**existing, **extra}
+        else:
+            payload[properties_key] = extra
+
+
+def _row_properties(record: dict[str, Any], config: AmplitudeDestinationConfig) -> dict[str, Any]:
+    excluded = _excluded_fields(config)
+    properties: dict[str, Any] = {}
+    for key, value in record.items():
+        if key in excluded or key in _RESERVED_ROW_KEYS:
+            continue
+        if value is None:
+            continue
+        properties[key] = value
+    return properties
+
+
+def _excluded_fields(config: AmplitudeDestinationConfig) -> set[str]:
+    excluded = {config.user_id_field}
+    if config.device_id_field:
+        excluded.add(config.device_id_field)
+    if config.event_type_field:
+        excluded.add(config.event_type_field)
+    if config.time_field:
+        excluded.add(config.time_field)
+    if config.insert_id_field:
+        excluded.add(config.insert_id_field)
+    return excluded
+
+
+def _field_value(record: dict[str, Any], field: str | None) -> Any:
+    if not field:
+        return None
+    return record.get(field)
+
+
+def _has_value(value: Any) -> bool:
+    return value is not None and str(value).strip() != ""
+
+
+def _resolve_insert_id(
+    record: dict[str, Any],
+    config: AmplitudeDestinationConfig,
+    event_type: str,
+) -> str | None:
+    if config.insert_id_field:
+        value = record.get(config.insert_id_field)
+        if _has_value(value):
+            return str(value)
+    existing = record.get("insert_id")
+    if _has_value(existing):
+        return str(existing)
+    canonical = json.dumps(record, sort_keys=True, default=str)
+    digest = hashlib.sha256(f"{canonical}:{event_type}".encode()).hexdigest()
+    return digest[:32]
+
+
+def _render_properties_template(template: str, record: dict[str, Any]) -> dict[str, Any]:
+    rendered = render_template(template, record)
+    data = json.loads(rendered)
+    if not isinstance(data, dict):
+        raise ValueError("properties_template must render a JSON object.")
+    return data
+
+
+def _post_identify(
+    client: httpx.Client,
+    url: str,
+    api_key: str,
+    identifications: list[dict[str, Any]],
+    retry_config: RetryConfig,
+) -> None:
+    def do_post() -> httpx.Response:
+        response = client.post(
+            url,
+            data={
+                "api_key": api_key,
+                "identification": json.dumps(identifications),
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response.raise_for_status()
+        return response
+
+    with_retry(do_post, retry_config)
+
+
+def _post_events(
+    client: httpx.Client,
+    url: str,
+    api_key: str,
+    events: list[dict[str, Any]],
+    retry_config: RetryConfig,
+    options: dict[str, Any] | None,
+) -> None:
+    body: dict[str, Any] = {"api_key": api_key, "events": events}
+    if options:
+        body["options"] = options
+
+    def do_post() -> httpx.Response:
+        response = client.post(url, json=body)
+        response.raise_for_status()
+        return response
+
+    with_retry(do_post, retry_config)
+
+
+def _chunks(
+    records: list[tuple[int, dict[str, Any], dict[str, Any]]],
+    size: int,
+) -> Iterator[list[tuple[int, dict[str, Any], dict[str, Any]]]]:
+    for start in range(0, len(records), size):
+        yield records[start : start + size]
+
+
+def _add_row_error(
+    result: SyncResult,
+    index: int,
+    record: dict[str, Any],
+    http_status: int | None,
+    message: str,
+) -> None:
+    result.failed += 1
+    result.row_errors.append(
+        RowError(
+            batch_index=index,
+            record_preview=json.dumps(record, default=str)[:200],
+            http_status=http_status,
+            error_message=message,
+        )
+    )

--- a/drt/mcp/server.py
+++ b/drt/mcp/server.py
@@ -346,6 +346,7 @@ def create_server(project_dir: Path | None = None) -> Any:
                 {"name": "Microsoft Teams", "type": "teams", "install": "(core)"},
                 {"name": "GitHub Actions", "type": "github_actions", "install": "(core)"},
                 {"name": "HubSpot", "type": "hubspot", "install": "(core)"},
+                {"name": "Amplitude", "type": "amplitude", "install": "(core)"},
                 {"name": "Zendesk", "type": "zendesk", "install": "(core)"},
                 {"name": "Google Sheets", "type": "google_sheets", "install": "drt-core[sheets]"},
                 {"name": "PostgreSQL", "type": "postgres", "install": "drt-core[postgres]"},

--- a/tests/unit/test_amplitude_destination.py
+++ b/tests/unit/test_amplitude_destination.py
@@ -1,0 +1,306 @@
+"""Unit tests for Amplitude destination."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from pytest_httpserver import HTTPServer
+
+from drt.config.models import (
+    AmplitudeDestinationConfig,
+    RateLimitConfig,
+    RetryConfig,
+    SyncOptions,
+)
+from drt.destinations.amplitude import AmplitudeDestination
+
+
+def _config(**overrides: object) -> AmplitudeDestinationConfig:
+    data: dict[str, object] = {
+        "type": "amplitude",
+        "api_key": "test-api-key",
+        "endpoint": "identify",
+    }
+    data.update(overrides)
+    return AmplitudeDestinationConfig(**data)
+
+
+def _options(**overrides: object) -> SyncOptions:
+    data: dict[str, object] = {
+        "rate_limit": RateLimitConfig(requests_per_second=0),
+        "retry": RetryConfig(max_attempts=1, initial_backoff=0.0, backoff_multiplier=1.0),
+        "on_error": "skip",
+    }
+    data.update(overrides)
+    return SyncOptions(**data)
+
+
+def _response(status_code: int = 200, text: str = "{}") -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = text
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _http_error(status_code: int, text: str) -> httpx.HTTPStatusError:
+    response = httpx.Response(
+        status_code=status_code,
+        text=text,
+        request=httpx.Request("POST", "https://api2.amplitude.com/identify"),
+    )
+    return httpx.HTTPStatusError(
+        message=f"HTTP {status_code}",
+        request=response.request,
+        response=response,
+    )
+
+
+class TestAmplitudeDestinationConfig:
+    def test_valid_identify_config(self) -> None:
+        config = _config()
+        assert config.type == "amplitude"
+        assert config.endpoint == "identify"
+        assert config.batch_size == 1000
+
+    def test_valid_event_config(self) -> None:
+        config = _config(endpoint="event", event_type="sync_event")
+        assert config.event_type == "sync_event"
+
+    def test_missing_api_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="api_key"):
+            AmplitudeDestinationConfig(type="amplitude", api_key_env=None)
+
+    def test_event_endpoint_requires_event_type(self) -> None:
+        with pytest.raises(ValueError, match="event_type"):
+            _config(endpoint="event")
+
+    def test_batch_size_clamped(self) -> None:
+        config = AmplitudeDestinationConfig(
+            type="amplitude",
+            api_key="key",
+            batch_size=5000,
+        )
+        assert config.batch_size == 1000
+
+        config_too_small = AmplitudeDestinationConfig(
+            type="amplitude",
+            api_key="key",
+            batch_size=0,
+        )
+        assert config_too_small.batch_size == 1
+
+
+class TestAmplitudeIdentifyLoad:
+    def test_identify_success(self) -> None:
+        records = [
+            {"user_id": "user-10001", "plan": "enterprise", "ltv": 1200},
+            {"user_id": "user-10002", "plan": "starter"},
+        ]
+        config = _config(endpoint="identify")
+
+        with patch("drt.destinations.amplitude.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = _response()
+
+            result = AmplitudeDestination().load(records, config, _options())
+
+        assert result.success == 2
+        assert result.failed == 0
+        mock_client.post.assert_called_once()
+        _, kwargs = mock_client.post.call_args
+        assert kwargs["data"]["api_key"] == "test-api-key"
+        identifications = json.loads(kwargs["data"]["identification"])
+        assert identifications[0]["user_id"] == "user-10001"
+        assert identifications[0]["user_properties"] == {"plan": "enterprise", "ltv": 1200}
+        assert "plan" not in identifications[0]
+
+    def test_properties_template_merge(self) -> None:
+        record = {"user_id": "user-10001", "plan": "legacy", "ltv": 99}
+        config = _config(
+            properties_template='{"plan": "{{ row.plan }}", "ltv_tier": "high"}',
+        )
+
+        with patch("drt.destinations.amplitude.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = _response()
+
+            result = AmplitudeDestination().load([record], config, _options())
+
+        assert result.success == 1
+        _, kwargs = mock_client.post.call_args
+        identifications = json.loads(kwargs["data"]["identification"])
+        assert identifications[0]["user_properties"] == {
+            "plan": "legacy",
+            "ltv": 99,
+            "ltv_tier": "high",
+        }
+
+    def test_missing_user_and_device_id(self) -> None:
+        config = _config()
+        result = AmplitudeDestination().load([{"plan": "free"}], config, _options())
+        assert result.success == 0
+        assert result.failed == 1
+        assert "user_id" in result.row_errors[0].error_message
+
+    def test_identify_batch_split(self) -> None:
+        records = [{"user_id": f"user-{i:05d}", "score": i} for i in range(1001)]
+        config = _config(batch_size=1000)
+
+        with patch("drt.destinations.amplitude.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = _response()
+
+            result = AmplitudeDestination().load(records, config, _options())
+
+        assert result.success == 1001
+        assert mock_client.post.call_count == 2
+        calls = mock_client.post.call_args_list
+        first_batch = json.loads(calls[0].kwargs["data"]["identification"])
+        second_batch = json.loads(calls[1].kwargs["data"]["identification"])
+        assert len(first_batch) == 1000
+        assert len(second_batch) == 1
+
+    def test_identify_httpserver(self, httpserver: HTTPServer) -> None:
+        httpserver.expect_request("/identify").respond_with_data("{}", status=200)
+        config = _config(
+            api_key="live-key",
+            endpoint="identify",
+        )
+        records = [{"user_id": "user-10001", "segment": "vip"}]
+
+        with patch(
+            "drt.destinations.amplitude._AMPLITUDE_HOSTS",
+            {"default": httpserver.url_for(""), "eu": httpserver.url_for("")},
+        ):
+            result = AmplitudeDestination().load(records, config, _options())
+
+        assert result.success == 1
+        assert result.failed == 0
+
+
+class TestAmplitudeEventLoad:
+    def test_event_success_with_field(self) -> None:
+        records = [
+            {
+                "user_id": "user-10001",
+                "event_name": "feature_used",
+                "feature": "export",
+            },
+        ]
+        config = _config(endpoint="event", event_type_field="event_name")
+
+        with patch("drt.destinations.amplitude.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = _response()
+
+            result = AmplitudeDestination().load(records, config, _options())
+
+        assert result.success == 1
+        _, kwargs = mock_client.post.call_args
+        body = kwargs["json"]
+        assert body["api_key"] == "test-api-key"
+        assert body["events"][0]["event_type"] == "feature_used"
+        assert body["events"][0]["event_properties"] == {"feature": "export"}
+        assert "insert_id" in body["events"][0]
+
+    def test_event_constant_event_type(self) -> None:
+        records = [{"user_id": "user-10001", "value": 1}]
+        config = _config(endpoint="event", event_type="warehouse_sync")
+
+        with patch("drt.destinations.amplitude.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = _response()
+
+            result = AmplitudeDestination().load(records, config, _options())
+
+        assert result.success == 1
+        body = mock_client.post.call_args.kwargs["json"]
+        assert body["events"][0]["event_type"] == "warehouse_sync"
+
+    def test_event_missing_event_type_row_error(self) -> None:
+        records = [{"user_id": "user-10001"}]
+        config = _config(endpoint="event", event_type_field="event_name")
+
+        result = AmplitudeDestination().load(records, config, _options())
+        assert result.failed == 1
+        assert "event_type" in result.row_errors[0].error_message
+
+    def test_event_min_id_length_options(self) -> None:
+        records = [{"user_id": "abc", "event_name": "click"}]
+        config = _config(
+            endpoint="event",
+            event_type_field="event_name",
+            min_id_length=1,
+        )
+
+        with patch("drt.destinations.amplitude.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = _response()
+
+            AmplitudeDestination().load(records, config, _options())
+
+        body = mock_client.post.call_args.kwargs["json"]
+        assert body["options"] == {"min_id_length": 1}
+
+    def test_http_error_records_row_errors(self) -> None:
+        records = [{"user_id": "user-10001", "plan": "pro"}]
+        config = _config()
+
+        with patch("drt.destinations.amplitude.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.side_effect = _http_error(400, "bad request")
+
+            result = AmplitudeDestination().load(records, config, _options())
+
+        assert result.success == 0
+        assert result.failed == 1
+        assert result.row_errors[0].http_status == 400
+
+    def test_on_error_fail_stops_after_batch_failure(self) -> None:
+        records = [
+            {"user_id": "user-10001", "plan": "a"},
+            {"user_id": "user-10002", "plan": "b"},
+        ]
+        config = _config(batch_size=1)
+
+        with patch("drt.destinations.amplitude.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.side_effect = _http_error(500, "server error")
+
+            result = AmplitudeDestination().load(
+                records,
+                config,
+                _options(on_error="fail"),
+            )
+
+        assert result.failed == 1
+        assert mock_client.post.call_count == 1
+
+    def test_empty_records(self) -> None:
+        result = AmplitudeDestination().load([], _config(), _options())
+        assert result.success == 0
+        assert result.failed == 0
+
+    def test_missing_api_key_at_load(self) -> None:
+        config = AmplitudeDestinationConfig(
+            type="amplitude",
+            api_key_env="MISSING_AMPLITUDE_KEY",
+        )
+        with pytest.raises(ValueError, match="api_key"):
+            AmplitudeDestination().load(
+                [{"user_id": "user-10001"}],
+                config,
+                _options(),
+            )

--- a/tests/unit/test_connector_registry.py
+++ b/tests/unit/test_connector_registry.py
@@ -6,6 +6,7 @@ import pytest
 
 from drt.config.credentials import DuckDBProfile, PostgresProfile
 from drt.config.models import (
+    AmplitudeDestinationConfig,
     RestApiDestinationConfig,
     SlackDestinationConfig,
     SyncConfig,
@@ -48,6 +49,17 @@ class TestConnectorRegistry:
         destination = get_destination(config)
         assert destination is not None
         assert type(destination).__name__ == "ZendeskDestination"
+
+    def test_get_destination_amplitude(self):
+        """Get an Amplitude destination from registry."""
+        config = AmplitudeDestinationConfig(
+            type="amplitude",
+            api_key="test-key",
+            endpoint="identify",
+        )
+        destination = get_destination(config)
+        assert destination is not None
+        assert type(destination).__name__ == "AmplitudeDestination"
 
     def test_get_source_postgres(self):
         """Get a Postgres source from registry."""


### PR DESCRIPTION
## What does this PR do?

Adds a new Amplitude destination connector so drt can push warehouse rows to Amplitude for reverse ETL (user properties and/or events). It uses only core httpx—no new optional dependency.

* Auth: api_key or api_key_env (default AMPLITUDE_API_KEY); validated at model load time.
* Mode: endpoint: identify | event (default identify).
* Region: region: default | eu → api2.amplitude.com vs api.eu.amplitude.com.
* Field mapping: user_id_field, optional device_id_field, event_type / event_type_field, time_field, insert_id_field.
* Template: optional properties_template (Jinja → JSON merged into properties).
* Batching: batch_size clamped to 1–1000; optional min_id_length for Amplitude options; optional retry override.
* Tests: 18 unit tests added
 
## Related Issue

Closes #416 

## Checklist

- [x] Tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Updated `CHANGELOG.md` (if user-facing change)