### PR TITLE
docs(i18n): sync README.ja.md marker hash to v0.7.6 release commit

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-sync: base=README.md, hash=68c96f5a42a21ccf6d6926c636eac07241b74bf1 -->
+<!-- i18n-sync: base=README.md, hash=ea9cbe8c20b98b2cde6693f427f0fd310ced2932 -->
 
 [English](./README.md) | [日本語](./README.ja.md)
 


### PR DESCRIPTION
## Summary

Post-merge follow-up to PR #582 (v0.7.6 release prep). Bumps the README.ja.md i18n-sync marker hash from `68c96f5` (Amplitude PR #574 merge commit) to `ea9cbe8` (v0.7.6 release squash-merge commit). README.ja.md content itself was already updated in PR #582 — only the marker needed the new commit reference, which couldn't be set in the same commit.

Same cadence as the v0.7.5 → cfef58b follow-up.

## Verification

- [x] `make check-i18n` — `OK  README.ja.md  (synced with README.md)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)