### PR TITLE
refactor(cli): extract validate / status / test to commands/ — #573 Phase 2b PR (b)

### DIFF
--- a/drt/cli/commands/__init__.py
+++ b/drt/cli/commands/__init__.py
@@ -26,4 +26,7 @@ from drt.cli.commands import (
     mcp,  # noqa: F401
     run,  # noqa: F401 — registers `drt run`
     serve,  # noqa: F401
+    status,  # noqa: F401 — registers `drt status`
+    test,  # noqa: F401 — registers `drt test`
+    validate,  # noqa: F401 — registers `drt validate`
 )

--- a/drt/cli/commands/status.py
+++ b/drt/cli/commands/status.py
@@ -1,0 +1,135 @@
+"""``drt status`` — show most-recent run state, or ``--history`` log tail.
+
+Extracted from ``drt/cli/main.py`` in Phase 2b PR (b) of the #546 split
+(tracked under #573). The private ``_print_history`` helper moves
+alongside since nothing else uses it.
+
+Back-compat: ``drt.cli.main`` re-exports ``_print_history`` so existing
+``from drt.cli.main import _print_history`` paths keep working.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+
+from drt.cli._app import app
+from drt.cli.output import (
+    console,
+    print_status_table,
+    print_status_verbose,
+)
+
+
+@app.command()
+def status(
+    verbose: bool = typer.Option(False, "--verbose", help="Show row-level error details."),
+    output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
+    history: bool = typer.Option(
+        False,
+        "--history",
+        help="Show past execution history instead of just the most recent run.",
+    ),
+    sync_name: str | None = typer.Option(
+        None,
+        "--sync",
+        help="Only show entries for this sync (--history mode only).",
+    ),
+    limit: int = typer.Option(20, "--limit", help="Max entries to show in --history mode."),
+) -> None:
+    """Show the status of the most recent sync runs."""
+
+    if history:
+        _print_history(sync_name=sync_name, limit=limit, output=output)
+        return
+
+    from drt.state.manager import StateManager
+
+    states = StateManager(Path(".")).get_all()
+
+    if output == "json":
+        print(
+            json.dumps(
+                {
+                    "syncs": [
+                        {
+                            "name": name,
+                            "status": state.status,
+                            "last_run_at": state.last_run_at,
+                            "records_synced": state.records_synced,
+                            "last_cursor_value": state.last_cursor_value,
+                            "error": state.error,
+                        }
+                        for name, state in sorted(states.items())
+                    ],
+                },
+                indent=2,
+            )
+        )
+        return
+
+    if verbose:
+        print_status_verbose(states, {})
+    else:
+        print_status_table(states)
+
+
+def _print_history(*, sync_name: str | None, limit: int, output: str) -> None:
+    """Render ``drt status --history`` output for one or all syncs."""
+    from dataclasses import asdict
+
+    from drt.state.history import HistoryManager
+
+    entries = HistoryManager(Path(".")).read(sync_name=sync_name, limit=limit)
+
+    if output == "json":
+        print(
+            json.dumps(
+                {"entries": [asdict(e) for e in entries]},
+                indent=2,
+                default=str,
+            )
+        )
+        return
+
+    if not entries:
+        scope = f"sync='{sync_name}'" if sync_name else "any sync"
+        console.print(f"[yellow]No history found for {scope}.[/yellow]")
+        return
+
+    from rich.table import Table
+
+    table = Table(
+        title=(
+            f"Execution history — sync='{sync_name}'"
+            if sync_name
+            else "Execution history (all syncs)"
+        ),
+        show_lines=False,
+    )
+    table.add_column("Started", style="cyan", no_wrap=True)
+    table.add_column("Sync", style="magenta")
+    table.add_column("Status", justify="center")
+    table.add_column("Synced", justify="right")
+    table.add_column("Failed", justify="right")
+    table.add_column("Duration", justify="right")
+    table.add_column("Error", overflow="fold")
+
+    for e in entries:
+        status_style = {
+            "success": "green",
+            "partial": "yellow",
+            "failed": "red",
+        }.get(e.status, "white")
+        table.add_row(
+            e.started_at[:19].replace("T", " "),
+            e.sync_name,
+            f"[{status_style}]{e.status}[/{status_style}]",
+            str(e.records_synced),
+            str(e.records_failed),
+            f"{e.duration_seconds:.1f}s",
+            (e.errors[0] if e.errors else ""),
+        )
+    console.print(table)

--- a/drt/cli/commands/test.py
+++ b/drt/cli/commands/test.py
@@ -1,0 +1,163 @@
+"""``drt test`` — run post-sync validation tests against destination data.
+
+Extracted from ``drt/cli/main.py`` in Phase 2b PR (b) of the #546 split
+(tracked under #573). The private ``_SyncTestResult`` TypedDict and
+``_test_display_name`` shim move alongside since nothing else uses them.
+
+Back-compat: ``drt.cli.main`` re-exports ``_SyncTestResult`` +
+``_test_display_name`` so existing ``from drt.cli.main import ...``
+paths keep working.
+
+The module name is ``test``; the registered command is also ``test``
+via ``@app.command(name="test")`` (Python function called
+``test_syncs`` to avoid shadowing pytest in unrelated tooling).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TypedDict
+
+import typer
+
+from drt.cli._app import app
+from drt.cli.output import (
+    console,
+    print_error,
+    print_test_header,
+    print_test_result,
+    print_test_skip,
+)
+
+
+class _SyncTestResult(TypedDict, total=False):
+    """Type hint for test result dict in JSON output."""
+
+    sync: str
+    tests: list[dict[str, object]]
+    skipped: bool
+    reason: str
+
+
+@app.command(name="test")
+def test_syncs(
+    output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
+    select: str = typer.Option(None, "--select", "-s", help="Test a specific sync by name."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without running tests."),
+) -> None:
+    """Run post-sync validation tests.
+
+    With --dry-run, shows what tests would be executed without actually
+    connecting to the destination or running queries.
+    """
+    from drt.config.parser import load_syncs
+    from drt.destinations.query import (
+        execute_test_query,
+        get_table_name,
+        is_queryable,
+    )
+    from drt.engine.test_runner import build_test_query
+
+    json_mode = output == "json"
+    results: list[_SyncTestResult] = []
+
+    syncs = load_syncs(Path("."))
+    if not syncs:
+        if not json_mode:
+            console.print("[dim]No syncs found.[/dim]")
+        else:
+            print(json.dumps({"status": "no_syncs", "results": []}))
+        return
+
+    if select:
+        syncs = [s for s in syncs if s.name == select]
+        if not syncs:
+            print_error(f"No sync named '{select}' found.")
+            raise typer.Exit(1)
+
+    syncs_with_tests = [s for s in syncs if s.tests]
+    if not syncs_with_tests:
+        if not json_mode:
+            console.print("[dim]No tests defined in any sync.[/dim]")
+        else:
+            print(json.dumps({"status": "no_tests", "results": []}))
+        return
+
+    had_failures = False
+
+    for sync in syncs_with_tests:
+        if not json_mode:
+            print_test_header(sync.name)
+        sync_results: _SyncTestResult = {"sync": sync.name, "tests": []}
+
+        if not is_queryable(sync.destination):
+            if not json_mode:
+                if dry_run:
+                    console.print(
+                        f"  [dim]⏭ {sync.name}: would be skipped"
+                        f" (tests not supported for"
+                        f" {sync.destination.type} destinations)[/dim]"
+                    )
+                else:
+                    print_test_skip(
+                        sync.name,
+                        f"tests not supported for {sync.destination.type} destinations",
+                    )
+            sync_results["skipped"] = True
+            sync_results["reason"] = f"tests not supported for {sync.destination.type}"
+            results.append(sync_results)
+            continue
+
+        table = get_table_name(sync.destination)
+        for test_def in sync.tests:
+            test_name = _test_display_name(test_def)
+            if dry_run:
+                if not json_mode:
+                    console.print(f"  [dim](dry-run)[/dim] {test_name}")
+                sync_results["tests"].append({"name": test_name, "dry_run": True})
+            else:
+                try:
+                    query, check = build_test_query(test_def, table)
+                    result_val = execute_test_query(sync.destination, query)
+                    passed = check(result_val)
+                    if not json_mode:
+                        print_test_result(test_name, passed, str(result_val))
+                    sync_results["tests"].append(
+                        {"name": test_name, "passed": passed, "value": str(result_val)}
+                    )
+                    if not passed:
+                        had_failures = True
+                except Exception as e:
+                    if not json_mode:
+                        print_test_result(test_name, False, str(e))
+                    sync_results["tests"].append(
+                        {"name": test_name, "passed": False, "error": str(e)}
+                    )
+                    had_failures = True
+
+        results.append(sync_results)
+
+    if json_mode:
+        print(
+            json.dumps(
+                {
+                    "status": "failed" if had_failures else "passed",
+                    "results": results,
+                    "dry_run": dry_run,
+                }
+            )
+        )
+    elif dry_run:
+        console.print("\n[dry-run] Preview of tests that would be executed")
+    if had_failures:
+        raise typer.Exit(1)
+
+
+def _test_display_name(test_def: object) -> str:
+    """Backward-compatible private wrapper — delegates to the public helper."""
+    from drt.config.models import SyncTest
+    from drt.engine.test_runner import test_display_name
+
+    assert isinstance(test_def, SyncTest)
+    return test_display_name(test_def)

--- a/drt/cli/commands/validate.py
+++ b/drt/cli/commands/validate.py
@@ -1,0 +1,217 @@
+"""``drt validate`` — sync schema validation + secret scan + optional connection probe.
+
+Extracted from ``drt/cli/main.py`` in Phase 2b PR (b) of the #546 split
+(tracked under #573). The two private helpers (``_group_secret_findings``,
+``_run_connection_test``) move along with the command since they are not
+used anywhere else.
+
+Back-compat: ``drt.cli.main`` re-exports the underscore-prefixed helpers
+so existing ``from drt.cli.main import _run_connection_test`` (used by
+tests and library callers) keeps working.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import typer
+
+if TYPE_CHECKING:
+    from drt.config.models import SyncConfig
+    from drt.config.secrets import SecretFinding
+
+
+from drt.cli._app import app
+from drt.cli.output import (
+    console,
+    print_error,
+    print_validation_error,
+    print_validation_ok,
+)
+
+
+@app.command()
+def validate(
+    select: str = typer.Option(None, "--select", "-s", help="Validate a specific sync by name."),
+    emit_schema: bool = typer.Option(  # noqa: E501
+        False, "--emit-schema", help="Write JSON Schemas to .drt/schemas/."
+    ),
+    check_connection: bool = typer.Option(
+        False, "--check-connection", help="Test connectivity to SQL destinations."
+    ),
+    output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
+    strict: bool = typer.Option(False, "--strict", help="Treat warnings as validation errors."),
+) -> None:
+    """Validate sync definitions against the JSON Schema.
+
+    Examples:
+      drt validate
+      drt validate --select post_users
+      drt validate --emit-schema
+      drt validate --strict
+    """
+
+    from drt.config.parser import load_syncs_safe
+    from drt.config.schema import write_schemas
+    from drt.config.secrets import find_hardcoded_secrets
+
+    result = load_syncs_safe(Path("."))
+    secret_findings = find_hardcoded_secrets(Path("."))
+
+    if select:
+        result.syncs = [s for s in result.syncs if s.name == select]
+        result.errors = {k: v for k, v in result.errors.items() if k == select}
+        result.deprecations = {k: v for k, v in result.deprecations.items() if k == select}
+        secret_findings = [finding for finding in secret_findings if finding.sync_name == select]
+        if not result.syncs and not result.errors:
+            print_error(f"No sync named '{select}' found.")
+            raise typer.Exit(1)
+
+    secret_warnings_by_sync = _group_secret_findings(secret_findings)
+
+    if output == "json":
+        # Collect all deprecations into a flat list for JSON output
+        all_deprecations = []
+        for sync_name, sync_deprecations in result.deprecations.items():
+            all_deprecations.extend(sync_deprecations)
+
+        results_json = []
+        for s in result.syncs:
+            entry = {
+                "name": s.name,
+                "valid": True,
+                "deprecations": result.deprecations.get(s.name, []),
+                "warnings": [
+                    finding.to_dict() for finding in secret_warnings_by_sync.get(s.name, [])
+                ],
+            }
+            if strict and entry["warnings"]:
+                entry["valid"] = False
+                entry["errors"] = [
+                    finding.message for finding in secret_warnings_by_sync.get(s.name, [])
+                ]
+            if check_connection:
+                entry["connection_test"] = _run_connection_test(s)
+            results_json.append(entry)
+
+        for name, errs in result.errors.items():
+            results_json.append(
+                {
+                    "name": name,
+                    "valid": False,
+                    "errors": errs,
+                    "warnings": [
+                        finding.to_dict() for finding in secret_warnings_by_sync.get(name, [])
+                    ],
+                }
+            )
+
+        print(
+            json.dumps(
+                {"results": results_json},
+                indent=2,
+            )
+        )
+        if result.errors or (strict and secret_findings):
+            raise typer.Exit(code=1)
+        return
+
+    if not result.syncs and not result.errors:
+        console.print("[dim]No syncs found.[/dim]")
+        return
+
+    for sync in result.syncs:
+        if strict and sync.name in secret_warnings_by_sync:
+            continue
+        print_validation_ok(sync.name)
+        # Print deprecation warnings for this sync
+        if sync.name in result.deprecations:
+            for deprecation in result.deprecations[sync.name]:
+                console.print(
+                    f"  [yellow]⚠️  {deprecation['key']} is deprecated "
+                    f"(removed in {deprecation['removed_in']})[/yellow]"
+                )
+                console.print(f"       Use {deprecation['replacement']} instead.")
+                if deprecation["docs_link"]:
+                    console.print(f"       See {deprecation['docs_link']}")
+
+        for finding in secret_warnings_by_sync.get(sync.name, []):
+            console.print(f"  [yellow]WARNING[/yellow] {finding.message}")
+
+        if check_connection:
+            from drt.cli.output import print_connection_test_result
+
+            conn_res = _run_connection_test(sync)
+            print_connection_test_result(
+                sync.name,
+                success=conn_res["success"],
+                error=conn_res["error"],
+            )
+
+    for name, errors in result.errors.items():
+        print_validation_error(name, errors)
+
+    if strict:
+        for name, findings in secret_warnings_by_sync.items():
+            print_validation_error(name, [finding.message for finding in findings])
+
+    if result.errors or (strict and secret_findings):
+        raise typer.Exit(code=1)
+
+    if emit_schema:
+        schema_dir = Path(".") / ".drt" / "schemas"
+        written = write_schemas(schema_dir)
+        console.print(f"\n[dim]Schemas written to {schema_dir}/[/dim]")
+        for p in written:
+            console.print(f"  {p}")
+
+
+def _group_secret_findings(
+    findings: list[SecretFinding],
+) -> dict[str, list[SecretFinding]]:
+    grouped: dict[str, list[SecretFinding]] = {}
+    for finding in findings:
+        grouped.setdefault(finding.sync_name, []).append(finding)
+    return grouped
+
+
+def _run_connection_test(sync: SyncConfig) -> dict[str, Any]:
+    """Internal helper to test connectivity for a sync's destination."""
+    from drt.config.models import (
+        ClickHouseDestinationConfig,
+        MySQLDestinationConfig,
+        PostgresDestinationConfig,
+        SnowflakeDestinationConfig,
+    )
+    from drt.connectors.registry import get_destination
+    from drt.destinations.base import ConnectionTestable
+
+    dest_config = sync.destination
+    is_sql = isinstance(
+        dest_config,
+        (
+            PostgresDestinationConfig,
+            MySQLDestinationConfig,
+            ClickHouseDestinationConfig,
+            SnowflakeDestinationConfig,
+        ),
+    )
+
+    if not is_sql:
+        return {"success": None, "error": None, "skipped": True}
+
+    try:
+        dest = get_destination(dest_config)
+        if isinstance(dest, ConnectionTestable):
+            dest.test_connection(dest_config)
+            return {"success": True, "error": None, "skipped": False}
+        else:
+            return {
+                "success": False,
+                "error": "test_connection method missing",
+                "skipped": False,
+            }
+    except Exception as e:
+        return {"success": False, "error": str(e), "skipped": False}

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -2,17 +2,15 @@
 
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any
 
 import typer
 
 if TYPE_CHECKING:
     from drt.config.credentials import ProfileConfig
     from drt.config.models import SyncConfig
-    from drt.config.secrets import SecretFinding
     from drt.destinations.base import Destination
     from drt.sources.base import Source
 
@@ -27,14 +25,6 @@ from drt.cli import commands as _commands  # noqa: F401 — register commands
 from drt.cli._app import app
 from drt.cli.output import (
     console,
-    print_error,
-    print_status_table,
-    print_status_verbose,
-    print_test_header,
-    print_test_result,
-    print_test_skip,
-    print_validation_error,
-    print_validation_ok,
 )
 
 
@@ -93,455 +83,14 @@ def main(
 
 
 # `drt list` lives in drt/cli/commands/list_syncs.py (#546)
-
-
-# ---------------------------------------------------------------------------
-# validate
-# ---------------------------------------------------------------------------
-
-
-@app.command()
-def validate(
-    select: str = typer.Option(None, "--select", "-s", help="Validate a specific sync by name."),
-    emit_schema: bool = typer.Option(  # noqa: E501
-        False, "--emit-schema", help="Write JSON Schemas to .drt/schemas/."
-    ),
-    check_connection: bool = typer.Option(
-        False, "--check-connection", help="Test connectivity to SQL destinations."
-    ),
-    output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
-    strict: bool = typer.Option(False, "--strict", help="Treat warnings as validation errors."),
-) -> None:
-    """Validate sync definitions against the JSON Schema.
-
-    Examples:
-      drt validate
-      drt validate --select post_users
-      drt validate --emit-schema
-      drt validate --strict
-    """
-
-    from drt.config.parser import load_syncs_safe
-    from drt.config.schema import write_schemas
-    from drt.config.secrets import find_hardcoded_secrets
-
-    result = load_syncs_safe(Path("."))
-    secret_findings = find_hardcoded_secrets(Path("."))
-
-    if select:
-        result.syncs = [s for s in result.syncs if s.name == select]
-        result.errors = {k: v for k, v in result.errors.items() if k == select}
-        result.deprecations = {k: v for k, v in result.deprecations.items() if k == select}
-        secret_findings = [finding for finding in secret_findings if finding.sync_name == select]
-        if not result.syncs and not result.errors:
-            print_error(f"No sync named '{select}' found.")
-            raise typer.Exit(1)
-
-    secret_warnings_by_sync = _group_secret_findings(secret_findings)
-
-    if output == "json":
-        # Collect all deprecations into a flat list for JSON output
-        all_deprecations = []
-        for sync_name, sync_deprecations in result.deprecations.items():
-            all_deprecations.extend(sync_deprecations)
-
-        results_json = []
-        for s in result.syncs:
-            entry = {
-                "name": s.name,
-                "valid": True,
-                "deprecations": result.deprecations.get(s.name, []),
-                "warnings": [
-                    finding.to_dict() for finding in secret_warnings_by_sync.get(s.name, [])
-                ],
-            }
-            if strict and entry["warnings"]:
-                entry["valid"] = False
-                entry["errors"] = [
-                    finding.message for finding in secret_warnings_by_sync.get(s.name, [])
-                ]
-            if check_connection:
-                entry["connection_test"] = _run_connection_test(s)
-            results_json.append(entry)
-
-        for name, errs in result.errors.items():
-            results_json.append(
-                {
-                    "name": name,
-                    "valid": False,
-                    "errors": errs,
-                    "warnings": [
-                        finding.to_dict() for finding in secret_warnings_by_sync.get(name, [])
-                    ],
-                }
-            )
-
-        print(
-            json.dumps(
-                {"results": results_json},
-                indent=2,
-            )
-        )
-        if result.errors or (strict and secret_findings):
-            raise typer.Exit(code=1)
-        return
-
-    if not result.syncs and not result.errors:
-        console.print("[dim]No syncs found.[/dim]")
-        return
-
-    for sync in result.syncs:
-        if strict and sync.name in secret_warnings_by_sync:
-            continue
-        print_validation_ok(sync.name)
-        # Print deprecation warnings for this sync
-        if sync.name in result.deprecations:
-            for deprecation in result.deprecations[sync.name]:
-                console.print(
-                    f"  [yellow]⚠️  {deprecation['key']} is deprecated "
-                    f"(removed in {deprecation['removed_in']})[/yellow]"
-                )
-                console.print(f"       Use {deprecation['replacement']} instead.")
-                if deprecation["docs_link"]:
-                    console.print(f"       See {deprecation['docs_link']}")
-
-        for finding in secret_warnings_by_sync.get(sync.name, []):
-            console.print(f"  [yellow]WARNING[/yellow] {finding.message}")
-
-        if check_connection:
-            from drt.cli.output import print_connection_test_result
-
-            conn_res = _run_connection_test(sync)
-            print_connection_test_result(
-                sync.name,
-                success=conn_res["success"],
-                error=conn_res["error"],
-            )
-
-    for name, errors in result.errors.items():
-        print_validation_error(name, errors)
-
-    if strict:
-        for name, findings in secret_warnings_by_sync.items():
-            print_validation_error(name, [finding.message for finding in findings])
-
-    if result.errors or (strict and secret_findings):
-        raise typer.Exit(code=1)
-
-    if emit_schema:
-        schema_dir = Path(".") / ".drt" / "schemas"
-        written = write_schemas(schema_dir)
-        console.print(f"\n[dim]Schemas written to {schema_dir}/[/dim]")
-        for p in written:
-            console.print(f"  {p}")
-
-
-def _group_secret_findings(
-    findings: list[SecretFinding],
-) -> dict[str, list[SecretFinding]]:
-    grouped: dict[str, list[SecretFinding]] = {}
-    for finding in findings:
-        grouped.setdefault(finding.sync_name, []).append(finding)
-    return grouped
-
-
-def _run_connection_test(sync: SyncConfig) -> dict[str, Any]:
-    """Internal helper to test connectivity for a sync's destination."""
-    from drt.config.models import (
-        ClickHouseDestinationConfig,
-        MySQLDestinationConfig,
-        PostgresDestinationConfig,
-        SnowflakeDestinationConfig,
-    )
-    from drt.connectors.registry import get_destination
-    from drt.destinations.base import ConnectionTestable
-
-    dest_config = sync.destination
-    is_sql = isinstance(
-        dest_config,
-        (
-            PostgresDestinationConfig,
-            MySQLDestinationConfig,
-            ClickHouseDestinationConfig,
-            SnowflakeDestinationConfig,
-        ),
-    )
-
-    if not is_sql:
-        return {"success": None, "error": None, "skipped": True}
-
-    try:
-        dest = get_destination(dest_config)
-        if isinstance(dest, ConnectionTestable):
-            dest.test_connection(dest_config)
-            return {"success": True, "error": None, "skipped": False}
-        else:
-            return {
-                "success": False,
-                "error": "test_connection method missing",
-                "skipped": False,
-            }
-    except Exception as e:
-        return {"success": False, "error": str(e), "skipped": False}
-
-
-# ---------------------------------------------------------------------------
-# status
-# ---------------------------------------------------------------------------
-
-
-@app.command()
-def status(
-    verbose: bool = typer.Option(False, "--verbose", help="Show row-level error details."),
-    output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
-    history: bool = typer.Option(
-        False,
-        "--history",
-        help="Show past execution history instead of just the most recent run.",
-    ),
-    sync_name: str | None = typer.Option(
-        None,
-        "--sync",
-        help="Only show entries for this sync (--history mode only).",
-    ),
-    limit: int = typer.Option(20, "--limit", help="Max entries to show in --history mode."),
-) -> None:
-    """Show the status of the most recent sync runs."""
-
-    if history:
-        _print_history(sync_name=sync_name, limit=limit, output=output)
-        return
-
-    from drt.state.manager import StateManager
-
-    states = StateManager(Path(".")).get_all()
-
-    if output == "json":
-        print(
-            json.dumps(
-                {
-                    "syncs": [
-                        {
-                            "name": name,
-                            "status": state.status,
-                            "last_run_at": state.last_run_at,
-                            "records_synced": state.records_synced,
-                            "last_cursor_value": state.last_cursor_value,
-                            "error": state.error,
-                        }
-                        for name, state in sorted(states.items())
-                    ],
-                },
-                indent=2,
-            )
-        )
-        return
-
-    if verbose:
-        print_status_verbose(states, {})
-    else:
-        print_status_table(states)
-
-
-def _print_history(*, sync_name: str | None, limit: int, output: str) -> None:
-    """Render ``drt status --history`` output for one or all syncs."""
-    from dataclasses import asdict
-
-    from drt.state.history import HistoryManager
-
-    entries = HistoryManager(Path(".")).read(sync_name=sync_name, limit=limit)
-
-    if output == "json":
-        print(
-            json.dumps(
-                {"entries": [asdict(e) for e in entries]},
-                indent=2,
-                default=str,
-            )
-        )
-        return
-
-    if not entries:
-        scope = f"sync='{sync_name}'" if sync_name else "any sync"
-        console.print(f"[yellow]No history found for {scope}.[/yellow]")
-        return
-
-    from rich.table import Table
-
-    table = Table(
-        title=(
-            f"Execution history — sync='{sync_name}'"
-            if sync_name
-            else "Execution history (all syncs)"
-        ),
-        show_lines=False,
-    )
-    table.add_column("Started", style="cyan", no_wrap=True)
-    table.add_column("Sync", style="magenta")
-    table.add_column("Status", justify="center")
-    table.add_column("Synced", justify="right")
-    table.add_column("Failed", justify="right")
-    table.add_column("Duration", justify="right")
-    table.add_column("Error", overflow="fold")
-
-    for e in entries:
-        status_style = {
-            "success": "green",
-            "partial": "yellow",
-            "failed": "red",
-        }.get(e.status, "white")
-        table.add_row(
-            e.started_at[:19].replace("T", " "),
-            e.sync_name,
-            f"[{status_style}]{e.status}[/{status_style}]",
-            str(e.records_synced),
-            str(e.records_failed),
-            f"{e.duration_seconds:.1f}s",
-            (e.errors[0] if e.errors else ""),
-        )
-    console.print(table)
-
-
+# `drt validate` lives in drt/cli/commands/validate.py (#573 Phase 2b PR (b) —
+# `_group_secret_findings` and `_run_connection_test` are re-exported below
+# as back-compat shims)
 # `drt doctor` lives in drt/cli/commands/doctor.py (#546)
-
-
-# ---------------------------------------------------------------------------
-# test
-# ---------------------------------------------------------------------------
-
-
-class _SyncTestResult(TypedDict, total=False):
-    """Type hint for test result dict in JSON output."""
-
-    sync: str
-    tests: list[dict[str, object]]
-    skipped: bool
-    reason: str
-
-
-@app.command(name="test")
-def test_syncs(
-    output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
-    select: str = typer.Option(None, "--select", "-s", help="Test a specific sync by name."),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without running tests."),
-) -> None:
-    """Run post-sync validation tests.
-
-    With --dry-run, shows what tests would be executed without actually
-    connecting to the destination or running queries.
-    """
-    from drt.config.parser import load_syncs
-    from drt.destinations.query import (
-        execute_test_query,
-        get_table_name,
-        is_queryable,
-    )
-    from drt.engine.test_runner import build_test_query
-
-    json_mode = output == "json"
-    results: list[_SyncTestResult] = []
-
-    syncs = load_syncs(Path("."))
-    if not syncs:
-        if not json_mode:
-            console.print("[dim]No syncs found.[/dim]")
-        else:
-            print(json.dumps({"status": "no_syncs", "results": []}))
-        return
-
-    if select:
-        syncs = [s for s in syncs if s.name == select]
-        if not syncs:
-            print_error(f"No sync named '{select}' found.")
-            raise typer.Exit(1)
-
-    syncs_with_tests = [s for s in syncs if s.tests]
-    if not syncs_with_tests:
-        if not json_mode:
-            console.print("[dim]No tests defined in any sync.[/dim]")
-        else:
-            print(json.dumps({"status": "no_tests", "results": []}))
-        return
-
-    had_failures = False
-
-    for sync in syncs_with_tests:
-        if not json_mode:
-            print_test_header(sync.name)
-        sync_results: _SyncTestResult = {"sync": sync.name, "tests": []}
-
-        if not is_queryable(sync.destination):
-            if not json_mode:
-                if dry_run:
-                    console.print(
-                        f"  [dim]⏭ {sync.name}: would be skipped"
-                        f" (tests not supported for"
-                        f" {sync.destination.type} destinations)[/dim]"
-                    )
-                else:
-                    print_test_skip(
-                        sync.name,
-                        f"tests not supported for {sync.destination.type} destinations",
-                    )
-            sync_results["skipped"] = True
-            sync_results["reason"] = f"tests not supported for {sync.destination.type}"
-            results.append(sync_results)
-            continue
-
-        table = get_table_name(sync.destination)
-        for test_def in sync.tests:
-            test_name = _test_display_name(test_def)
-            if dry_run:
-                if not json_mode:
-                    console.print(f"  [dim](dry-run)[/dim] {test_name}")
-                sync_results["tests"].append({"name": test_name, "dry_run": True})
-            else:
-                try:
-                    query, check = build_test_query(test_def, table)
-                    result_val = execute_test_query(sync.destination, query)
-                    passed = check(result_val)
-                    if not json_mode:
-                        print_test_result(test_name, passed, str(result_val))
-                    sync_results["tests"].append(
-                        {"name": test_name, "passed": passed, "value": str(result_val)}
-                    )
-                    if not passed:
-                        had_failures = True
-                except Exception as e:
-                    if not json_mode:
-                        print_test_result(test_name, False, str(e))
-                    sync_results["tests"].append(
-                        {"name": test_name, "passed": False, "error": str(e)}
-                    )
-                    had_failures = True
-
-        results.append(sync_results)
-
-    if json_mode:
-        print(
-            json.dumps(
-                {
-                    "status": "failed" if had_failures else "passed",
-                    "results": results,
-                    "dry_run": dry_run,
-                }
-            )
-        )
-    elif dry_run:
-        console.print("\n[dry-run] Preview of tests that would be executed")
-    if had_failures:
-        raise typer.Exit(1)
-
-
-def _test_display_name(test_def: object) -> str:
-    """Backward-compatible private wrapper — delegates to the public helper."""
-    from drt.config.models import SyncTest
-    from drt.engine.test_runner import test_display_name
-
-    assert isinstance(test_def, SyncTest)
-    return test_display_name(test_def)
-
-
+# `drt status` lives in drt/cli/commands/status.py (#573 Phase 2b PR (b) —
+# `_print_history` is re-exported below)
+# `drt test` lives in drt/cli/commands/test.py (#573 Phase 2b PR (b) —
+# `_SyncTestResult` and `_test_display_name` are re-exported below)
 # `drt serve` lives in drt/cli/commands/serve.py (#546 Phase 2)
 
 
@@ -601,4 +150,17 @@ from drt.cli.commands.run import (  # noqa: E402, F401
     _print_watermark_summary,
     _run_one,
     _RunContext,
+)
+
+# ---------------------------------------------------------------------------
+# Back-compat re-exports from validate / status / test (#573 Phase 2b PR (b))
+# ---------------------------------------------------------------------------
+from drt.cli.commands.status import _print_history  # noqa: E402, F401
+from drt.cli.commands.test import (  # noqa: E402, F401
+    _SyncTestResult,
+    _test_display_name,
+)
+from drt.cli.commands.validate import (  # noqa: E402, F401
+    _group_secret_findings,
+    _run_connection_test,
 )

--- a/tests/unit/test_cli_status_coverage.py
+++ b/tests/unit/test_cli_status_coverage.py
@@ -1,0 +1,43 @@
+"""Coverage tests for `drt status` text-mode rendering (#573 follow-up).
+
+Covers the verbose / non-verbose dispatch at the end of the status
+command (status.py:73-76) — both branches were silent in codecov on the
+PR (b) move because no existing test exercised text-mode status without
+``--history``.
+
+Uses an empty StateManager (no state file present) so the renderers are
+called with an empty mapping, which is enough to lock the dispatch wiring.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from drt.cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def empty_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "drt_project.yml").write_text(
+        yaml.dump({"name": "t", "version": "0.1", "profile": "default"})
+    )
+    return tmp_path
+
+
+def test_status_text_mode_non_verbose_renders(empty_project: Path) -> None:
+    """``drt status`` (default, no flags) takes the non-verbose branch."""
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+
+
+def test_status_text_mode_verbose_renders(empty_project: Path) -> None:
+    """``drt status --verbose`` takes the verbose branch."""
+    result = runner.invoke(app, ["status", "--verbose"])
+    assert result.exit_code == 0

--- a/tests/unit/test_cli_validate_coverage.py
+++ b/tests/unit/test_cli_validate_coverage.py
@@ -1,0 +1,80 @@
+"""Coverage tests for `drt validate` edge paths (#573 follow-up).
+
+Covers two branches that were silent in codecov on the PR (b) move:
+
+- `--select <name>` where the name doesn't match any sync → exits 1
+  with a "No sync named '<name>' found." error.
+- `--emit-schema` in text mode (the JSON-mode emit_schema path is
+  already covered by other tests) → writes JSON schemas to
+  ``.drt/schemas/`` and prints the paths.
+
+Both paths require nothing more than a minimal ``drt_project.yml`` in
+cwd; no profile loading or sync execution involved.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from drt.cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def empty_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A drt project with no syncs/."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "drt_project.yml").write_text(
+        yaml.dump({"name": "t", "version": "0.1", "profile": "default"})
+    )
+    (tmp_path / "syncs").mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def project_with_sync(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A drt project with one minimal valid sync. emit_schema only fires
+    once result.syncs is non-empty (the no-syncs branch returns early)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "drt_project.yml").write_text(
+        yaml.dump({"name": "t", "version": "0.1", "profile": "default"})
+    )
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    (syncs_dir / "post_users.yml").write_text(
+        yaml.dump(
+            {
+                "name": "post_users",
+                "model": "SELECT 1 AS id",
+                "destination": {
+                    "type": "rest_api",
+                    "url": "https://example.com",
+                    "method": "POST",
+                },
+            }
+        )
+    )
+    return tmp_path
+
+
+def test_validate_select_nonexistent_sync_exits_1(empty_project: Path) -> None:
+    """``--select <unknown>`` exits 1 with 'No sync named' error."""
+    result = runner.invoke(app, ["validate", "--select", "nonexistent_sync"])
+    assert result.exit_code == 1
+    assert "No sync named 'nonexistent_sync' found." in result.output
+
+
+def test_validate_emit_schema_text_mode_writes_files(project_with_sync: Path) -> None:
+    """``--emit-schema`` (text mode) writes schemas under .drt/schemas/."""
+    result = runner.invoke(app, ["validate", "--emit-schema"])
+    assert result.exit_code == 0
+    schemas_dir = project_with_sync / ".drt" / "schemas"
+    assert schemas_dir.exists()
+    schema_files = list(schemas_dir.glob("*.json"))
+    assert len(schema_files) > 0
+    assert "Schemas written to" in result.output


### PR DESCRIPTION
## Summary

Phase 2b **PR (b)** of [#546](https://github.com/drt-hub/drt/issues/546) — completes the cli/main.py split. Moves the remaining three top-level commands (`validate` / `status` / `test`) + their private helpers out of `drt/cli/main.py`. After this PR, [#573](https://github.com/drt-hub/drt/issues/573) is closed and the umbrella #546 split is fully done.

## What moved

| From `cli/main.py` | To |
|---|---|
| `validate` (`@app.command()`, ~135 LOC) | `drt/cli/commands/validate.py` |
| `_group_secret_findings` | (same) |
| `_run_connection_test` | (same) |
| `status` (`@app.command()`, ~52 LOC) | `drt/cli/commands/status.py` |
| `_print_history` | (same) |
| `_SyncTestResult` TypedDict | `drt/cli/commands/test.py` |
| `test_syncs` (`@app.command(name="test")`, ~113 LOC) | (same) |
| `_test_display_name` | (same) |

Total moved: **~440 LOC**.

## After

`drt/cli/main.py`: **595 → 166 LOC (-72%)**.

Of those 166 LOC, ~100 LOC are actual code (the rest are comments cataloguing where each command lives + the back-compat re-export block). The #573 target of \"~50-100 LOC of pure wiring\" is met for actual code lines.

The full split now reads:

| Phase | PR | main.py LOC after |
|---|---|---|
| Pre-split | — | 1706 |
| Phase 1 | #565 | (commands moved: doctor, list_syncs, …) |
| Phase 2a | #572 | 1706 → 1086 |
| Phase 2b PR (a) | #579 | 1086 → 595 |
| **Phase 2b PR (b)** | **this PR** | **595 → 166** |

## Back-compat

`drt.cli.main` re-exports the helpers + TypedDict so existing `from drt.cli.main import _print_history` / `_run_connection_test` / `_SyncTestResult` / `_test_display_name` / `_group_secret_findings` keep working — same shim pattern as PR (a)'s run.py move.

```python
from drt.cli.commands.status import _print_history
from drt.cli.commands.test import _SyncTestResult, _test_display_name
from drt.cli.commands.validate import (
    _group_secret_findings,
    _run_connection_test,
)
```

## Acceptance criteria

- [x] `validate` / `status` / `test` all moved to `drt/cli/commands/`
- [x] `cli/main.py` shrinks (-72%; ~100 LOC of actual code in wiring)
- [x] Back-compat re-exports for all underscore-prefixed names + the `_SyncTestResult` TypedDict
- [x] `make test`: **1259 passed, 1 skipped**
- [x] `make lint`: clean (114 source files; ruff + mypy)
- [x] CLI surfaces unchanged: `drt run` / `drt validate` / `drt status` / `drt test` all show identical help text
- [ ] CI green on 3.10 / 3.11 / 3.12 / 3.13

## What's left in main.py

```text
~100 LOC of actual code:
  _resolve_profile_name   (~12 LOC — still used by drt/integrations/_runner.py
                                     and tests/unit/test_cli_profile_override.py;
                                     could be a one-line shim itself in a follow-up)
  version_callback        (~20 LOC)
  main + @app.callback    (~8 LOC)
  _get_source / _get_watermark_storage / _get_destination shims (~20 LOC,
    from PR #572 — re-export helpers from drt.cli._helpers)
  re-exports from commands.run + .validate + .status + .test (~20 LOC)
```

A future \"tighten main.py\" cleanup could compress `_resolve_profile_name` into a one-line shim like `_get_source`. Out of scope here to keep this PR's diff focused on the move.

## References

- Umbrella: #573 (this PR closes it)
- Master split issue: #546 (Phase 1 #565, Phase 2a #572, Phase 2b PR (a) #579, this PR)
- Related #577 LogFormat Enum: #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)