### PR TITLE
docs(i18n): resync README.ja marker to current README.md tip (#631 follow-up)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-sync: base=README.md, hash=fe801bea667943e5cad36ff5fff3b13c48b41ef2 -->
+<!-- i18n-sync: base=README.md, hash=92b368ef0ff1f89f3a49844be1ca77746b07c7fc -->
 
 [English](./README.md) | [日本語](./README.ja.md)
 


### PR DESCRIPTION
Standalone follow-up to #631.

## Problem

`make check-i18n` reports **README.ja.md STALE** on `main`:

```
STALE README.ja.md  (base=README.md updated: 92b368e, recorded: fe801be)
```

## Cause

#631 was squash-merged. Its in-PR marker bump recorded the **pre-squash branch SHA** (`fe801be`), but the squashed commit on `main` is `92b368e` — so the marker hash lags the actual README.md tip.

## Content is in sync

This is a **pure marker-hash bump, no content change**. The only README.md delta between the recorded baseline and the current tip is the **GCS + Azure Blob destination rows** (#623/#624), and README.ja.md already carries both (lines 265-266). Verified:

```
git diff fe801be 92b368e -- README.md   # → only the GCS + Azure rows
grep "Google Cloud Storage\|Azure Blob" README.ja.md   # → both present
```

## Fix

Bump the `i18n-sync` marker in `README.ja.md` to `92b368e`. `make check-i18n` now passes:

```
OK    README.ja.md  (synced with README.md)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)