### PR TITLE
chore(skill): refresh /drt-init — catch up to v0.7+ sources + flows (2-month gap)

### DIFF
--- a/.claude/commands/drt-init.md
+++ b/.claude/commands/drt-init.md
@@ -3,51 +3,71 @@ Guide the user through initializing a new drt project.
 
 ## Steps
 
-1. Confirm the user has drt installed:
+1. Confirm drt is installed. Pick the install line for the user's source:
    ```bash
-   pip install drt-core[bigquery]   # BigQuery
-   # or
-   uv add drt-core[bigquery]
+   pip install drt-core                 # core (DuckDB / SQLite / REST API source — no extras)
+   pip install drt-core[bigquery]       # BigQuery source
+   pip install drt-core[postgres]       # Postgres / Redshift source
+   pip install drt-core[mysql]          # MySQL source
+   pip install drt-core[clickhouse]     # ClickHouse source
+   pip install drt-core[snowflake]      # Snowflake source
+   pip install drt-core[databricks]     # Databricks source
+   pip install drt-core[sqlserver]      # SQL Server source
    ```
+   (Or `uv add drt-core[...]` if the user prefers uv.)
 
-2. Create and enter a project directory:
+2. Pick the right starter shape. Two flows produce the same project skeleton:
+
+   **A) Template scaffolds (fastest, ~3 commands)** — best when the user just wants something running:
+   ```bash
+   mkdir my-drt-project && cd my-drt-project
+   drt init --template duckdb_to_rest        # DuckDB → REST API (no accounts needed, uses httpbin.org)
+   ```
+   Other templates:
+   ```bash
+   drt init --template list                  # see all available templates
+   drt init --template postgres_to_slack     # operational alerts
+   drt init --template duckdb_to_hubspot     # CRM-style upsert
+   ```
+   Each template prints next-steps for the env vars / source data it needs.
+
+   **B) Interactive wizard (guided)** — best when the user wants to be walked through a real warehouse setup:
    ```bash
    mkdir my-drt-project && cd my-drt-project
    drt init
    ```
-   `drt init` will prompt for:
-   - Project name
-   - Source type (bigquery / duckdb / sqlite / postgres / redshift / clickhouse)
-   - GCP project + dataset + location (if BigQuery)
-   - Auth method (Application Default Credentials or keyfile)
+   Prompts for project name, source type (any of: **bigquery / duckdb / sqlite / postgres / redshift / clickhouse / snowflake / mysql / databricks / sqlserver / rest_api**), source-specific connection fields, and auth method.
 
-3. This creates:
+   Either flow writes:
    ```
    my-drt-project/
    ├── drt_project.yml
-   └── syncs/
-       └── example_sync.yml
+   └── syncs/<name>.yml      # first sync, runnable
    ```
-   And writes credentials to `~/.drt/profiles.yml`.
+   plus credentials to `~/.drt/profiles.yml`.
 
-4. For BigQuery, ensure credentials are set up:
+3. Set up auth for the chosen source (only the relevant bullet):
+   - **BigQuery**: `gcloud auth application-default login` or `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json`
+   - **Postgres / Redshift / MySQL / ClickHouse / Snowflake / SQL Server**: set the password env var the profile references (e.g. `export DRT_PG_PASSWORD=...`)
+   - **Databricks**: set `DATABRICKS_TOKEN` (personal access token from Workspace → User Settings)
+   - **DuckDB / SQLite**: nothing — file path only
+   - **REST API source**: set the bearer token env var the profile references (e.g. `export REST_API_TOKEN=...`)
+
+4. Validate the setup:
    ```bash
-   gcloud auth application-default login
-   # or set GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
+   drt doctor       # env-level triage — catches missing env vars, malformed profile, etc.
+   drt validate     # YAML schema check
+   drt list         # confirm syncs are discovered
    ```
 
-5. Validate the setup:
-   ```bash
-   drt validate
-   drt list
-   ```
-
-6. Offer to create a first sync using the `drt-create-sync` skill.
+5. Offer to create a first sync using the `/drt-create-sync` skill.
 
 ## Tips
 
