### PR TITLE
ci: upgrade pip before pip-audit scan (env vuln on hosted runner)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,11 @@ jobs:
         # vuln data is python-version-independent.
         if: matrix.python-version == '3.12'
         run: |
+          # GitHub-hosted runners may ship a pip version with a known OSV
+          # advisory (e.g. PYSEC-2026-196 against pip<26.1.2). Upgrade before
+          # scanning so the audit passes cleanly without contributor PRs
+          # tripping on environmental pip vulns unrelated to their changes.
+          pip install --upgrade "pip>=26.1.2"
           pip install "pip-audit==2.10.0"
           # Allow-list: pass `--ignore-vuln GHSA-xxxx` here when a finding is
           # triaged as a known false positive. Keep this list empty by default


### PR DESCRIPTION
> **Attribution note** — the diagnosis of the underlying pip-audit / pip-vuln issue, and the original fix this PR hoists, were entirely the work of **[@Muawiya-contact](https://github.com/Muawiya-contact)**. They surfaced the env failure on [#616](https://github.com/drt-hub/drt/pull/616) and bundled the workflow fix into their open PR [#615](https://github.com/drt-hub/drt/pull/615) (OTel Phase 2) before this hotfix was hoisted out. The Co-Authored-By trailer on the merge commit unfortunately used a placeholder email (`noreply@anthropic.com`) instead of their actual address (`contactmuawia@gmail.com`) — so GitHub doesn't link the commit to their profile and the contribution doesn't show up on their graph. The commit credit on `main` cannot be force-pushed safely now, so this note exists to make the attribution explicit and unambiguous: **the work belongs to @Muawiya-contact**, with co-author intent recorded on the commit, just under the wrong address.

## Why

GitHub-hosted runners are currently shipping `pip 26.1.1`, which has an open OSV advisory ([PYSEC-2026-196](https://osv.dev/PYSEC-2026-196)) with the fix in `pip 26.1.2`. Our pip-audit step runs with `--strict`, so this picks up as a CI failure on **the 3.12 matrix entry** for every contributor PR, even when the change has nothing to do with pip.

Surfaced by @Muawiya-contact on PR [#616](https://github.com/drt-hub/drt/pull/616) — a 1-line README URL fix that hit this failure unrelated to its actual content. They diagnosed the root cause and proactively bundled the fix into their open PR [#615](https://github.com/drt-hub/drt/pull/615) (OTel Phase 2). Hoisting it out as a standalone hotfix here so it can land independently and unblock other contributor PRs without waiting for the OTel review cycle.

## What

Upgrade pip to `>=26.1.2` immediately before pip-audit installs:

```yaml
# .github/workflows/ci.yml
if: matrix.python-version == '3.12'
run: |
  # GitHub-hosted runners may ship a pip version with a known OSV
  # advisory (e.g. PYSEC-2026-196 against pip<26.1.2). Upgrade before
  # scanning so the audit passes cleanly without contributor PRs
  # tripping on environmental pip vulns unrelated to their changes.
  pip install --upgrade "pip>=26.1.2"
  pip install "pip-audit==2.10.0"
```

Same shape and intent as the change Muawiya bundled into #615; co-author credit on the commit.

## After this merges

- [#616](https://github.com/drt-hub/drt/pull/616) — rebase + admin-merge cleanly (just the README URL change)
- [#615](https://github.com/drt-hub/drt/pull/615) — review focuses on the OTel implementation; the ci.yml change there becomes a no-op or can be dropped on rebase

`[skip changelog]` — CI-only fix, no behaviour or release-note impact.

## Test plan

- [ ] CI green on this PR (pip-audit step passes against `pip>=26.1.2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
