### PR TITLE
docs: add CI/CD GitHub Action section to README (drt-hub/drt-action)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -346,6 +346,23 @@ defs = Definitions(
 
 ---
 
+## CI/CD: GitHub Action
+
+公式の [**drt-hub/drt-action**](https://github.com/drt-hub/drt-action) を使えば、CI/CD から直接 drt の同期を実行できます。インフラ不要、数行の YAML だけ。スケジュール実行・push ごと・dbt 完了直後など、好きなタイミングで起動できます。
+
+```yaml
+- uses: drt-hub/drt-action@v1
+  with:
+    select: '*'
+    extras: postgres
+  env:
+    PG_PASSWORD: ${{ secrets.PG_PASSWORD }}
+```
+
+入力は同期の選択（`select`）・コネクタの `extras`・`profile`・`dry-run`・`threads` などをカバーし、出力として `status` / `succeeded` / `failed` / `duration-seconds`（＋ステップサマリ表）が得られます。シークレットは `env:` 経由で渡し、drt の `*_env` キーで解決されます。シークレットの渡し方やその他の例（dbt 後の実行、PR プレビュー）は [action README](https://github.com/drt-hub/drt-action#readme) を参照してください。
+
+---
+
 ## エコシステム
 
 drtは最新のデータスタックと競合するのではなく、共存するように設計されています:

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-sync: base=README.md, hash=92b368ef0ff1f89f3a49844be1ca77746b07c7fc -->
+<!-- i18n-sync: base=README.md, hash=2afc8c6df5c0e7eacd060fed8fcff7e4418f8c7a -->
 
 [English](./README.md) | [日本語](./README.ja.md)
 

--- a/README.md
+++ b/README.md
@@ -373,6 +373,23 @@ See [dagster-drt README](integrations/dagster-drt/README.md) for full API docs (
 
 ---
 
+## CI/CD: GitHub Action
+
+Run drt syncs straight from CI/CD with the official [**drt-hub/drt-action**](https://github.com/drt-hub/drt-action) — no infrastructure, just a few lines of YAML. Trigger on a schedule, on every push, or right after dbt finishes.
+
+```yaml
+- uses: drt-hub/drt-action@v1
+  with:
+    select: '*'
+    extras: postgres
+  env:
+    PG_PASSWORD: ${{ secrets.PG_PASSWORD }}
+```
+
+Inputs cover sync selection (`select`), connector `extras`, `profile`, `dry-run` and `threads`; outputs expose `status`, `succeeded`, `failed` and `duration-seconds` (plus a step-summary table). Secrets are passed via `env:` and resolved by drt's `*_env` keys. See the [action README](https://github.com/drt-hub/drt-action#readme) for the secrets pattern and more examples (run-after-dbt, PR preview).
+
+---
+
 ## Ecosystem
 
 drt is designed to work alongside, not against, the modern data stack:


### PR DESCRIPTION
Adds a **CI/CD: GitHub Action** section to `README.md` and `README.ja.md`, pointing users to the new [drt-hub/drt-action](https://github.com/drt-hub/drt-action) Action for running drt syncs in CI/CD.

- Placed right after the `dagster-drt` section (sibling "run drt in automation" content).
- Mirrored in `README.ja.md`; i18n marker bumped, `make check-i18n` green.
- Docs-only, no code changes.

**Context:** drt-action v1.0.0 shipped today (closes #292) and is live on the GitHub Marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)