-- `drt_project.yml` selects which profile from `~/.drt/profiles.yml` to use
-- Put each sync in a separate `syncs/<name>.yml` file
-- Use `drt run --dry-run` to test without writing data
-- Use `drt status` to check recent run results
-- For non-US BigQuery datasets, set `location` in `profiles.yml` (e.g. `"EU"`, `"asia-northeast1"`)
+- `drt_project.yml` selects which profile from `~/.drt/profiles.yml` to use; override per-run with `--profile <name>` or `DRT_PROFILE`.
+- Put each sync in a separate `syncs/<name>.yml` file (sync discovery is glob-based).
+- `drt sources --detailed` and `drt destinations --detailed` print every connector's required env vars and a sample YAML stanza — useful when hand-authoring beyond the templates.
+- `drt run --dry-run` runs through the engine without writing data; `--dry-run --diff` previews record-level changes for queryable destinations.
+- `drt status` shows recent run results; `drt status --output json` is the CI-friendly form.
+- For non-US BigQuery datasets, set `location` in `profiles.yml` (e.g. `"EU"`, `"asia-northeast1"`).
+- Want to try drt without installing locally? Open the repo in GitHub Codespaces — the devcontainer ships drt + a seeded DuckDB warehouse + the `duckdb_to_rest` template pre-scaffolded.

--- a/skills/drt/skills/drt-init/SKILL.md
+++ b/skills/drt/skills/drt-init/SKILL.md
@@ -10,51 +10,71 @@ Guide the user through initializing a new drt project.
 
 ## Steps
 
-1. Confirm the user has drt installed:
+1. Confirm drt is installed. Pick the install line for the user's source:
    ```bash
-   pip install drt-core[bigquery]   # BigQuery
-   # or
-   uv add drt-core[bigquery]
+   pip install drt-core                 # core (DuckDB / SQLite / REST API source — no extras)
+   pip install drt-core[bigquery]       # BigQuery source
+   pip install drt-core[postgres]       # Postgres / Redshift source
+   pip install drt-core[mysql]          # MySQL source
+   pip install drt-core[clickhouse]     # ClickHouse source
+   pip install drt-core[snowflake]      # Snowflake source
+   pip install drt-core[databricks]     # Databricks source
+   pip install drt-core[sqlserver]      # SQL Server source
    ```
+   (Or `uv add drt-core[...]` if the user prefers uv.)
 
-2. Create and enter a project directory:
+2. Pick the right starter shape. Two flows produce the same project skeleton:
+
+   **A) Template scaffolds (fastest, ~3 commands)** — best when the user just wants something running:
+   ```bash
+   mkdir my-drt-project && cd my-drt-project
+   drt init --template duckdb_to_rest        # DuckDB → REST API (no accounts needed, uses httpbin.org)
+   ```
+   Other templates:
+   ```bash
+   drt init --template list                  # see all available templates
+   drt init --template postgres_to_slack     # operational alerts
+   drt init --template duckdb_to_hubspot     # CRM-style upsert
+   ```
+   Each template prints next-steps for the env vars / source data it needs.
+
+   **B) Interactive wizard (guided)** — best when the user wants to be walked through a real warehouse setup:
    ```bash
    mkdir my-drt-project && cd my-drt-project
    drt init
    ```
-   `drt init` will prompt for:
-   - Project name
-   - Source type (bigquery / duckdb / sqlite / postgres / redshift / clickhouse)
-   - GCP project + dataset + location (if BigQuery)
-   - Auth method (Application Default Credentials or keyfile)
+   Prompts for project name, source type (any of: **bigquery / duckdb / sqlite / postgres / redshift / clickhouse / snowflake / mysql / databricks / sqlserver / rest_api**), source-specific connection fields, and auth method.
 
-3. This creates:
+   Either flow writes:
    ```
    my-drt-project/
    ├── drt_project.yml
-   └── syncs/
-       └── example_sync.yml
+   └── syncs/<name>.yml      # first sync, runnable
    ```
-   And writes credentials to `~/.drt/profiles.yml`.
+   plus credentials to `~/.drt/profiles.yml`.
 
-4. For BigQuery, ensure credentials are set up:
+3. Set up auth for the chosen source (only the relevant bullet):
+   - **BigQuery**: `gcloud auth application-default login` or `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json`
+   - **Postgres / Redshift / MySQL / ClickHouse / Snowflake / SQL Server**: set the password env var the profile references (e.g. `export DRT_PG_PASSWORD=...`)
+   - **Databricks**: set `DATABRICKS_TOKEN` (personal access token from Workspace → User Settings)
+   - **DuckDB / SQLite**: nothing — file path only
+   - **REST API source**: set the bearer token env var the profile references (e.g. `export REST_API_TOKEN=...`)
+
+4. Validate the setup:
    ```bash
-   gcloud auth application-default login
-   # or set GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
+   drt doctor       # env-level triage — catches missing env vars, malformed profile, etc.
+   drt validate     # YAML schema check
+   drt list         # confirm syncs are discovered
    ```
 
