### PR TITLE
chore(skill): refresh /drt-migrate — add mirror/replace modes + post-v0.7 mappings

### DIFF
--- a/.claude/commands/drt-migrate.md
+++ b/.claude/commands/drt-migrate.md
@@ -5,7 +5,7 @@ Help the user migrate from an existing Reverse ETL tool (Census, Hightouch, Poly
 
 1. Ask the user to share their existing sync configuration (screenshot, YAML, JSON, or description).
 
-2. Map their existing config to drt equivalents using the table below.
+2. Map their existing config to drt equivalents using the tables below.
 
 3. Generate a valid `syncs/<name>.yml` for each sync.
 
@@ -19,19 +19,33 @@ Help the user migrate from an existing Reverse ETL tool (Census, Hightouch, Poly
 |---------------------------|----------------|
 | Source (BigQuery model) | `model: ref('table')` or raw SQL |
 | Destination connection | `destination.type` + auth config |
-| Sync behavior: Full | `sync.mode: full` |
-| Sync behavior: Append | `sync.mode: incremental` + `cursor_field` |
-| Field mappings | `body_template` / `properties_template` (Jinja2) |
-| Run schedule | `drt run` via cron or CI |
-| Error notifications | `on_error: skip` + `drt status` |
+| Sync behavior: Full | `sync.mode: full` (every run, no dedup) |
+| Sync behavior: Append (incremental) | `sync.mode: incremental` + `cursor_field` |
+| Sync behavior: Mirror (upsert + delete-removed) | `sync.mode: mirror` (v0.7.7+) + `upsert_key` — supported on postgres / mysql / clickhouse / snowflake |
+| Sync behavior: Replace (overwrite table) | `sync.mode: replace` (TRUNCATE + INSERT, zero-downtime via `replace_strategy: swap` on supported DWHs) |
+| Field mappings (UI column picker) | `body_template` / `properties_template` (Jinja2) |
+| Run schedule | `drt run` via cron, CI, Dagster, Airflow, or Prefect |
+| Error notifications | `failure_alerts` (Slack / webhook, v0.7.0+) — fires on sync-level failures |
+| Per-row error policy | `on_error: skip` (continue past failures) vs `on_error: fail` (stop at first) |
+
+### Sync-mode picking guide (which `sync.mode` matches the source semantic)
+
+| User wants | drt mode | Notes |
+|------------|----------|-------|
+| "Re-send everything every run" | `full` | Default. Idempotent destinations only — REST API / Slack / file outputs. |
+| "Append new rows since last run" | `incremental` + `cursor_field` | Watermark-based. `--cursor-value` overrides for backfill. |
+| "Upsert by key" | `upsert` + `upsert_key` | Census's most common "Update" shape. |
+| "Upsert by key AND delete rows removed from source" | `mirror` + `upsert_key` | Census's "Full Sync with Deletion" / Hightouch's "Mirror" semantic. v0.7.7+, SQL destinations. Source key cardinality fits in memory. |
+| "Overwrite the destination table each run" | `replace` | TRUNCATE + INSERT. Set `replace_strategy: swap` (Postgres / Snowflake) for zero-downtime via staging-table swap. |
 
 ### Auth migration
 
 | Old tool style | drt equivalent |
 |---------------|----------------|
-| Stored API key in UI | `token_env: MY_TOKEN` + `export MY_TOKEN=...` |
+| Stored API key in UI | `token_env: MY_TOKEN` + `export MY_TOKEN=...` (never hardcode — `drt validate` flags hardcoded secrets) |
 | OAuth app | Use token from OAuth flow → `token_env` |
 | Service account JSON | Set `GOOGLE_APPLICATION_CREDENTIALS` for BigQuery source |
+| Connection string | Source profile field in `~/.drt/profiles.yml` (env-var-substituted via `${VAR}`) |
 
 ## Output Format
 
@@ -48,14 +62,17 @@ destination:
   # ... fields
 
 sync:
-  mode: full   # or incremental
+  mode: full   # or incremental / upsert / mirror / replace
   # ...
 ```
 
 Then summarize:
 - What manual steps are needed (env vars, `~/.drt/profiles.yml`)
 - Any features the old tool had that drt doesn't support yet (flag these clearly)
+- Whether the migration changes semantics (e.g. Census "Full Sync with Deletion" → drt `mirror` is the same shape; Census "Full Sync without Deletion" → drt `full` keeps stale rows in the destination, so the user may want `upsert` instead)
 
 ## Reference
 
-See `docs/llm/API_REFERENCE.md` for all destination types and fields.
+- `docs/llm/API_REFERENCE.md` — all destination types and fields
+- `docs/connectors/` — per-destination details (auth, supported modes)
+- `examples/postgres_to_postgres_mirror/` — runnable example for the `mirror` mode shape

--- a/skills/drt/skills/drt-migrate/SKILL.md
+++ b/skills/drt/skills/drt-migrate/SKILL.md
@@ -12,7 +12,7 @@ Help the user migrate from an existing Reverse ETL tool (Census, Hightouch, Poly
 
 1. Ask the user to share their existing sync configuration (screenshot, YAML, JSON, or description).
 
-2. Map their existing config to drt equivalents using the table below.
+2. Map their existing config to drt equivalents using the tables below.
 
 3. Generate a valid `syncs/<name>.yml` for each sync.
 
@@ -26,19 +26,33 @@ Help the user migrate from an existing Reverse ETL tool (Census, Hightouch, Poly
 |---------------------------|----------------|
 | Source (BigQuery model) | `model: ref('table')` or raw SQL |
 | Destination connection | `destination.type` + auth config |
-| Sync behavior: Full | `sync.mode: full` |
-| Sync behavior: Append | `sync.mode: incremental` + `cursor_field` |
-| Field mappings | `body_template` / `properties_template` (Jinja2) |
-| Run schedule | `drt run` via cron or CI |
-| Error notifications | `on_error: skip` + `drt status` |
+| Sync behavior: Full | `sync.mode: full` (every run, no dedup) |
+| Sync behavior: Append (incremental) | `sync.mode: incremental` + `cursor_field` |
+| Sync behavior: Mirror (upsert + delete-removed) | `sync.mode: mirror` (v0.7.7+) + `upsert_key` — supported on postgres / mysql / clickhouse / snowflake |
+| Sync behavior: Replace (overwrite table) | `sync.mode: replace` (TRUNCATE + INSERT, zero-downtime via `replace_strategy: swap` on supported DWHs) |
+| Field mappings (UI column picker) | `body_template` / `properties_template` (Jinja2) |
+| Run schedule | `drt run` via cron, CI, Dagster, Airflow, or Prefect |
+| Error notifications | `failure_alerts` (Slack / webhook, v0.7.0+) — fires on sync-level failures |
+| Per-row error policy | `on_error: skip` (continue past failures) vs `on_error: fail` (stop at first) |
+
+### Sync-mode picking guide (which `sync.mode` matches the source semantic)
+
+| User wants | drt mode | Notes |
+|------------|----------|-------|
+| "Re-send everything every run" | `full` | Default. Idempotent destinations only — REST API / Slack / file outputs. |
+| "Append new rows since last run" | `incremental` + `cursor_field` | Watermark-based. `--cursor-value` overrides for backfill. |
+| "Upsert by key" | `upsert` + `upsert_key` | Census's most common "Update" shape. |
+| "Upsert by key AND delete rows removed from source" | `mirror` + `upsert_key` | Census's "Full Sync with Deletion" / Hightouch's "Mirror" semantic. v0.7.7+, SQL destinations. Source key cardinality fits in memory. |
+| "Overwrite the destination table each run" | `replace` | TRUNCATE + INSERT. Set `replace_strategy: swap` (Postgres / Snowflake) for zero-downtime via staging-table swap. |
 
 ### Auth migration
 
 | Old tool style | drt equivalent |
 |---------------|----------------|
-| Stored API key in UI | `token_env: MY_TOKEN` + `export MY_TOKEN=...` |
+| Stored API key in UI | `token_env: MY_TOKEN` + `export MY_TOKEN=...` (never hardcode — `drt validate` flags hardcoded secrets) |
 | OAuth app | Use token from OAuth flow → `token_env` |
 | Service account JSON | Set `GOOGLE_APPLICATION_CREDENTIALS` for BigQuery source |
+| Connection string | Source profile field in `~/.drt/profiles.yml` (env-var-substituted via `${VAR}`) |
 
 ## Output Format
 
@@ -55,14 +69,17 @@ destination:
   # ... fields
 
 sync:
-  mode: full   # or incremental
+  mode: full   # or incremental / upsert / mirror / replace
   # ...
 ```
 
 Then summarize:
 - What manual steps are needed (env vars, `~/.drt/profiles.yml`)
 - Any features the old tool had that drt doesn't support yet (flag these clearly)
+- Whether the migration changes semantics (e.g. Census "Full Sync with Deletion" → drt `mirror` is the same shape; Census "Full Sync without Deletion" → drt `full` keeps stale rows in the destination, so the user may want `upsert` instead)
 
 ## Reference
 
-See `docs/llm/API_REFERENCE.md` for all destination types and fields.
+- `docs/llm/API_REFERENCE.md` — all destination types and fields
+- `docs/connectors/` — per-destination details (auth, supported modes)
+- `examples/postgres_to_postgres_mirror/` — runnable example for the `mirror` mode shape


### PR DESCRIPTION
## Summary

`/drt-migrate` was last touched **2026-03-30** (#60) and had missed the sync-mode expansions that landed since. This PR catches it up.

Part 3 of the 4-PR skill refresh sequence (#625 /drt-debug, #626 /drt-init).

## Drift fixed

| # | Feature | Skill update |
|---|---------|--------------|
| 1 | `sync.mode: mirror` (v0.7.7) — Census "Full Sync with Deletion" / Hightouch "Mirror" | Added to concept map (postgres / mysql / clickhouse / snowflake) |
| 2 | `sync.mode: replace` + `replace_strategy: swap` | Added to concept map (zero-downtime on Postgres / Snowflake) |
| 3 | `failure_alerts` (v0.7.0) | Replaces old "Error notifications" row that pointed at `on_error: skip + drt status` (which is per-row, not sync-level alerting) |
| 4 | Hardcoded-secret detection (v0.7.5) | Added to auth migration table — "never hardcode, `drt validate` flags it" |
| 5 | Connection-string profiles | Added to auth migration table — `${VAR}` resolution in `~/.drt/profiles.yml` |

## New section: Sync-mode picking guide

A "user wants X, drt mode is Y" table so the LLM picks from intent rather than guessing from the old tool's vocabulary:

| User wants | drt mode |
|------------|----------|
| "Re-send everything every run" | `full` |
| "Append new rows since last run" | `incremental` + `cursor_field` |
| "Upsert by key" | `upsert` + `upsert_key` |
| "Upsert + delete rows removed from source" | `mirror` + `upsert_key` (v0.7.7+ SQL destinations) |
| "Overwrite the destination table each run" | `replace` (TRUNCATE + INSERT, `swap` strategy for zero-downtime) |

## New "summary" guidance

The LLM now surfaces semantic drift explicitly — e.g. Census "Full Sync with Deletion" → `mirror` is the same shape; Census "Full Sync without Deletion" → `full` keeps stale rows in the destination, so the user may want `upsert` instead. Avoids silent semantic mismatches.

## New Reference entry

`examples/postgres_to_postgres_mirror/` — runnable example for `mirror` shape so the user can confirm before adopting.

## Verification

- [x] `make sync-skills` — synced to `.claude/commands/drt-migrate.md`
- [x] `make check-skills` — clean

## Sequence

1. ✅ /drt-debug refresh — #625
2. ✅ /drt-init refresh — #626
3. **This PR — /drt-migrate refresh**
4. /drt-create-sync GCS+Azure follow-up (after #623 #624 merge)
5. MCP refresh: `drt_doctor` + `drt_run_sync(diff=True)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)