### PR TITLE
docs(i18n): resync README.ja marker after #639

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-sync: base=README.md, hash=2afc8c6df5c0e7eacd060fed8fcff7e4418f8c7a -->
+<!-- i18n-sync: base=README.md, hash=a05482930e95f0db036d95c9244a492650d91d18 -->
 
 [English](./README.md) | [日本語](./README.ja.md)
 


### PR DESCRIPTION
Follow-up to #639 (squash-merge changed the README.md tip hash). Bumps the `README.ja.md` i18n-sync marker to the current README.md tip so `make check-i18n` is green. README.ja.md only — no content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)