-5. Validate the setup:
-   ```bash
-   drt validate
-   drt list
-   ```
-
-6. Offer to create a first sync using the `drt-create-sync` skill.
+5. Offer to create a first sync using the `/drt-create-sync` skill.
 
 ## Tips
 
-- `drt_project.yml` selects which profile from `~/.drt/profiles.yml` to use
-- Put each sync in a separate `syncs/<name>.yml` file
-- Use `drt run --dry-run` to test without writing data
-- Use `drt status` to check recent run results
-- For non-US BigQuery datasets, set `location` in `profiles.yml` (e.g. `"EU"`, `"asia-northeast1"`)
+- `drt_project.yml` selects which profile from `~/.drt/profiles.yml` to use; override per-run with `--profile <name>` or `DRT_PROFILE`.
+- Put each sync in a separate `syncs/<name>.yml` file (sync discovery is glob-based).
+- `drt sources --detailed` and `drt destinations --detailed` print every connector's required env vars and a sample YAML stanza — useful when hand-authoring beyond the templates.
+- `drt run --dry-run` runs through the engine without writing data; `--dry-run --diff` previews record-level changes for queryable destinations.
+- `drt status` shows recent run results; `drt status --output json` is the CI-friendly form.
+- For non-US BigQuery datasets, set `location` in `profiles.yml` (e.g. `"EU"`, `"asia-northeast1"`).
+- Want to try drt without installing locally? Open the repo in GitHub Codespaces — the devcontainer ships drt + a seeded DuckDB warehouse + the `duckdb_to_rest` template pre-scaffolded.


### PR DESCRIPTION
## Summary

`/drt-init` was last touched **2026-04-12** and had drifted behind the expanding source list and the new init flows. This PR catches it up.

Part 2 of the 4-PR skill refresh sequence (Part 1 = #625 /drt-debug).

## Drift fixed

| # | Feature | Skill update |
|---|---------|--------------|
| 1 | Sources list (6 → 11) | Was bigquery/duckdb/sqlite/postgres/redshift/clickhouse. Real `drt sources` adds **mysql**, **snowflake**, **databricks**, **sqlserver**, **rest_api** (#474) |
| 2 | `drt init --template <name>` (v0.7) | Skill now leads with template flow as path A; interactive wizard becomes path B |
| 3 | `drt doctor` (v0.7.0) | Added to validate step alongside `drt validate` / `drt list` |
| 4 | `drt sources --detailed` / `drt destinations --detailed` | Referenced in Tips as answer for "what env vars does this connector need" |
| 5 | `drt run --dry-run --diff` (#413) | Referenced in Tips |
| 6 | `drt status --output json` | Referenced in Tips for CI users |
| 7 | Codespaces playground (#407) | Added as a Tip for users trying drt without installing |
| 8 | Per-source install lines | Was BigQuery-only. Now enumerated per supported source |
| 9 | Per-source auth notes | Was BigQuery-only. Now includes Databricks, all SQL family, DuckDB / SQLite (no auth), REST API source |

## Structural changes

- **Step 1** now picks the install line BEFORE `drt init`, so the user doesn't hit "module not found" mid-wizard
- **Step 2** splits into flow A (template, fastest) vs flow B (interactive wizard) — matches the actual CLI shape
- **Step 4** swaps the order: `drt doctor` (env) → `drt validate` (config) → `drt list` (discovery)

## Verification

- [x] `make sync-skills` — synced to `.claude/commands/drt-init.md`
- [x] `make check-skills` — clean
- [x] Real `drt sources` / `drt init --template list` output cross-checked

## Sequence

1. ✅ /drt-debug refresh — #625
2. **This PR — /drt-init refresh**
3. /drt-migrate refresh (mirror / replace mode)
4. /drt-create-sync GCS+Azure follow-up (after #623 #624 merge)
5. MCP refresh: `drt_doctor` + `drt_run_sync(diff=True)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)