### PR TITLE
fix(cli): switch --log-format to LogFormat Enum (closes #577)

### DIFF
--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -10,10 +10,10 @@ import threading
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict
 
-import click
 import typer
 
 if TYPE_CHECKING:
@@ -49,6 +49,14 @@ from drt.cli.output import (
     print_validation_error,
     print_validation_ok,
 )
+
+
+class LogFormat(str, Enum):
+    """Output format for application logs (separate from --output)."""
+
+    TEXT = "text"
+    JSON = "json"
+
 
 # ---------------------------------------------------------------------------
 # JSON logging
@@ -203,11 +211,7 @@ def _run_one(
 
         elapsed = round(time.monotonic() - t0, 2)
         status_str = (
-            "success"
-            if result.failed == 0
-            else "partial"
-            if result.success > 0
-            else "failed"
+            "success" if result.failed == 0 else "partial" if result.success > 0 else "failed"
         )
         rows_synced = result.success
         entry = {
@@ -357,19 +361,13 @@ def run(
     profile_name: str = typer.Option(
         None, "--profile", "-p", help="Override profile (default: drt_project.yml or DRT_PROFILE)."
     ),
-    log_format: str = typer.Option(  # type: ignore[call-overload]
-        # CI mypy on Python 3.10 / 3.11 rejects the (default, param_decl,
-        # help, click_type) call shape since 2026-05-26 — the local mypy
-        # 1.20 on Python 3.12 accepts it. The runtime call works on every
-        # supported Python; the stubs disagree across mypy versions. Track
-        # in a follow-up issue.
-        "text",
+    log_format: LogFormat = typer.Option(
+        LogFormat.TEXT,
         "--log-format",
         help=(
             "Log format: 'text' (default) or 'json' (structured JSON Lines,"
             " separate from --output json)."
         ),
-        click_type=click.Choice(["text", "json"]),
     ),
     cursor_value: str = typer.Option(
         None,
@@ -414,7 +412,7 @@ def run(
     from drt.config.parser import load_project, load_syncs
     from drt.state.manager import StateManager
 
-    if log_format == "json":
+    if log_format is LogFormat.JSON:
         _configure_json_logging()
 
     json_mode = output == "json"
@@ -523,7 +521,7 @@ def run(
         dry_run=dry_run,
         verbose=verbose,
         quiet=quiet,
-        log_json=log_format == "json",
+        log_json=log_format is LogFormat.JSON,
         cursor_value=cursor_value,
         stop_event=stop_event,
         compute_diff=diff,
@@ -556,8 +554,10 @@ def run(
 
     # Summary report
     if not json_mode and not quiet and len(syncs) > 1:
-        console.print(f"\n[bold]Summary:[/bold] {succeeded} succeeded, {failed} failed, "
-                       f"{total_duration}s total")
+        console.print(
+            f"\n[bold]Summary:[/bold] {succeeded} succeeded, {failed} failed, "
+            f"{total_duration}s total"
+        )
 
     if not json_mode and not quiet:
         _print_watermark_summary(json_results)
@@ -584,8 +584,7 @@ def run(
             force_timer["t"].cancel()
         if not json_mode and not quiet:
             console.print(
-                f"[yellow]Stopped after {succeeded + failed} sync(s). "
-                f"State persisted.[/yellow]"
+                f"[yellow]Stopped after {succeeded + failed} sync(s). State persisted.[/yellow]"
             )
         raise typer.Exit(_exit_code_for_signal(received_signal["sig"]))
 
@@ -645,7 +644,7 @@ def validate(
         all_deprecations = []
         for sync_name, sync_deprecations in result.deprecations.items():
             all_deprecations.extend(sync_deprecations)
-        
+
         results_json = []
         for s in result.syncs:
             entry = {
@@ -664,7 +663,7 @@ def validate(
             if check_connection:
                 entry["connection_test"] = _run_connection_test(s)
             results_json.append(entry)
-        
+
         for name, errs in result.errors.items():
             results_json.append(
                 {
@@ -711,6 +710,7 @@ def validate(
 
         if check_connection:
             from drt.cli.output import print_connection_test_result
+
             conn_res = _run_connection_test(sync)
             print_connection_test_result(
                 sync.name,
@@ -926,7 +926,7 @@ def test_syncs(
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview without running tests."),
 ) -> None:
     """Run post-sync validation tests.
-    
+
     With --dry-run, shows what tests would be executed without actually
     connecting to the destination or running queries.
     """
@@ -994,9 +994,7 @@ def test_syncs(
             if dry_run:
                 if not json_mode:
                     console.print(f"  [dim](dry-run)[/dim] {test_name}")
-                sync_results["tests"].append(
-                    {"name": test_name, "dry_run": True}
-                )
+                sync_results["tests"].append({"name": test_name, "dry_run": True})
             else:
                 try:
                     query, check = build_test_query(test_def, table)
@@ -1016,7 +1014,7 @@ def test_syncs(
                         {"name": test_name, "passed": False, "error": str(e)}
                     )
                     had_failures = True
-        
+
         results.append(sync_results)
 
     if json_mode:

--- a/tests/unit/test_cli_log_format.py
+++ b/tests/unit/test_cli_log_format.py
@@ -1,0 +1,44 @@
+"""Tests for the --log-format option on the run command.
+
+Covers the ``LogFormat(str, Enum)`` path introduced in #577 — both the
+JSON branch that switches the root logger to ``_JsonFormatter`` and the
+Choice-style validation that rejects unknown values (the latter is what
+the typer 0.26 stubs were rejecting at the type level before the Enum
+refactor).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from typer.testing import CliRunner
+
+from drt.cli.main import app
+
+runner = CliRunner()
+
+
+def test_run_accepts_log_format_json() -> None:
+    """``--log-format json`` is parsed and exercises the JSON-logging branch."""
+    original_handlers = logging.root.handlers[:]
+    try:
+        result = runner.invoke(app, ["run", "--log-format", "json"])
+        # exit 2 = Click/Typer "invalid option/value" error.
+        # Any other exit code means the value was accepted (the run itself may
+        # fail because no project file is in the cwd — that's fine here).
+        assert result.exit_code != 2
+    finally:
+        logging.root.handlers = original_handlers
+
+
+def test_run_accepts_log_format_text() -> None:
+    """``--log-format text`` (the default) is also accepted explicitly."""
+    result = runner.invoke(app, ["run", "--log-format", "text"])
+    assert result.exit_code != 2
+
+
+def test_run_rejects_invalid_log_format() -> None:
+    """Choice derived from the LogFormat Enum rejects unknown values."""
+    result = runner.invoke(app, ["run", "--log-format", "invalid"])
+    assert result.exit_code == 2
+    assert "'invalid' is not one of 'text', 'json'" in result.output


### PR DESCRIPTION
## Summary

Fixes #577 — replaces the `str + click_type=click.Choice(...)` shape on `--log-format` with a `LogFormat(str, Enum)`. typer 0.26.1 (the version CI's `pip install drt-core[dev]` resolves to as of 2026-05-26) ships a stub revision that no longer accepts the `typer.Option(default, param_decl, help=..., click_type=Choice(...))` shape, while local mypy 1.20 on Python 3.12 + typer 0.24.1 still accepts it. The Enum shape is the canonical typer pattern, version-agnostic, and removes the need for a `# type: ignore`.

## Changes

- `drt/cli/main.py`:
  - Add `LogFormat(str, Enum)` (mirrors `Stage(str, Enum)` in `cli/errors.py` — single in-repo precedent for the pattern)
  - `log_format: LogFormat = typer.Option(LogFormat.TEXT, "--log-format", help=...)` — typer auto-derives the Choice from the Enum, no `click_type=` needed
  - Drop `# type: ignore[call-overload]` and the multi-line workaround comment from #575
  - Drop unused `import click` (was only used for the `click.Choice` that's gone)
  - Comparison sites use `is LogFormat.JSON` (str Enum, so `== "json"` would still work, but `is` is clearer)
- Incidental: a three-way ternary in `_run_one` collapses to one line via `ruff format` — unrelated to this change but the formatter would catch it on any subsequent touch.

## Why Enum over pinning `typer<0.26`

- Canonical typer pattern for Choice-style options — same recipe documented across typer's own README
- Version-agnostic — verified locally with **both** typer 0.24.1 + click 8.3.1 **and** typer 0.26.1 + click 8.4.1 (CI versions); mypy clean in both
- No future re-fix when typer bumps stubs again
- Avoids pinning a CLI library that we'd want to track upstream

## Audit (#577 acceptance criteria)

- `grep -rn "click_type=click.Choice" drt/` → only the one site in `drt/cli/main.py:360` (now fixed). No other call sites to update.
- Behaviour preservation verified locally:
  - `drt run --log-format text` / `--log-format json` work as before
  - `drt run --log-format invalid` → ``Invalid value for '--log-format': 'invalid' is not one of 'text', 'json'.`` (Choice validation maintained)
  - `drt run --help` shows ``--log-format [text|json]``

## Test plan

- [x] `make lint` → ruff + mypy clean (110 source files)
- [x] `make test` → 1244 passed, 1 skipped
- [x] Local mypy with typer 0.26.1 + click 8.4.1 (CI versions) → clean
- [x] CLI behaviour: valid + invalid `--log-format` values + `--help` rendering
- [ ] CI green on 3.10 / 3.11 / 3.12 / 3.13

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)