### PR TITLE
feat(templates): add tojson_safe Jinja2 filter (closes #580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Amplitude destination**: Sync DWH rows to Amplitude Identify API (user properties) or HTTP V2 API (events). No extra dependencies. 18 unit tests.
+- **`tojson_safe` Jinja2 filter** ([#580](https://github.com/drt-hub/drt/issues/580)): drop-in replacement for `tojson` in `body_template` rendering that tolerates `datetime` / `date` / `time` (encoded as ISO 8601), `Decimal` and `UUID` (encoded as string). Registered on both `drt.templates.renderer` and `drt.destinations.staged_upload`'s local Jinja environments. The default `tojson` filter is unchanged — opt-in only, no behavioural change for existing templates. Unblocks BigQuery `TIMESTAMP` / Postgres `numeric` / `uuid` columns flowing into REST API destinations without `CAST(... AS STRING)` workarounds in model SQL. Docs: [docs/connectors/rest-api.md](docs/connectors/rest-api.md#serializing-datetime--decimal--uuid-columns).
 
 ## [0.7.5] - 2026-05-25
 

--- a/docs/connectors/rest-api.md
+++ b/docs/connectors/rest-api.md
@@ -85,6 +85,30 @@ method: PUT
 body_template: '{"id": {{ row.id }}, "name": "{{ row.name }}"}'
 ```
 
+## Serializing datetime / Decimal / UUID columns
+
+Jinja2's built-in `tojson` filter calls `json.dumps(value)` with no `default=`, so it raises `Object of type datetime is not JSON serializable` when a row contains a `datetime`, `date`, `Decimal`, or `UUID` (common for BigQuery `TIMESTAMP`, Postgres `numeric` / `uuid`, etc.).
+
+Use the `tojson_safe` filter instead — it encodes the same types as ISO 8601 / string representations:
+
+```yaml
+body_template: |
+  {
+    "name":     {{ row.name | tojson_safe }},
+    "metadata": {{ row | tojson_safe }}
+  }
+```
+
+`tojson_safe` mirrors `tojson` for all JSON-native types (strings, numbers, bool, None, lists, dicts) and additionally handles:
+
+| Python type | Encoded as |
+|---|---|
+| `datetime`, `date`, `time` | ISO 8601 string (`obj.isoformat()`) |
+| `Decimal` | string (`str(obj)`) |
+| `UUID` | string (`str(obj)`) |
+
+Anything else still raises `TypeError`, matching `json.dumps`. The default `tojson` filter is unchanged.
+
 ## Notes
 
 - Without `body_template`, each record is sent as-is as a JSON object

--- a/drt/destinations/staged_upload.py
+++ b/drt/destinations/staged_upload.py
@@ -64,11 +64,13 @@ from drt.config.models import (
 )
 from drt.destinations.auth import AuthHandler
 from drt.destinations.base import SyncResult
+from drt.templates.renderer import tojson_safe
 
 
 def _render(template_str: str, context: dict[str, str]) -> str:
     """Render a Jinja2 template with context variables (not row-scoped)."""
     env = Environment(loader=BaseLoader(), undefined=StrictUndefined)
+    env.filters["tojson_safe"] = tojson_safe
     try:
         return env.from_string(template_str).render(**context)
     except UndefinedError as e:

--- a/drt/templates/renderer.py
+++ b/drt/templates/renderer.py
@@ -4,10 +4,42 @@ Future: replace with MiniJinja (Rust) via PyO3 for zero-dependency binary.
 Interface is intentionally simple to make the swap transparent.
 """
 
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, time
+from decimal import Decimal
 from typing import Any
+from uuid import UUID
 
 from jinja2 import BaseLoader, Environment, StrictUndefined
 from jinja2.exceptions import UndefinedError
+
+
+def _json_default(obj: Any) -> Any:
+    """JSON encoder fallback for non-JSON-serializable Python types.
+
+    Handles datetime/date/time → ISO 8601, Decimal/UUID → str. Anything else
+    raises TypeError to preserve `json.dumps` semantics.
+    """
+    if isinstance(obj, (datetime, date, time)):
+        return obj.isoformat()
+    if isinstance(obj, Decimal):
+        return str(obj)
+    if isinstance(obj, UUID):
+        return str(obj)
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+
+def tojson_safe(value: Any) -> str:
+    """Jinja2 filter: like `tojson` but tolerant of datetime / Decimal / UUID."""
+    return json.dumps(value, default=_json_default, ensure_ascii=False)
+
+
+def _build_env() -> Environment:
+    env = Environment(loader=BaseLoader(), undefined=StrictUndefined)
+    env.filters["tojson_safe"] = tojson_safe
+    return env
 
 
 def render_template(template_str: str, row: dict[str, Any]) -> str:
@@ -16,7 +48,7 @@ def render_template(template_str: str, row: dict[str, Any]) -> str:
     Variables are accessed as {{ row.field_name }}.
     Raises ValueError on missing variables (strict mode).
     """
-    env = Environment(loader=BaseLoader(), undefined=StrictUndefined)
+    env = _build_env()
     try:
         tmpl = env.from_string(template_str)
         return tmpl.render(row=row)

--- a/drt/templates/renderer.py
+++ b/drt/templates/renderer.py
@@ -36,19 +36,14 @@ def tojson_safe(value: Any) -> str:
     return json.dumps(value, default=_json_default, ensure_ascii=False)
 
 
-def _build_env() -> Environment:
-    env = Environment(loader=BaseLoader(), undefined=StrictUndefined)
-    env.filters["tojson_safe"] = tojson_safe
-    return env
-
-
 def render_template(template_str: str, row: dict[str, Any]) -> str:
     """Render a Jinja2 template string with a single row of data.
 
     Variables are accessed as {{ row.field_name }}.
     Raises ValueError on missing variables (strict mode).
     """
-    env = _build_env()
+    env = Environment(loader=BaseLoader(), undefined=StrictUndefined)
+    env.filters["tojson_safe"] = tojson_safe
     try:
         tmpl = env.from_string(template_str)
         return tmpl.render(row=row)

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -1,8 +1,13 @@
 """Tests for template renderer."""
 
+import json
+from datetime import date, datetime, time, timezone
+from decimal import Decimal
+from uuid import UUID
+
 import pytest
 
-from drt.templates.renderer import render_template
+from drt.templates.renderer import render_template, tojson_safe
 
 
 def test_render_simple(sample_row: dict) -> None:
@@ -13,3 +18,55 @@ def test_render_simple(sample_row: dict) -> None:
 def test_render_missing_variable(sample_row: dict) -> None:
     with pytest.raises(ValueError, match="Template error"):
         render_template("{{ row.missing_field }}", sample_row)
+
+
+def test_tojson_safe_datetime() -> None:
+    dt = datetime(2026, 5, 28, 12, 34, 56, tzinfo=timezone.utc)
+    assert tojson_safe(dt) == '"2026-05-28T12:34:56+00:00"'
+
+
+def test_tojson_safe_date_and_time() -> None:
+    assert tojson_safe(date(2026, 5, 28)) == '"2026-05-28"'
+    assert tojson_safe(time(12, 34, 56)) == '"12:34:56"'
+
+
+def test_tojson_safe_decimal_and_uuid() -> None:
+    assert tojson_safe(Decimal("3.14")) == '"3.14"'
+    u = UUID("12345678-1234-5678-1234-567812345678")
+    assert tojson_safe(u) == '"12345678-1234-5678-1234-567812345678"'
+
+
+def test_tojson_safe_nested_row() -> None:
+    row = {
+        "name": "Alice",
+        "annotated_at": datetime(2026, 5, 28, 12, 0, 0, tzinfo=timezone.utc),
+        "price": Decimal("9.99"),
+        "uid": UUID("12345678-1234-5678-1234-567812345678"),
+        "note": None,
+    }
+    rendered = render_template("{{ row | tojson_safe }}", row)
+    parsed = json.loads(rendered)
+    assert parsed["name"] == "Alice"
+    assert parsed["annotated_at"] == "2026-05-28T12:00:00+00:00"
+    assert parsed["price"] == "9.99"
+    assert parsed["uid"] == "12345678-1234-5678-1234-567812345678"
+    assert parsed["note"] is None
+
+
+def test_tojson_safe_ensure_ascii_false() -> None:
+    assert tojson_safe({"msg": "こんにちは"}) == '{"msg": "こんにちは"}'
+
+
+def test_tojson_safe_unknown_type_raises() -> None:
+    class Custom:
+        pass
+
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        tojson_safe(Custom())
+
+
+def test_tojson_strict_still_fails_on_datetime() -> None:
+    """Standard `tojson` is unchanged — non-breaking guarantee."""
+    row = {"ts": datetime(2026, 5, 28, tzinfo=timezone.utc)}
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        render_template("{{ row.ts | tojson }}", row)


### PR DESCRIPTION
## Summary

Closes #580. Add a `tojson_safe` Jinja2 filter that tolerates `datetime` / `date` / `time` / `Decimal` / `UUID` — types that the standard `tojson` rejects with `Object of type datetime is not JSON serializable`. Unblocks BigQuery `TIMESTAMP` and Postgres `numeric` / `uuid` columns flowing through REST API `body_template` rendering without `CAST(... AS STRING)` workarounds in model SQL.

- `tojson_safe` calls `json.dumps(value, default=_json_default, ensure_ascii=False)` with a small whitelist:
  - `datetime` / `date` / `time` → ISO 8601 (`obj.isoformat()`)
  - `Decimal` / `UUID` → `str(obj)`
  - anything else → `TypeError`, matching `json.dumps`
- Registered on both `drt.templates.renderer` and `drt.destinations.staged_upload`'s local Jinja2 envs.
- **The default `tojson` filter is unchanged** — strictly opt-in, no behaviour change for existing templates. A regression test (`test_tojson_strict_still_fails_on_datetime`) locks this in.

### Files

- [drt/templates/renderer.py](drt/templates/renderer.py) — `_json_default`, `tojson_safe`, `_build_env()` helper
- [drt/destinations/staged_upload.py](drt/destinations/staged_upload.py) — import + register in `_render`
- [tests/unit/test_renderer.py](tests/unit/test_renderer.py) — 7 new tests
- [docs/connectors/rest-api.md](docs/connectors/rest-api.md) — new "Serializing datetime / Decimal / UUID columns" section
- [CHANGELOG.md](CHANGELOG.md) — `[Unreleased]` entry

### Usage

```yaml
body_template: |
  {
    "name":     {{ row.name | tojson_safe }},
    "metadata": {{ row | tojson_safe }}
  }
```

## Test plan

- [x] `pytest tests/unit/test_renderer.py` — 9 tests pass (2 existing + 7 new)
- [x] `pytest` full suite — 1254 passed, 1 skipped
- [x] `ruff check` on touched files — clean
- [x] `mypy` on touched files — clean
- [x] `make check-i18n` — clean
- [x] Non-breaking guard: existing `tojson` still rejects `datetime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)