### PR TITLE
feat(destinations): add Mixpanel destination (profiles + events)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Copy the files from `.claude/commands/` into your drt project's `.claude/command
 | HubSpot                 | ✅ v0.1   | (core)                             | Token (env var)                   |
 | Zendesk                 | ✅ v0.7   | (core)                             | Basic (email + API token)         |
 | Amplitude               | ✅ v0.7   | (core)                             | Project API key (env var)         |
+| Mixpanel                | ✅ v0.8   | (core)                             | Project token / service account   |
 | Google Ads              | ✅ v0.6   | (core)                             | OAuth2 Client Credentials         |
 | Google Sheets           | ✅ v0.4   | `pip install drt-core[sheets]`     | Service Account Keyfile           |
 | PostgreSQL (upsert)     | ✅ v0.4   | `pip install drt-core[postgres]`   | Password (env var)                |

--- a/docs/connectors/mixpanel.md
+++ b/docs/connectors/mixpanel.md
@@ -1,0 +1,87 @@
+# Mixpanel Destination
+
+> Sync user profiles or events from your warehouse to Mixpanel via the
+> `/engage` (profile-set) or `/import` (events) APIs.
+
+## YAML Example — user profiles (people_set)
+
+```yaml
+destination:
+  type: mixpanel
+  endpoint: people_set
+  project_token_env: MIXPANEL_TOKEN
+  distinct_id_field: user_id
+  properties_template: |
+    {
+      "plan": "{{ row.plan }}",
+      "signup_source": "{{ row.source }}"
+    }
+```
+
+## YAML Example — events (import)
+
+```yaml
+destination:
+  type: mixpanel
+  endpoint: import_events
+  project_id: "1234567"
+  service_account_username_env: MIXPANEL_SA_USERNAME
+  service_account_secret_env: MIXPANEL_SA_SECRET
+  distinct_id_field: user_id
+  event_name: signup_completed
+  time_field: event_time
+```
+
+## Configuration
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `type` | `"mixpanel"` | — | Required |
+| `endpoint` | `people_set\|import_events` | `people_set` | `/engage` profile-set or `/import` events |
+| `region` | `default\|eu` | `default` | API region (`api.mixpanel.com` vs `api-eu.mixpanel.com`) |
+| `project_token` | string \| null | null | Project token for `people_set` (direct value) |
+| `project_token_env` | string \| null | `MIXPANEL_TOKEN` | Env var containing the project token |
+| `project_id` | string \| null | null | Numeric project id, required for `import_events` |
+| `service_account_username` | string \| null | null | Service account username for `import_events` |
+| `service_account_username_env` | string \| null | `MIXPANEL_SA_USERNAME` | Env var containing the service account username |
+| `service_account_secret` | string \| null | null | Service account secret for `import_events` |
+| `service_account_secret_env` | string \| null | `MIXPANEL_SA_SECRET` | Env var containing the service account secret |
+| `distinct_id_field` | string | `distinct_id` | Source column for the Mixpanel distinct id |
+| `event_name_field` | string \| null | null | Source column for the event name (`import_events`) |
+| `event_name` | string \| null | null | Constant event name (alternative to `event_name_field`) |
+| `time_field` | string \| null | null | Source column for event `time` (Unix seconds); defaults to now |
+| `insert_id_field` | string \| null | null | Source column for `$insert_id`; derived deterministically if unset |
+| `properties_template` | string \| null | null | Jinja2 template rendering a JSON object merged into the profile `$set` or the event properties |
+| `batch_size` | int | `2000` | Records per API request (clamped to 1–2000, Mixpanel's limit) |
+| `retry` | RetryConfig \| null | null | Destination-level retry override |
+
+## Authentication
+
+**`people_set`** uses your **project token** (Mixpanel **Settings →
+Project Settings**), carried inside each record — no auth header:
+
+```bash
+export MIXPANEL_TOKEN="your-project-token"
+```
+
+**`import_events`** uses a **service account** (Mixpanel **Organization
+Settings → Service Accounts**) plus the numeric `project_id`:
+
+```bash
+export MIXPANEL_SA_USERNAME="your-service-account.mp-service-account"
+export MIXPANEL_SA_SECRET="your-service-account-secret"
+```
+
+## Notes
+
+- Both endpoints batch up to **2000 records** per request.
+- For `import_events`, each event gets a deterministic `$insert_id`
+  (derived from the row contents when `insert_id_field` is unset), so
+  re-running the same sync does **not** double-count events in Mixpanel.
+- EU data residency: set `region: eu` to route to
+  `api-eu.mixpanel.com`.
+
+## References
+
+- [Set profile properties (`/engage`)](https://developer.mixpanel.com/reference/profile-set)
+- [Import events (`/import`)](https://developer.mixpanel.com/reference/import-events)

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -291,6 +291,73 @@ class AmplitudeDestinationConfig(BaseModel):
         return max(1, min(value, 1000))
 
 
+class MixpanelDestinationConfig(BaseModel):
+    type: Literal["mixpanel"]
+    # endpoint selects which Mixpanel API to target:
+    #   people_set    -> /engage#profile-set (auth: project token, per-record)
+    #   import_events -> /import             (auth: service account + project_id)
+    endpoint: Literal["people_set", "import_events"] = "people_set"
+    region: Literal["default", "eu"] = "default"
+
+    # people_set auth — project token
+    project_token: str | None = None
+    project_token_env: str | None = "MIXPANEL_TOKEN"
+
+    # import_events auth — service account + numeric project id
+    project_id: str | None = None
+    service_account_username: str | None = None
+    service_account_username_env: str | None = "MIXPANEL_SA_USERNAME"
+    service_account_secret: str | None = None
+    service_account_secret_env: str | None = "MIXPANEL_SA_SECRET"
+
+    # field mapping
+    distinct_id_field: str = "distinct_id"
+    event_name_field: str | None = None  # import_events: per-row event name
+    event_name: str | None = None  # import_events: constant event name
+    time_field: str | None = None  # import_events: row field for event time
+    insert_id_field: str | None = None  # import_events: dedup id (else derived)
+    properties_template: str | None = None
+
+    batch_size: int = 2000
+    retry: RetryConfig | None = None
+
+    def describe(self) -> str:
+        return f"{self.type} ({self.endpoint}, {self.region})"
+
+    @model_validator(mode="after")
+    def _check_auth(self) -> MixpanelDestinationConfig:
+        if self.endpoint == "people_set":
+            if not self.project_token and not self.project_token_env:
+                raise ValueError(
+                    "project_token or project_token_env is required for endpoint 'people_set'."
+                )
+        else:  # import_events
+            if not self.project_id:
+                raise ValueError("project_id is required for endpoint 'import_events'.")
+            has_user = self.service_account_username or self.service_account_username_env
+            has_secret = self.service_account_secret or self.service_account_secret_env
+            if not has_user or not has_secret:
+                raise ValueError(
+                    "service account credentials (username + secret, or their *_env "
+                    "vars) are required for endpoint 'import_events'."
+                )
+        return self
+
+    @model_validator(mode="after")
+    def _check_event_name(self) -> MixpanelDestinationConfig:
+        if self.endpoint == "import_events" and not self.event_name and not self.event_name_field:
+            raise ValueError(
+                "event_name or event_name_field is required when endpoint is 'import_events'."
+            )
+        return self
+
+    @field_validator("batch_size", mode="after")
+    @classmethod
+    def _clamp_batch_size(cls, value: int) -> int:
+        # Mixpanel caps both /engage and /import at 2000 records per request.
+        return max(1, min(value, 2000))
+
+
 class IntercomDestinationConfig(BaseModel):
     type: Literal["intercom"]
 
@@ -688,6 +755,7 @@ DestinationConfig = Annotated[
     | HubSpotDestinationConfig
     | ZendeskDestinationConfig
     | AmplitudeDestinationConfig
+    | MixpanelDestinationConfig
     | SendGridDestinationConfig
     | LinearDestinationConfig
     | GoogleSheetsDestinationConfig

--- a/drt/connectors/registry.py
+++ b/drt/connectors/registry.py
@@ -153,6 +153,7 @@ def _register_all_connectors() -> None:
         IntercomDestinationConfig,
         JiraDestinationConfig,
         LinearDestinationConfig,
+        MixpanelDestinationConfig,
         MySQLDestinationConfig,
         NotionDestinationConfig,
         ParquetDestinationConfig,
@@ -181,6 +182,7 @@ def _register_all_connectors() -> None:
     from drt.destinations.intercom import IntercomDestination
     from drt.destinations.jira import JiraDestination
     from drt.destinations.linear import LinearDestination
+    from drt.destinations.mixpanel import MixpanelDestination
     from drt.destinations.mysql import MySQLDestination
     from drt.destinations.notion import NotionDestination
     from drt.destinations.parquet import ParquetDestination
@@ -216,6 +218,7 @@ def _register_all_connectors() -> None:
     register_destination("github_actions", GitHubActionsDestinationConfig, GitHubActionsDestination)
     register_destination("hubspot", HubSpotDestinationConfig, HubSpotDestination)
     register_destination("amplitude", AmplitudeDestinationConfig, AmplitudeDestination)
+    register_destination("mixpanel", MixpanelDestinationConfig, MixpanelDestination)
     register_destination("zendesk", ZendeskDestinationConfig, ZendeskDestination)
     register_destination("jira", JiraDestinationConfig, JiraDestination)
     register_destination("sendgrid", SendGridDestinationConfig, SendGridDestination)

--- a/drt/destinations/mixpanel.py
+++ b/drt/destinations/mixpanel.py
@@ -264,7 +264,7 @@ def _build_event(record: dict[str, Any], config: MixpanelDestinationConfig) -> d
     if config.time_field:
         time_value = record.get(config.time_field)
         if _has_value(time_value):
-            event_time = int(time_value)
+            event_time = int(str(time_value))
 
     properties: dict[str, Any] = {
         "distinct_id": str(distinct_id),
@@ -331,7 +331,12 @@ def _post_json(
     params: dict[str, str] | None = None,
 ) -> None:
     def do_post() -> httpx.Response:
-        response = client.post(url, json=payload, auth=auth, params=params)
+        kwargs: dict[str, Any] = {"json": payload}
+        if auth is not None:
+            kwargs["auth"] = auth
+        if params is not None:
+            kwargs["params"] = params
+        response = client.post(url, **kwargs)
         response.raise_for_status()
         return response
 

--- a/drt/destinations/mixpanel.py
+++ b/drt/destinations/mixpanel.py
@@ -1,0 +1,364 @@
+"""Mixpanel destination — sync user profiles and events via HTTP APIs.
+
+Two endpoints, selected by ``endpoint`` in the config:
+
+* ``people_set``    -> ``/engage#profile-set``. Sets user-profile
+  properties. Authenticated by the project token, which Mixpanel
+  carries inside each record (no auth header).
+* ``import_events`` -> ``/import``. Ingests events. Authenticated by a
+  service account (HTTP Basic) plus the numeric ``project_id`` query
+  parameter.
+
+Both batch up to 2000 records per request (Mixpanel's limit) and
+support EU data residency (``api-eu.mixpanel.com``). No extra
+dependencies beyond core httpx.
+
+Docs:
+* https://developer.mixpanel.com/reference/profile-set
+* https://developer.mixpanel.com/reference/import-events
+
+Example sync YAML — profile set:
+
+    destination:
+      type: mixpanel
+      endpoint: people_set
+      project_token_env: MIXPANEL_TOKEN
+      distinct_id_field: user_id
+      properties_template: |
+        {"plan": "{{ row.plan }}", "signup_source": "{{ row.source }}"}
+
+Example sync YAML — event import:
+
+    destination:
+      type: mixpanel
+      endpoint: import_events
+      project_id: "1234567"
+      service_account_username_env: MIXPANEL_SA_USERNAME
+      service_account_secret_env: MIXPANEL_SA_SECRET
+      distinct_id_field: user_id
+      event_name: signup_completed
+      time_field: event_time
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from collections.abc import Iterator
+from typing import Any
+
+import httpx
+
+from drt.config.credentials import resolve_env
+from drt.config.models import (
+    DestinationConfig,
+    MixpanelDestinationConfig,
+    RetryConfig,
+    SyncOptions,
+)
+from drt.destinations.base import SyncResult
+from drt.destinations.rate_limiter import RateLimiter
+from drt.destinations.retry import resolve_retry, with_retry
+from drt.destinations.row_errors import RowError
+from drt.templates.renderer import render_template
+
+_MIXPANEL_HOSTS = {
+    "default": "https://api.mixpanel.com",
+    "eu": "https://api-eu.mixpanel.com",
+}
+
+# Keys consumed by mapping config rather than passed through as properties.
+_PEOPLE_RESERVED = frozenset({"$token", "$distinct_id", "$set"})
+
+
+class MixpanelDestination:
+    """Send sync records to Mixpanel's /engage (profiles) or /import (events) APIs."""
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        assert isinstance(config, MixpanelDestinationConfig)
+        if not records:
+            return SyncResult()
+
+        base_url = _MIXPANEL_HOSTS[config.region]
+        retry_config = resolve_retry(config.retry, sync_options)
+        rate_limiter = RateLimiter(sync_options.rate_limit.requests_per_second)
+        result = SyncResult()
+
+        if config.endpoint == "people_set":
+            self._load_people(
+                records, config, sync_options, base_url, retry_config, rate_limiter, result
+            )
+        else:
+            self._load_events(
+                records, config, sync_options, base_url, retry_config, rate_limiter, result
+            )
+
+        return result
+
+    # -- /engage#profile-set -------------------------------------------------
+
+    def _load_people(
+        self,
+        records: list[dict[str, Any]],
+        config: MixpanelDestinationConfig,
+        sync_options: SyncOptions,
+        base_url: str,
+        retry_config: RetryConfig,
+        rate_limiter: RateLimiter,
+        result: SyncResult,
+    ) -> None:
+        token = resolve_env(config.project_token, config.project_token_env)
+        if not token:
+            raise ValueError(
+                "Mixpanel destination (people_set): provide project_token or set the "
+                f"env var named in project_token_env ({config.project_token_env!r})."
+            )
+        url = f"{base_url}/engage"
+
+        indexed = self._build_payloads(
+            records, config, result, sync_options, lambda r: _build_profile(r, config, token)
+        )
+        if not indexed:
+            return
+
+        with httpx.Client(timeout=30.0) as client:
+            for chunk in _chunks(indexed, config.batch_size):
+                payloads = [p for _, _, p in chunk]
+                self._post_chunk(
+                    chunk,
+                    result,
+                    sync_options,
+                    rate_limiter,
+                    lambda: _post_json(client, url, payloads, retry_config),
+                )
+
+    # -- /import -------------------------------------------------------------
+
+    def _load_events(
+        self,
+        records: list[dict[str, Any]],
+        config: MixpanelDestinationConfig,
+        sync_options: SyncOptions,
+        base_url: str,
+        retry_config: RetryConfig,
+        rate_limiter: RateLimiter,
+        result: SyncResult,
+    ) -> None:
+        username = resolve_env(config.service_account_username, config.service_account_username_env)
+        secret = resolve_env(config.service_account_secret, config.service_account_secret_env)
+        if not username or not secret:
+            raise ValueError(
+                "Mixpanel destination (import_events): provide service account "
+                "username + secret (or their *_env vars)."
+            )
+        url = f"{base_url}/import"
+        auth = (username, secret)
+        params = {"project_id": str(config.project_id)}
+
+        indexed = self._build_payloads(
+            records, config, result, sync_options, lambda r: _build_event(r, config)
+        )
+        if not indexed:
+            return
+
+        with httpx.Client(timeout=30.0) as client:
+            for chunk in _chunks(indexed, config.batch_size):
+                payloads = [p for _, _, p in chunk]
+                self._post_chunk(
+                    chunk,
+                    result,
+                    sync_options,
+                    rate_limiter,
+                    lambda: _post_json(
+                        client, url, payloads, retry_config, auth=auth, params=params
+                    ),
+                )
+
+    # -- shared --------------------------------------------------------------
+
+    def _build_payloads(
+        self,
+        records: list[dict[str, Any]],
+        config: MixpanelDestinationConfig,
+        result: SyncResult,
+        sync_options: SyncOptions,
+        builder: Any,
+    ) -> list[tuple[int, dict[str, Any], dict[str, Any]]]:
+        indexed: list[tuple[int, dict[str, Any], dict[str, Any]]] = []
+        for index, record in enumerate(records):
+            try:
+                indexed.append((index, record, builder(record)))
+            except Exception as e:  # noqa: BLE001 - row-level error capture
+                _add_row_error(result, index, record, None, str(e))
+                if sync_options.on_error == "fail":
+                    return []
+        return indexed
+
+    def _post_chunk(
+        self,
+        chunk: list[tuple[int, dict[str, Any], dict[str, Any]]],
+        result: SyncResult,
+        sync_options: SyncOptions,
+        rate_limiter: RateLimiter,
+        do_post: Any,
+    ) -> bool:
+        """POST one chunk; record success/row-errors. Returns False to stop."""
+        try:
+            rate_limiter.acquire()
+            do_post()
+            result.success += len(chunk)
+        except httpx.HTTPStatusError as e:
+            for index, record, _ in chunk:
+                _add_row_error(result, index, record, e.response.status_code, e.response.text[:500])
+            if sync_options.on_error == "fail":
+                return False
+        except Exception as e:  # noqa: BLE001 - chunk-level error capture
+            for index, record, _ in chunk:
+                _add_row_error(result, index, record, None, str(e))
+            if sync_options.on_error == "fail":
+                return False
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Payload builders
+# ---------------------------------------------------------------------------
+
+
+def _build_profile(
+    record: dict[str, Any], config: MixpanelDestinationConfig, token: str
+) -> dict[str, Any]:
+    distinct_id = record.get(config.distinct_id_field)
+    if not _has_value(distinct_id):
+        raise ValueError(f"Row must include distinct_id field {config.distinct_id_field!r}.")
+
+    properties = _row_properties(record, config, reserved=_PEOPLE_RESERVED)
+    if config.properties_template:
+        properties.update(_render_properties_template(config.properties_template, record))
+
+    return {
+        "$token": token,
+        "$distinct_id": str(distinct_id),
+        "$set": properties,
+    }
+
+
+def _build_event(record: dict[str, Any], config: MixpanelDestinationConfig) -> dict[str, Any]:
+    distinct_id = record.get(config.distinct_id_field)
+    if not _has_value(distinct_id):
+        raise ValueError(f"Row must include distinct_id field {config.distinct_id_field!r}.")
+
+    event_name = config.event_name
+    if config.event_name_field:
+        event_name = record.get(config.event_name_field)
+    if not _has_value(event_name):
+        raise ValueError("Row must include an event name.")
+
+    event_time = int(time.time())
+    if config.time_field:
+        time_value = record.get(config.time_field)
+        if _has_value(time_value):
+            event_time = int(time_value)
+
+    properties: dict[str, Any] = {
+        "distinct_id": str(distinct_id),
+        "time": event_time,
+        "$insert_id": _resolve_insert_id(record, config, str(event_name)),
+    }
+    properties.update(_row_properties(record, config, reserved=frozenset()))
+    if config.properties_template:
+        properties.update(_render_properties_template(config.properties_template, record))
+
+    return {"event": str(event_name), "properties": properties}
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors amplitude.py idioms)
+# ---------------------------------------------------------------------------
+
+
+def _row_properties(
+    record: dict[str, Any], config: MixpanelDestinationConfig, reserved: frozenset[str]
+) -> dict[str, Any]:
+    excluded = {config.distinct_id_field}
+    for f in (config.event_name_field, config.time_field, config.insert_id_field):
+        if f:
+            excluded.add(f)
+    out: dict[str, Any] = {}
+    for key, value in record.items():
+        if key in excluded or key in reserved or value is None:
+            continue
+        out[key] = value
+    return out
+
+
+def _has_value(value: Any) -> bool:
+    return value is not None and str(value).strip() != ""
+
+
+def _resolve_insert_id(
+    record: dict[str, Any], config: MixpanelDestinationConfig, event_name: str
+) -> str:
+    if config.insert_id_field:
+        value = record.get(config.insert_id_field)
+        if _has_value(value):
+            return str(value)
+    # Deterministic so a re-run of the same sync does not double-count events.
+    canonical = json.dumps(record, sort_keys=True, default=str)
+    return hashlib.sha256(f"{canonical}:{event_name}".encode()).hexdigest()[:32]
+
+
+def _render_properties_template(template: str, record: dict[str, Any]) -> dict[str, Any]:
+    rendered = render_template(template, record)
+    data = json.loads(rendered)
+    if not isinstance(data, dict):
+        raise ValueError("properties_template must render a JSON object.")
+    return data
+
+
+def _post_json(
+    client: httpx.Client,
+    url: str,
+    payload: list[dict[str, Any]],
+    retry_config: RetryConfig,
+    auth: tuple[str, str] | None = None,
+    params: dict[str, str] | None = None,
+) -> None:
+    def do_post() -> httpx.Response:
+        response = client.post(url, json=payload, auth=auth, params=params)
+        response.raise_for_status()
+        return response
+
+    with_retry(do_post, retry_config)
+
+
+def _chunks(
+    records: list[tuple[int, dict[str, Any], dict[str, Any]]],
+    size: int,
+) -> Iterator[list[tuple[int, dict[str, Any], dict[str, Any]]]]:
+    for start in range(0, len(records), size):
+        yield records[start : start + size]
+
+
+def _add_row_error(
+    result: SyncResult,
+    index: int,
+    record: dict[str, Any],
+    http_status: int | None,
+    message: str,
+) -> None:
+    result.failed += 1
+    result.row_errors.append(
+        RowError(
+            batch_index=index,
+            record_preview=json.dumps(record, default=str)[:200],
+            http_status=http_status,
+            error_message=message,
+        )
+    )

--- a/tests/unit/test_mixpanel_destination.py
+++ b/tests/unit/test_mixpanel_destination.py
@@ -132,7 +132,8 @@ class TestPeopleSet:
         _, kwargs = client.post.call_args
         url = client.post.call_args[0][0] if client.post.call_args[0] else kwargs.get("url")
         assert url.endswith("/engage")
-        assert kwargs["auth"] is None
+        # people_set carries auth in the record ($token), so no HTTP auth is sent
+        assert "auth" not in kwargs
         body = kwargs["json"]
         assert body[0]["$token"] == "test-token"
         assert body[0]["$distinct_id"] == "u0"

--- a/tests/unit/test_mixpanel_destination.py
+++ b/tests/unit/test_mixpanel_destination.py
@@ -131,7 +131,7 @@ class TestPeopleSet:
         assert result.failed == 0
         _, kwargs = client.post.call_args
         url = client.post.call_args[0][0] if client.post.call_args[0] else kwargs.get("url")
-        assert url.endswith("/engage")
+        assert url == "https://api.mixpanel.com/engage"
         # people_set carries auth in the record ($token), so no HTTP auth is sent
         assert "auth" not in kwargs
         body = kwargs["json"]
@@ -150,7 +150,7 @@ class TestPeopleSet:
             MixpanelDestination().load(_records(1), config, _options())
 
         url = client.post.call_args[0][0]
-        assert "api-eu.mixpanel.com" in url
+        assert url == "https://api-eu.mixpanel.com/engage"
 
     def test_missing_distinct_id_is_row_error(self) -> None:
         config = _people_config()
@@ -178,7 +178,7 @@ class TestImportEvents:
         assert result.success == 1
         _, kwargs = client.post.call_args
         url = client.post.call_args[0][0]
-        assert url.endswith("/import")
+        assert url == "https://api.mixpanel.com/import"
         assert kwargs["auth"] == ("svc", "secret")
         assert kwargs["params"] == {"project_id": "1234567"}
         event = kwargs["json"][0]

--- a/tests/unit/test_mixpanel_destination.py
+++ b/tests/unit/test_mixpanel_destination.py
@@ -1,0 +1,257 @@
+"""Unit tests for the Mixpanel destination (people_set + import_events)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from drt.config.models import (
+    MixpanelDestinationConfig,
+    RateLimitConfig,
+    RetryConfig,
+    SyncOptions,
+)
+from drt.destinations.mixpanel import MixpanelDestination
+
+
+def _people_config(**overrides: object) -> MixpanelDestinationConfig:
+    data: dict[str, object] = {
+        "type": "mixpanel",
+        "endpoint": "people_set",
+        "project_token": "test-token",
+        "distinct_id_field": "user_id",
+    }
+    data.update(overrides)
+    return MixpanelDestinationConfig(**data)
+
+
+def _event_config(**overrides: object) -> MixpanelDestinationConfig:
+    data: dict[str, object] = {
+        "type": "mixpanel",
+        "endpoint": "import_events",
+        "project_id": "1234567",
+        "service_account_username": "svc",
+        "service_account_secret": "secret",
+        "distinct_id_field": "user_id",
+        "event_name": "signup_completed",
+    }
+    data.update(overrides)
+    return MixpanelDestinationConfig(**data)
+
+
+def _options(**overrides: object) -> SyncOptions:
+    data: dict[str, object] = {
+        "rate_limit": RateLimitConfig(requests_per_second=0),
+        "retry": RetryConfig(max_attempts=1, initial_backoff=0.0, backoff_multiplier=1.0),
+        "on_error": "skip",
+    }
+    data.update(overrides)
+    return SyncOptions(**data)
+
+
+def _response(status_code: int = 200, text: str = "1") -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = text
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _http_error(status_code: int, text: str) -> httpx.HTTPStatusError:
+    response = httpx.Response(
+        status_code=status_code,
+        text=text,
+        request=httpx.Request("POST", "https://api.mixpanel.com/engage"),
+    )
+    return httpx.HTTPStatusError(
+        message=f"HTTP {status_code}", request=response.request, response=response
+    )
+
+
+def _records(n: int) -> list[dict[str, Any]]:
+    return [{"user_id": f"u{i}", "plan": "pro", "source": "web"} for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidation:
+    def test_people_requires_token(self) -> None:
+        with pytest.raises(ValueError, match="project_token"):
+            MixpanelDestinationConfig(
+                type="mixpanel", endpoint="people_set", project_token_env=None
+            )
+
+    def test_import_requires_project_id(self) -> None:
+        with pytest.raises(ValueError, match="project_id"):
+            MixpanelDestinationConfig(
+                type="mixpanel",
+                endpoint="import_events",
+                service_account_username="u",
+                service_account_secret="s",
+                event_name="x",
+            )
+
+    def test_import_requires_event_name(self) -> None:
+        with pytest.raises(ValueError, match="event_name"):
+            MixpanelDestinationConfig(
+                type="mixpanel",
+                endpoint="import_events",
+                project_id="1",
+                service_account_username="u",
+                service_account_secret="s",
+            )
+
+    def test_batch_size_clamped_to_2000(self) -> None:
+        assert _people_config(batch_size=9000).batch_size == 2000
+        assert _people_config(batch_size=0).batch_size == 1
+
+
+# ---------------------------------------------------------------------------
+# people_set (/engage)
+# ---------------------------------------------------------------------------
+
+
+class TestPeopleSet:
+    def test_profile_payload_shape(self) -> None:
+        config = _people_config()
+        with patch("drt.destinations.mixpanel.httpx.Client") as mock_cls:
+            client = MagicMock()
+            mock_cls.return_value.__enter__.return_value = client
+            client.post.return_value = _response()
+
+            result = MixpanelDestination().load(_records(2), config, _options())
+
+        assert result.success == 2
+        assert result.failed == 0
+        _, kwargs = client.post.call_args
+        url = client.post.call_args[0][0] if client.post.call_args[0] else kwargs.get("url")
+        assert url.endswith("/engage")
+        assert kwargs["auth"] is None
+        body = kwargs["json"]
+        assert body[0]["$token"] == "test-token"
+        assert body[0]["$distinct_id"] == "u0"
+        assert body[0]["$set"] == {"plan": "pro", "source": "web"}
+        assert "user_id" not in body[0]["$set"]
+
+    def test_eu_residency_host(self) -> None:
+        config = _people_config(region="eu")
+        with patch("drt.destinations.mixpanel.httpx.Client") as mock_cls:
+            client = MagicMock()
+            mock_cls.return_value.__enter__.return_value = client
+            client.post.return_value = _response()
+
+            MixpanelDestination().load(_records(1), config, _options())
+
+        url = client.post.call_args[0][0]
+        assert "api-eu.mixpanel.com" in url
+
+    def test_missing_distinct_id_is_row_error(self) -> None:
+        config = _people_config()
+        result = MixpanelDestination().load([{"plan": "pro"}], config, _options())
+        assert result.success == 0
+        assert result.failed == 1
+        assert "distinct_id" in result.row_errors[0].error_message
+
+
+# ---------------------------------------------------------------------------
+# import_events (/import)
+# ---------------------------------------------------------------------------
+
+
+class TestImportEvents:
+    def test_event_payload_shape(self) -> None:
+        config = _event_config()
+        with patch("drt.destinations.mixpanel.httpx.Client") as mock_cls:
+            client = MagicMock()
+            mock_cls.return_value.__enter__.return_value = client
+            client.post.return_value = _response()
+
+            result = MixpanelDestination().load(_records(1), config, _options())
+
+        assert result.success == 1
+        _, kwargs = client.post.call_args
+        url = client.post.call_args[0][0]
+        assert url.endswith("/import")
+        assert kwargs["auth"] == ("svc", "secret")
+        assert kwargs["params"] == {"project_id": "1234567"}
+        event = kwargs["json"][0]
+        assert event["event"] == "signup_completed"
+        props = event["properties"]
+        assert props["distinct_id"] == "u0"
+        assert "time" in props
+        assert "$insert_id" in props
+
+    def test_insert_id_is_deterministic(self) -> None:
+        config = _event_config(time_field="event_time")
+        rows = [{"user_id": "u1", "event_time": 1700000000, "plan": "pro"}]
+        captured: list[Any] = []
+
+        def run() -> None:
+            with patch("drt.destinations.mixpanel.httpx.Client") as mock_cls:
+                client = MagicMock()
+                mock_cls.return_value.__enter__.return_value = client
+                client.post.return_value = _response()
+                MixpanelDestination().load(rows, config, _options())
+                captured.append(client.post.call_args[1]["json"][0]["properties"]["$insert_id"])
+
+        run()
+        run()
+        assert captured[0] == captured[1], "same row must yield the same $insert_id"
+
+    def test_time_field_used(self) -> None:
+        config = _event_config(time_field="event_time")
+        rows = [{"user_id": "u1", "event_time": 1700000000}]
+        with patch("drt.destinations.mixpanel.httpx.Client") as mock_cls:
+            client = MagicMock()
+            mock_cls.return_value.__enter__.return_value = client
+            client.post.return_value = _response()
+            MixpanelDestination().load(rows, config, _options())
+
+        assert client.post.call_args[1]["json"][0]["properties"]["time"] == 1700000000
+
+
+# ---------------------------------------------------------------------------
+# Batching + error handling (shared)
+# ---------------------------------------------------------------------------
+
+
+class TestBatchingAndErrors:
+    def test_batch_size_splits_requests(self) -> None:
+        config = _people_config(batch_size=2)
+        with patch("drt.destinations.mixpanel.httpx.Client") as mock_cls:
+            client = MagicMock()
+            mock_cls.return_value.__enter__.return_value = client
+            client.post.return_value = _response()
+
+            result = MixpanelDestination().load(_records(5), config, _options())
+
+        assert result.success == 5
+        assert client.post.call_count == 3  # ceil(5/2)
+
+    def test_http_error_records_row_errors(self) -> None:
+        config = _people_config(batch_size=1)
+        with patch("drt.destinations.mixpanel.httpx.Client") as mock_cls:
+            client = MagicMock()
+            mock_cls.return_value.__enter__.return_value = client
+            client.post.side_effect = _http_error(400, "bad request")
+
+            result = MixpanelDestination().load(_records(2), config, _options())
+
+        assert result.success == 0
+        assert result.failed == 2
+        assert result.row_errors[0].http_status == 400
+
+    def test_empty_records(self) -> None:
+        result = MixpanelDestination().load([], _people_config(), _options())
+        assert result.success == 0
+        assert result.failed == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What does this PR do?

Adds a **Mixpanel** reverse-ETL destination (closes #417) with the two endpoints from the issue scope, selected by `endpoint`:

- **`people_set`** (default) → `/engage#profile-set`. Sets user-profile properties; auth is the project token, carried inside each record (no header).
- **`import_events`** → `/import`. Ingests events; auth is a service account (HTTP Basic) + the numeric `project_id` query param.

Both batch up to **2000 records/request** (Mixpanel's limit) and support **EU residency** (`api-eu.mixpanel.com`). Modelled on the existing Amplitude destination and reuses the shared `RateLimiter` / `with_retry` / `SyncResult` / `RowError` plumbing — no new dependencies beyond httpx.

Event imports get a **deterministic `$insert_id`** (derived from the row when `insert_id_field` is unset) so re-running a sync doesn't double-count events.

## Config

```yaml
# profile set
destination:
  type: mixpanel
  endpoint: people_set
  project_token_env: MIXPANEL_TOKEN
  distinct_id_field: user_id

# event import
destination:
  type: mixpanel
  endpoint: import_events
  project_id: "1234567"
  service_account_username_env: MIXPANEL_SA_USERNAME
  service_account_secret_env: MIXPANEL_SA_SECRET
  event_name: signup_completed
  time_field: event_time
```

## Related Issue

Closes #417.

## How was this tested

- [x] 13 unit tests in `tests/unit/test_mixpanel_destination.py` — both endpoints, payload shapes (`$token`/`$distinct_id`/`$set` and `event`/`properties`), EU routing, service-account auth + `project_id` param, deterministic `$insert_id`, batch splitting, HTTP error → row errors, config validation. Run alongside the Amplitude suite: 31 passed.
- [x] `ruff check` + `ruff format` clean on all touched files.
- [x] Registry round-trip verified: `type: mixpanel` resolves to both config and destination class for each endpoint.

Wire format checked against Mixpanel's API reference ([profile-set](https://developer.mixpanel.com/reference/profile-set), [import-events](https://developer.mixpanel.com/reference/import-events)).

## Checklist

- [x] Tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Registry entries added (config union + `connectors/registry.py`)
- [x] Docs added (`docs/connectors/mixpanel.md` + README destination table)

Opening as a draft per my note on the issue — happy to adjust direction (config shape, endpoint naming, etc.) before final.
