### PR TITLE
chore: post-#574 cleanup — dedup _RESERVED_ROW_KEYS + sync ja translations

### DIFF
--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-sync: base=CONTRIBUTING.md, hash=d31a04a58a6f281b143c00cbf9cb8a195c0f9f7a -->
+<!-- i18n-sync: base=CONTRIBUTING.md, hash=b3bb08c1a727bed96786c4fea8b37bdbafdadb46 -->
 
 [English](./CONTRIBUTING.md) | [日本語](./CONTRIBUTING.ja.md)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-sync: base=README.md, hash=fddd7daac53dc50a33a470a6e4239ffe98de45b6 -->
+<!-- i18n-sync: base=README.md, hash=68c96f5a42a21ccf6d6926c636eac07241b74bf1 -->
 
 [English](./README.md) | [日本語](./README.ja.md)
 
@@ -249,6 +249,7 @@ Claude Codeの公式スキルをインストールすると、チャットイン
 | GitHub Actions | ✅ v0.1 | (core) | Token（環境変数） |
 | HubSpot | ✅ v0.1 | (core) | Token（環境変数） |
 | Zendesk | ✅ v0.7 | (core) | Basic（メールアドレス + API トークン） |
+| Amplitude | ✅ v0.7 | (core) | プロジェクト API キー（環境変数） |
 | Google Ads | ✅ v0.6 | (core) | OAuth2 Client Credentials |
 | Google Sheets | ✅ v0.4 | `pip install drt-core[sheets]` | Service Account Keyfile |
 | PostgreSQL (upsert) | ✅ v0.4 | `pip install drt-core[postgres]` | パスワード（環境変数） |

--- a/drt/destinations/amplitude.py
+++ b/drt/destinations/amplitude.py
@@ -87,7 +87,6 @@ _RESERVED_ROW_KEYS = frozenset(
         "idfv",
         "adid",
         "android_id",
-        "event_id",
     }
 )
 


### PR DESCRIPTION
## Summary

Small post-merge cleanups following [#574](https://github.com/drt-hub/drt/pull/574) (Amplitude destination), with an opportunistic i18n marker bump from #570.

- **`drt/destinations/amplitude.py`** — remove duplicate `"event_id"` entry in `_RESERVED_ROW_KEYS` frozenset (harmless dedup-by-frozenset, copy-paste leftover flagged during #574 review).
- **`README.ja.md`** — add the Amplitude row to the destinations table to mirror `README.md` (English added in #574), and bump the `i18n-sync` marker to `68c96f5` (the #574 squash hash).
- **`CONTRIBUTING.ja.md`** — bump the `i18n-sync` marker from `d31a04a` to `b3bb08c`. The Japanese translation of the new "CI guard" subsection was already merged in #570, but the marker referenced the pre-squash hash (the chicken-and-egg called out in #570's own commit message). Opportunistic cleanup so `check-i18n` is green.

## Test plan

- [x] `make check-i18n` → `OK CONTRIBUTING.ja.md` / `OK README.ja.md`
- [x] `pytest tests/unit/test_amplitude_destination.py` → 18 passed
- [x] `ruff check drt/destinations/amplitude.py` → clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)