### PR TITLE
docs(i18n): sync README.ja marker to v0.7.8 release commit

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-sync: base=README.md, hash=47e4c75c57ce465d83f387e990bdaa629072bd53 -->
+<!-- i18n-sync: base=README.md, hash=1771f756b351ca851e63f16d4815a39cfb5ebcb2 -->
 
 [English](./README.md) | [日本語](./README.ja.md)
 


### PR DESCRIPTION
## Summary

Post-v0.7.8 release housekeeping. The Japanese roadmap row for v0.7.8 was already added in #611 (release PR); this bumps the marker hash so `make check-i18n` reports green.

| File | From | To | Trigger |
|---|---|---|---|
| `README.ja.md` | 47e4c75 | 1771f75 | v0.7.8 release commit |

After this PR, `make check-i18n` passes:

```
OK    CONTRIBUTING.ja.md  (synced with CONTRIBUTING.md)
SKIP  GOVERNANCE.ja.md  (no i18n-sync marker)
OK    README.ja.md  (synced with README.md)
```

`[skip changelog]` — i18n marker bump, no behaviour.

## Test plan

- [x] `make check-i18n` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)