### PR TITLE
ci: notify drt-web to resync on release / docs change

### DIFF
--- a/.github/workflows/notify-drt-web.yml
+++ b/.github/workflows/notify-drt-web.yml
@@ -1,0 +1,42 @@
+name: Notify drt-web (resync site)
+
+# Tells drt-hub/drt-web to regenerate its connector matrix + docs whenever drt
+# ships a release or changes docs/connectors. drt-web then opens an SSoT sync PR
+# that a maintainer reviews + merges to deploy.
+#
+# Requires a fine-grained PAT with **Contents: Read and write** on drt-hub/drt-web,
+# stored as the `WEB_SYNC_TOKEN` secret on THIS (drt) repo. The job no-ops until
+# that secret exists, so this workflow is safe to merge before the PAT is set up.
+
+on:
+  release:
+    types: [published]
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "README.md"
+      - "drt/connectors/registry.py"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    env:
+      WEB_SYNC_TOKEN: ${{ secrets.WEB_SYNC_TOKEN }}
+    steps:
+      - name: Dispatch `drt-updated` to drt-web
+        if: ${{ env.WEB_SYNC_TOKEN != '' }}
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: Bearer $WEB_SYNC_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/drt-hub/drt-web/dispatches \
+            -d '{"event_type":"drt-updated"}'
+
+      - name: Note when skipped
+        if: ${{ env.WEB_SYNC_TOKEN == '' }}
+        run: echo "WEB_SYNC_TOKEN not set — skipping drt-web resync dispatch (weekly cron still covers it)."


### PR DESCRIPTION
Adds `.github/workflows/notify-drt-web.yml` — fires a `repository_dispatch` (`drt-updated`) to **drt-hub/drt-web** on release-published and on pushes touching `docs/**`, `README.md`, or `drt/connectors/registry.py`, so the site's SSoT sync runs immediately (vs. its weekly cron).

**Requires** a fine-grained PAT with **Contents: Read and write** on `drt-hub/drt-web`, stored as the `WEB_SYNC_TOKEN` secret on this repo. The job is guarded (`if: env.WEB_SYNC_TOKEN != ''`) so it **no-ops until the secret exists** — safe to merge before the PAT is set up.

Part of standing up the official site (drt-hub/drt-web).