### PR TITLE
feat(config): write ~/.drt credentials 0o600 / dir 0o700 on POSIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`~/.drt/profiles.yml` is now written `0o600` (owner-only) on POSIX** (#650) — credential-adjacent files were written with the process umask (typically world-readable `0o644`). All `credentials.py` write sites (`save_profile` and the `drt profile add` / `remove` path via `_rewrite_profiles`) now create the file atomically with mode `0o600` via `os.open(..., O_CREAT, 0o600)` (no world-readable window) and `chmod` the descriptor to tighten a pre-existing `0o644` file; the `~/.drt` directory is created `0o700`. No-op on Windows (NTFS ACLs differ), guarded behind `os.name == "posix"`.
+
 ### Fixed
 
 - **`drt destinations` was missing 9 registered connectors** — `bigquery`, `databricks`, `snowflake`, `s3`, `gcs`, `azure_blob`, `elasticsearch`, `mixpanel`, and `salesforce_bulk` were registered in the connector registry but absent from the hand-maintained `DESTINATIONS` list in `drt/config/connectors.py`, so `drt destinations` / `drt destinations --detailed` / `--format json` silently listed only 23 of 32 (every cloud/DWH destination, including all six added in v0.7.9, was invisible to the CLI even though it worked in syncs). Synced both `DESTINATIONS` and the `DESTINATION_CONFIG_CLASSES` map in `drt/cli/_connector_detail.py` to the registry. **Closed the drift blind spot**: the existing parity tests only checked `DESTINATIONS ⊆ _connector_detail`, never `registry ⊆ DESTINATIONS` — new `test_DESTINATIONS_matches_registry` / `test_SOURCES_matches_registry` assert the CLI lists equal the registry exactly, failing the build at PR time (the post-merge `check_drift.sh` audit never covered this surface). `SOURCES` was already in sync.

--- a/drt/config/credentials.py
+++ b/drt/config/credentials.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TextIO
 
 import yaml
 from pydantic import BaseModel, Field
@@ -487,6 +487,41 @@ def load_profile(profile_name: str, config_dir: Path | None = None) -> ProfileCo
     )
 
 
