### PR TITLE
fix(vscode): regenerate bundled schemas to include sync.mask (#668)

### DIFF
--- a/integrations/vscode-drt/schemas/sync.schema.json
+++ b/integrations/vscode-drt/schemas/sync.schema.json
@@ -3740,6 +3740,25 @@
           "default": null,
           "title": "Field Mappings"
         },
+        "mask": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "enum": [
+                  "hash",
+                  "redact"
+                ],
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Mask"
+        },
         "dlq": {
           "anyOf": [
             {


### PR DESCRIPTION
The new VS Code schema-drift guard (#669) went red on `main` — correctly. #668 (`sync.mask`) changed the config schema, but the bundled `integrations/vscode-drt/schemas/sync.schema.json` (regenerated in #669, before #668 merged) was missing the `mask` field.

Regenerated via `drt.config.schema.write_schemas` so the bundle matches drt-core again — the drift guard should pass on this PR (proof it works). Extension version bump can ride with the Marketplace publish (not yet published).