+def _ensure_private_dir(dir_path: Path) -> None:
+    """Create ``dir_path`` (and parents), owner-only (0o700) on POSIX.
+
+    The chmod is best-effort and POSIX-only — NTFS ACLs differ, so it's a
+    no-op on Windows (guarded behind ``os.name``) rather than erroring.
+    """
+    dir_path.mkdir(parents=True, exist_ok=True)
+    if os.name == "posix":
+        try:
+            dir_path.chmod(0o700)
+        except OSError:
+            pass
+
+
+def _open_private(path: Path) -> TextIO:
+    """Open ``path`` for writing with owner-only (0o600) perms on POSIX.
+
+    ``~/.drt/profiles.yml`` can hold inline credentials, so it should never be
+    world-readable. ``os.open`` with ``O_CREAT`` + mode ``0o600`` means a newly
+    created file is private from the moment it exists (no umask-default
+    ``0o644`` window), and the explicit ``os.chmod`` on the descriptor also
+    tightens a *pre-existing* file that an older drt may have written
+    ``0o644``. No-op on Windows, where the call falls back to a plain text
+    write.
+    """
+    if os.name != "posix":
+        return path.open("w")
+    fd = os.open(path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+    try:
+        os.chmod(fd, 0o600)  # descriptor-based: also tightens a pre-existing file
+    except OSError:
+        pass
+    return os.fdopen(fd, "w")
+
+
 def save_profile(
     profile_name: str,
     profile: ProfileConfig,
@@ -494,7 +529,7 @@ def save_profile(
 ) -> Path:
     """Append or update a profile in ~/.drt/profiles.yml."""
     dir_path = _config_dir(config_dir)
-    dir_path.mkdir(parents=True, exist_ok=True)
+    _ensure_private_dir(dir_path)
     profiles_path = dir_path / "profiles.yml"
 
     data: dict[str, Any] = {}
@@ -605,7 +640,7 @@ def save_profile(
         raise ValueError(f"Unknown profile type: {type(profile)}")
 
     profiles[profile_name] = entry
-    with profiles_path.open("w") as f:
+    with _open_private(profiles_path) as f:
         yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
 
     return profiles_path
@@ -646,8 +681,8 @@ def _rewrite_profiles(
     if observability is not None:
         out["observability"] = observability
     out["profiles"] = profiles
-    profiles_path.parent.mkdir(parents=True, exist_ok=True)
-    with profiles_path.open("w") as f:
+    _ensure_private_dir(profiles_path.parent)
+    with _open_private(profiles_path) as f:
         yaml.dump(out, f, default_flow_style=False, allow_unicode=True)
 
 

--- a/tests/unit/test_credentials_permissions.py
+++ b/tests/unit/test_credentials_permissions.py
@@ -1,0 +1,77 @@
+"""Tests for ~/.drt credential file/dir permission hardening (#650).
+
+POSIX-only: the hardening is a no-op on Windows (NTFS ACLs differ), so the
+mode assertions are skipped off POSIX. drt's CI runs on Linux, so these
+execute there.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from drt.config.credentials import (
+    BigQueryProfile,
+    save_profile,
+    write_raw_profile,
+)
+
+posix_only = pytest.mark.skipif(os.name != "posix", reason="POSIX file modes only")
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+def _bq() -> BigQueryProfile:
+    return BigQueryProfile(
+        type="bigquery",
+        project="p",
+        dataset="d",
+        method="application_default",
+    )
+
+
+@posix_only
+def test_save_profile_writes_0o600(tmp_path: Path) -> None:
+    path = save_profile("dev", _bq(), config_dir=tmp_path)
+    assert _mode(path) == 0o600
+
+
+@posix_only
+def test_save_profile_tightens_preexisting_world_readable_file(tmp_path: Path) -> None:
+    profiles = tmp_path / "profiles.yml"
+    profiles.write_text("profiles: {}\n")
+    profiles.chmod(0o644)
+    save_profile("dev", _bq(), config_dir=tmp_path)
+    assert _mode(profiles) == 0o600
+
+
+@posix_only
+def test_save_profile_creates_0o700_dir(tmp_path: Path) -> None:
+    config_dir = tmp_path / "dotdrt"
+    save_profile("dev", _bq(), config_dir=config_dir)
+    assert _mode(config_dir) == 0o700
+
+
+@posix_only
+def test_write_raw_profile_writes_0o600(tmp_path: Path) -> None:
+    path = write_raw_profile(
+        "dev",
+        {"type": "duckdb", "database": "./w.duckdb"},
+        config_dir=tmp_path,
+    )
+    assert _mode(path) == 0o600
+
+
+def test_save_profile_roundtrips_regardless_of_platform(tmp_path: Path) -> None:
+    """The hardening must not change the written content (Windows or POSIX)."""
+    from drt.config.credentials import load_profile
+
+    save_profile("dev", _bq(), config_dir=tmp_path)
+    loaded = load_profile("dev", config_dir=tmp_path)
+    assert loaded.project == "p"
+    assert loaded.dataset == "d"


### PR DESCRIPTION
Closes #650.

## What

`~/.drt/profiles.yml` was written with the process umask, so on POSIX it usually lands `0o644` (world-readable) even though it can hold inline credentials (hosts, users, the occasional inline password for a quick local setup).

This hardens every write site in `drt/config/credentials.py`:

- `save_profile` (the typed engine path)
- `_rewrite_profiles`, used by both `write_raw_profile` and `remove_profile` (the `drt profile add` / `remove` path added in #635)

Two small helpers do the work:

- `_open_private` opens the file with `os.open(..., O_CREAT | O_WRONLY | O_TRUNC, 0o600)`, so a newly created file is never world-readable, and `chmod`s the descriptor so a pre-existing `0o644` file gets tightened too.
- `_ensure_private_dir` creates `~/.drt` as `0o700`.

Both are guarded behind `os.name == "posix"` and are a no-op on Windows (NTFS ACLs differ), as the issue suggested.

## Notes

- `os.fchmod` isn't in the Windows typeshed stub and the repo doesn't allow `type: ignore`, so I used `os.chmod(fd, ...)` instead — descriptor-based, same effect, mypy-clean cross-platform.
- Out of scope, per the issue: encrypted-at-rest profile storage (tracked in #303).

## Tests

New `tests/unit/test_credentials_permissions.py`: asserts `save_profile` / `write_raw_profile` write `0o600`, the `~/.drt` directory is `0o700`, and a pre-existing `0o644` file is tightened. The mode assertions are POSIX-gated (they run on Linux in CI); a platform-agnostic round-trip test guards content parity. ruff and mypy pass.
