### PR TITLE
ci(test): DWH smoke harness — gated/nightly, skip when no secrets (#674)

### DIFF
--- a/.github/workflows/dwh-smoke.yml
+++ b/.github/workflows/dwh-smoke.yml
@@ -1,0 +1,143 @@
+# DWH smoke validation — real-warehouse end-to-end checks (#674, part of #654).
+#
+# The cloud-warehouse destinations (Snowflake / Databricks / BigQuery) are
+# CI-tested only with sys.modules-injected mocks — that covers drt's own logic
+# but can't catch dialect-specific behaviour only a live service exercises.
+# This workflow runs a minimal seeded-DuckDB -> engine -> real-warehouse sync
+# and reads the rows back, mirroring the v0.7.5 DuckDB E2E harness.
+#
+# Credential-agnostic by design:
+#   * Only runs on the upstream repo (forks have no secrets).
+#   * Each job checks whether its DRT_SMOKE_* secrets are present and, if not,
+#     no-ops green — so this is safe to merge before any secrets exist and
+#     "activates" per-warehouse as masukai adds them.
+# Cloud secrets + the "verified on a real service" sign-off are owned by the
+# maintainer (his accounts / repo secrets); see #671 / #672 / #673.
+#
+# Required repo secrets (per warehouse) are listed in
+# tests/integration/dwh/README.md.
+
+name: dwh-smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Nightly 03:00 UTC — offset from CI (00:00) and the weekly audits.
+    - cron: '0 3 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  snowflake:
+    name: Snowflake smoke
+    runs-on: ubuntu-latest
+    if: github.repository == 'drt-hub/drt'
+    env:
+      DRT_SMOKE_SNOWFLAKE_ACCOUNT: ${{ secrets.SMOKE_SNOWFLAKE_ACCOUNT }}
+      DRT_SMOKE_SNOWFLAKE_USER: ${{ secrets.SMOKE_SNOWFLAKE_USER }}
+      DRT_SMOKE_SNOWFLAKE_PASSWORD: ${{ secrets.SMOKE_SNOWFLAKE_PASSWORD }}
+      DRT_SMOKE_SNOWFLAKE_DATABASE: ${{ secrets.SMOKE_SNOWFLAKE_DATABASE }}
+      DRT_SMOKE_SNOWFLAKE_SCHEMA: ${{ secrets.SMOKE_SNOWFLAKE_SCHEMA }}
+      DRT_SMOKE_SNOWFLAKE_WAREHOUSE: ${{ secrets.SMOKE_SNOWFLAKE_WAREHOUSE }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check credentials
+        id: creds
+        run: |
+          if [ -z "$DRT_SMOKE_SNOWFLAKE_ACCOUNT" ]; then
+            echo "No Snowflake smoke secrets configured — skipping (no-op)."
+            echo "has_creds=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_creds=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Set up Python
+        if: steps.creds.outputs.has_creds == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        if: steps.creds.outputs.has_creds == 'true'
+        run: pip install uv
+      - name: Install drt-core[dev,duckdb,snowflake]
+        if: steps.creds.outputs.has_creds == 'true'
+        run: uv pip install --system -e ".[dev,duckdb,snowflake]"
+      - name: Run Snowflake smoke
+        if: steps.creds.outputs.has_creds == 'true'
+        run: pytest -m dwh_smoke tests/integration/dwh/test_snowflake_smoke.py -v
+
+  databricks:
+    name: Databricks smoke
+    runs-on: ubuntu-latest
+    if: github.repository == 'drt-hub/drt'
+    env:
+      DRT_SMOKE_DATABRICKS_HOST: ${{ secrets.SMOKE_DATABRICKS_HOST }}
+      DRT_SMOKE_DATABRICKS_HTTP_PATH: ${{ secrets.SMOKE_DATABRICKS_HTTP_PATH }}
+      DRT_SMOKE_DATABRICKS_TOKEN: ${{ secrets.SMOKE_DATABRICKS_TOKEN }}
+      DRT_SMOKE_DATABRICKS_CATALOG: ${{ secrets.SMOKE_DATABRICKS_CATALOG }}
+      DRT_SMOKE_DATABRICKS_SCHEMA: ${{ secrets.SMOKE_DATABRICKS_SCHEMA }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check credentials
+        id: creds
+        run: |
+          if [ -z "$DRT_SMOKE_DATABRICKS_HOST" ]; then
+            echo "No Databricks smoke secrets configured — skipping (no-op)."
+            echo "has_creds=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_creds=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Set up Python
+        if: steps.creds.outputs.has_creds == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        if: steps.creds.outputs.has_creds == 'true'
+        run: pip install uv
+      - name: Install drt-core[dev,duckdb,databricks]
+        if: steps.creds.outputs.has_creds == 'true'
+        run: uv pip install --system -e ".[dev,duckdb,databricks]"
+      - name: Run Databricks smoke
+        if: steps.creds.outputs.has_creds == 'true'
+        run: pytest -m dwh_smoke tests/integration/dwh/test_databricks_smoke.py -v
+
+  bigquery:
+    name: BigQuery smoke
+    runs-on: ubuntu-latest
+    if: github.repository == 'drt-hub/drt'
+    env:
+      DRT_SMOKE_BIGQUERY_PROJECT: ${{ secrets.SMOKE_BIGQUERY_PROJECT }}
+      DRT_SMOKE_BIGQUERY_DATASET: ${{ secrets.SMOKE_BIGQUERY_DATASET }}
+      # Service-account JSON (whole file contents) stored as a secret.
+      SMOKE_BIGQUERY_KEYFILE_JSON: ${{ secrets.SMOKE_BIGQUERY_KEYFILE_JSON }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check credentials
+        id: creds
+        run: |
+          if [ -z "$DRT_SMOKE_BIGQUERY_PROJECT" ]; then
+            echo "No BigQuery smoke secrets configured — skipping (no-op)."
+            echo "has_creds=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_creds=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Set up Python
+        if: steps.creds.outputs.has_creds == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        if: steps.creds.outputs.has_creds == 'true'
+        run: pip install uv
+      - name: Install drt-core[dev,duckdb,bigquery]
+        if: steps.creds.outputs.has_creds == 'true'
+        run: uv pip install --system -e ".[dev,duckdb,bigquery]"
+      - name: Write service-account keyfile
+        if: steps.creds.outputs.has_creds == 'true'
+        run: |
+          echo "$SMOKE_BIGQUERY_KEYFILE_JSON" > "$RUNNER_TEMP/bq-sa.json"
+          echo "DRT_SMOKE_BIGQUERY_KEYFILE=$RUNNER_TEMP/bq-sa.json" >> "$GITHUB_ENV"
+      - name: Run BigQuery smoke
+        if: steps.creds.outputs.has_creds == 'true'
+        run: pytest -m dwh_smoke tests/integration/dwh/test_bigquery_smoke.py -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,4 +121,7 @@ disallow_untyped_decorators = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "dwh_smoke: real cloud-warehouse smoke checks (Snowflake/Databricks/BigQuery); skip without DRT_SMOKE_* secrets (#674).",
+]
 asyncio_mode = "auto"

--- a/tests/integration/dwh/README.md
+++ b/tests/integration/dwh/README.md
@@ -1,0 +1,69 @@
+# DWH smoke harness (#674, part of #654)
+
+Real-warehouse end-to-end checks for the cloud destinations (Snowflake,
+Databricks, BigQuery). They drive the same pipeline as the rest of the
+integration suite — seeded DuckDB `users` → engine → **real** warehouse table →
+read back → verify — to catch dialect-specific behaviour that the
+mock-injected unit suites can't.
+
+## Why this is a safe no-op until secrets exist
+
+Each test is gated twice:
+
+1. **Driver gate** — `pytest.importorskip(...)` skips the module unless the
+   warehouse extra is installed (`drt-core[snowflake|databricks|bigquery]`).
+2. **Credential gate** — `require_env(...)` skips unless the `DRT_SMOKE_*`
+   env vars are set.
+
+So a plain `pytest` run, every fork, and the upstream repo *before secrets are
+added* are all green without ever opening a connection. The `dwh-smoke`
+workflow injects the secrets from the repo so the checks run for real only on
+`drt-hub/drt`.
+
+## Running locally
+
+```bash
+pip install -e ".[dev,duckdb,snowflake]"     # or databricks / bigquery
+export DRT_SMOKE_SNOWFLAKE_ACCOUNT=...        # see the secret list below
+# ...export the rest...
+pytest -m dwh_smoke tests/integration/dwh/test_snowflake_smoke.py -v
+```
+
+## Required repo secrets (maintainer-owned)
+
+Add these under **Settings → Secrets and variables → Actions**. Per the split,
+the cloud accounts and the "verified ✓" sign-off are the maintainer's
+(#671 / #672 / #673). Until a warehouse's secrets exist, its job no-ops.
+
+**Snowflake** (#671)
+| Secret | Notes |
+| --- | --- |
+| `SMOKE_SNOWFLAKE_ACCOUNT` | account identifier |
+| `SMOKE_SNOWFLAKE_USER` | |
+| `SMOKE_SNOWFLAKE_PASSWORD` | |
+| `SMOKE_SNOWFLAKE_DATABASE` | a throwaway DB the role can create/drop tables in |
+| `SMOKE_SNOWFLAKE_SCHEMA` | |
+| `SMOKE_SNOWFLAKE_WAREHOUSE` | |
+
+**Databricks** (#672)
+| Secret | Notes |
+| --- | --- |
+| `SMOKE_DATABRICKS_HOST` | workspace hostname, e.g. `dbc-….cloud.databricks.com` |
+| `SMOKE_DATABRICKS_HTTP_PATH` | SQL warehouse HTTP path |
+| `SMOKE_DATABRICKS_TOKEN` | PAT (`dapi…`) |
+| `SMOKE_DATABRICKS_CATALOG` | |
+| `SMOKE_DATABRICKS_SCHEMA` | |
+
+**BigQuery** (#673)
+| Secret | Notes |
+| --- | --- |
+| `SMOKE_BIGQUERY_PROJECT` | |
+| `SMOKE_BIGQUERY_DATASET` | a throwaway dataset |
+| `SMOKE_BIGQUERY_KEYFILE_JSON` | full service-account JSON; the workflow writes it to a temp file |
+
+## Adding a warehouse leg
+
+`test_snowflake_smoke.py` is the reference shape. To add another, copy it and
+swap: the `importorskip` driver, the destination config, and the
+read-back/cleanup connection. The source side (`seed_duckdb_users`) and the
+3-row assertion stay identical.

--- a/tests/integration/dwh/conftest.py
+++ b/tests/integration/dwh/conftest.py
@@ -1,0 +1,80 @@
+"""Shared fixtures + credential gating for the DWH smoke harness (#674, part of #654).
+
+These tests drive a *real* end-to-end sync into a live cloud warehouse
+(Snowflake / Databricks / BigQuery) and read the rows back to confirm they
+landed. They are the real-service complement to the mock-injected unit suites.
+
+Gating contract (so this is a safe no-op for forks / contributors):
+  * The connector driver is gated with ``pytest.importorskip`` — environments
+    without ``drt-core[snowflake|databricks|bigquery]`` skip at collection.
+  * Credentials come from ``DRT_SMOKE_*`` env vars. When they're absent the
+    module skips, so a normal ``pytest`` run (and every fork) is green without
+    ever touching a warehouse. The dwh-smoke workflow injects them from repo
+    secrets so the checks run for real only on the upstream repo.
+
+The source side is the same seeded DuckDB ``users`` table used by the rest of
+the integration harness, so only the destination leg differs per warehouse.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from drt.config.credentials import DuckDBProfile
+from drt.sources.duckdb import DuckDBSource
+
+# Rows every smoke test seeds + expects to read back. Kept identical to the
+# rest of tests/integration so the per-warehouse bodies stay copy-paste close.
+SEED_ROWS = [
+    (1, "Alice", "alice@example.com"),
+    (2, "Bob", "bob@example.com"),
+    (3, "Carol", "carol@example.com"),
+]
+
+
+def require_env(*names: str) -> dict[str, str]:
+    """Return the requested env vars, or skip the test if any are unset.
+
+    This is the credential gate: no ``DRT_SMOKE_*`` secrets -> graceful skip,
+    so forks and the default ``pytest`` run never attempt a real connection.
+    """
+    missing = [n for n in names if not os.environ.get(n)]
+    if missing:
+        pytest.skip(
+            "DWH smoke credentials not set: "
+            + ", ".join(missing)
+            + " (expected for forks / local runs without cloud secrets)."
+        )
+    return {n: os.environ[n] for n in names}
+
+
+def unique_table(base: str) -> str:
+    """A collision-free target table name so parallel/nightly runs don't clash."""
+    return f"{base}_{uuid.uuid4().hex[:10]}"
+
+
+def seed_duckdb_users(tmp_path: Path) -> tuple[DuckDBSource, DuckDBProfile]:
+    """Seed a DuckDB ``users`` table and return ``(Source, Profile)``.
+
+    Mirrors the ``duckdb_with_users`` fixture in the parent conftest, but lives
+    here so the smoke package is self-contained.
+    """
+    duckdb = pytest.importorskip("duckdb")
+    db_path = str(tmp_path / "smoke_source.duckdb")
+    conn = duckdb.connect(db_path)
+    try:
+        conn.execute("CREATE TABLE users (id INTEGER, name VARCHAR, email VARCHAR)")
+        conn.executemany("INSERT INTO users VALUES (?, ?, ?)", SEED_ROWS)
+    finally:
+        conn.close()
+    return DuckDBSource(), DuckDBProfile(type="duckdb", database=db_path)
+
+
+@pytest.fixture
+def duckdb_users(tmp_path: Path) -> Iterator[tuple[DuckDBSource, DuckDBProfile]]:
+    yield seed_duckdb_users(tmp_path)

--- a/tests/integration/dwh/test_bigquery_smoke.py
+++ b/tests/integration/dwh/test_bigquery_smoke.py
@@ -1,0 +1,68 @@
+"""BigQuery DWH smoke test (#674 / #673) — mirrors test_snowflake_smoke.py.
+
+seeded DuckDB ``users`` -> engine -> live BigQuery table -> read back.
+Runs only when ``DRT_SMOKE_BIGQUERY_*`` secrets are present; skips otherwise.
+
+Auth uses a service-account keyfile: the workflow writes the SA JSON secret to a
+file and exposes its path as ``DRT_SMOKE_BIGQUERY_KEYFILE``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from drt.config.models import BigQueryDestinationConfig, SyncConfig, SyncOptions
+from drt.destinations.bigquery import BigQueryDestination
+from drt.engine.sync import run_sync
+
+from .conftest import require_env, seed_duckdb_users, unique_table
+
+pytestmark = pytest.mark.dwh_smoke
+
+bigquery = pytest.importorskip("google.cloud.bigquery")
+
+
+def test_bigquery_insert_roundtrip(tmp_path: Path) -> None:
+    creds = require_env(
+        "DRT_SMOKE_BIGQUERY_PROJECT",
+        "DRT_SMOKE_BIGQUERY_DATASET",
+        "DRT_SMOKE_BIGQUERY_KEYFILE",
+    )
+    source, profile = seed_duckdb_users(tmp_path)
+    table = unique_table("drt_smoke")
+    project = creds["DRT_SMOKE_BIGQUERY_PROJECT"]
+    dataset = creds["DRT_SMOKE_BIGQUERY_DATASET"]
+    keyfile = creds["DRT_SMOKE_BIGQUERY_KEYFILE"]
+    fqn = f"`{project}`.`{dataset}`.`{table}`"
+
+    dest = BigQueryDestinationConfig(
+        **{
+            "type": "bigquery",
+            "project": project,
+            "dataset": dataset,
+            "table": table,
+            "mode": "insert",
+            "method": "keyfile",
+            "keyfile": keyfile,
+        }
+    )
+    sync = SyncConfig(
+        name="bigquery_smoke",
+        model="ref('users')",
+        destination=dest,
+        sync=SyncOptions(batch_size=10),
+    )
+
+    client = bigquery.Client.from_service_account_json(keyfile, project=project)
+    try:
+        result = run_sync(sync, source, BigQueryDestination(), profile, tmp_path)
+        assert result.success == 3, f"expected 3 loaded rows, got {result.success}"
+        assert result.failed == 0
+
+        rows = client.query(f"SELECT name FROM {fqn}").result()
+        names = {row["name"] for row in rows}
+        assert names == {"Alice", "Bob", "Carol"}
+    finally:
+        client.query(f"DROP TABLE IF EXISTS {fqn}").result()

--- a/tests/integration/dwh/test_bigquery_smoke.py
+++ b/tests/integration/dwh/test_bigquery_smoke.py
@@ -9,6 +9,7 @@ file and exposes its path as ``DRT_SMOKE_BIGQUERY_KEYFILE``.
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
@@ -57,12 +58,25 @@ def test_bigquery_insert_roundtrip(tmp_path: Path) -> None:
 
     client = bigquery.Client.from_service_account_json(keyfile, project=project)
     try:
+        # drt's insert mode streams into an existing table (insert_rows_json);
+        # it doesn't create one, so pre-create with the seed schema.
+        client.query(
+            f"CREATE TABLE {fqn} (id INT64, name STRING, email STRING)"
+        ).result()
+
         result = run_sync(sync, source, BigQueryDestination(), profile, tmp_path)
         assert result.success == 3, f"expected 3 loaded rows, got {result.success}"
         assert result.failed == 0
 
-        rows = client.query(f"SELECT name FROM {fqn}").result()
-        names = {row["name"] for row in rows}
+        # Streaming inserts land in a buffer that isn't immediately visible to
+        # SQL SELECT — poll briefly until all three rows are queryable.
+        names: set[str] = set()
+        for _ in range(12):
+            rows = client.query(f"SELECT name FROM {fqn}").result()
+            names = {row["name"] for row in rows}
+            if names == {"Alice", "Bob", "Carol"}:
+                break
+            time.sleep(5)
         assert names == {"Alice", "Bob", "Carol"}
     finally:
         client.query(f"DROP TABLE IF EXISTS {fqn}").result()

--- a/tests/integration/dwh/test_databricks_smoke.py
+++ b/tests/integration/dwh/test_databricks_smoke.py
@@ -66,6 +66,17 @@ def test_databricks_insert_roundtrip(tmp_path: Path) -> None:
         sync=SyncOptions(batch_size=10),
     )
 
+    # drt's insert mode appends into an existing table — pre-create it. Must be
+    # a Delta table (the destination relies on Delta for merge/replace paths).
+    conn = _connect(creds)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"CREATE TABLE {fqn} (id INT, name STRING, email STRING) USING DELTA"
+            )
+    finally:
+        conn.close()
+
     try:
         result = run_sync(sync, source, DatabricksDestination(), profile, tmp_path)
         assert result.success == 3, f"expected 3 loaded rows, got {result.success}"

--- a/tests/integration/dwh/test_databricks_smoke.py
+++ b/tests/integration/dwh/test_databricks_smoke.py
@@ -1,0 +1,88 @@
+"""Databricks DWH smoke test (#674 / #672) — mirrors test_snowflake_smoke.py.
+
+seeded DuckDB ``users`` -> engine -> live Databricks Delta table -> read back.
+Runs only when ``DRT_SMOKE_DATABRICKS_*`` secrets are present; skips otherwise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from drt.config.models import DatabricksDestinationConfig, SyncConfig, SyncOptions
+from drt.destinations.databricks import DatabricksDestination
+from drt.engine.sync import run_sync
+
+from .conftest import require_env, seed_duckdb_users, unique_table
+
+pytestmark = pytest.mark.dwh_smoke
+
+dbsql = pytest.importorskip("databricks.sql")
+
+HOST_ENV = "DRT_SMOKE_DATABRICKS_HOST"
+HTTP_PATH_ENV = "DRT_SMOKE_DATABRICKS_HTTP_PATH"
+TOKEN_ENV = "DRT_SMOKE_DATABRICKS_TOKEN"
+
+
+def _connect(creds: dict[str, str]):
+    return dbsql.connect(
+        server_hostname=creds[HOST_ENV],
+        http_path=creds[HTTP_PATH_ENV],
+        access_token=creds[TOKEN_ENV],
+    )
+
+
+def test_databricks_insert_roundtrip(tmp_path: Path) -> None:
+    creds = require_env(
+        HOST_ENV,
+        HTTP_PATH_ENV,
+        TOKEN_ENV,
+        "DRT_SMOKE_DATABRICKS_CATALOG",
+        "DRT_SMOKE_DATABRICKS_SCHEMA",
+    )
+    source, profile = seed_duckdb_users(tmp_path)
+    table = unique_table("drt_smoke")
+    catalog = creds["DRT_SMOKE_DATABRICKS_CATALOG"]
+    schema = creds["DRT_SMOKE_DATABRICKS_SCHEMA"]
+    fqn = f"`{catalog}`.`{schema}`.`{table}`"
+
+    dest = DatabricksDestinationConfig(
+        **{
+            "type": "databricks",
+            "host_env": HOST_ENV,
+            "http_path_env": HTTP_PATH_ENV,
+            "token_env": TOKEN_ENV,
+            "catalog": catalog,
+            "schema": schema,
+            "table": table,
+            "mode": "insert",
+        }
+    )
+    sync = SyncConfig(
+        name="databricks_smoke",
+        model="ref('users')",
+        destination=dest,
+        sync=SyncOptions(batch_size=10),
+    )
+
+    try:
+        result = run_sync(sync, source, DatabricksDestination(), profile, tmp_path)
+        assert result.success == 3, f"expected 3 loaded rows, got {result.success}"
+        assert result.failed == 0
+
+        conn = _connect(creds)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT name FROM {fqn}")
+                names = {row[0] for row in cur.fetchall()}
+        finally:
+            conn.close()
+        assert names == {"Alice", "Bob", "Carol"}
+    finally:
+        conn = _connect(creds)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(f"DROP TABLE IF EXISTS {fqn}")
+        finally:
+            conn.close()

--- a/tests/integration/dwh/test_snowflake_smoke.py
+++ b/tests/integration/dwh/test_snowflake_smoke.py
@@ -47,9 +47,32 @@ def _readback_count_and_names(creds: dict[str, str], table: str) -> tuple[int, s
     )
     try:
         with conn.cursor() as cur:
-            cur.execute(f'SELECT "name" FROM "{table}"')
+            # Unquoted to match the destination's unquoted INSERT, which
+            # Snowflake folds to UPPERCASE (quoted lowercase wouldn't match).
+            cur.execute(f"SELECT name FROM {table}")
             names = {row[0] for row in cur.fetchall()}
         return len(names), names
+    finally:
+        conn.close()
+
+
+def _create_table(creds: dict[str, str], table: str) -> None:
+    """Pre-create the target table — drt's insert mode INSERTs into an existing
+    table, it doesn't create one. Unquoted identifiers so Snowflake folds them
+    to UPPERCASE, matching the destination's unquoted INSERT column list."""
+    conn = snowflake_connector.connect(
+        account=creds[ACCOUNT_ENV],
+        user=creds[USER_ENV],
+        password=creds[PASSWORD_ENV],
+        warehouse=creds["DRT_SMOKE_SNOWFLAKE_WAREHOUSE"],
+        database=creds["DRT_SMOKE_SNOWFLAKE_DATABASE"],
+        schema=creds["DRT_SMOKE_SNOWFLAKE_SCHEMA"],
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"CREATE TABLE {table} (id INTEGER, name VARCHAR, email VARCHAR)"
+            )
     finally:
         conn.close()
 
@@ -65,7 +88,7 @@ def _drop_table(creds: dict[str, str], table: str) -> None:
     )
     try:
         with conn.cursor() as cur:
-            cur.execute(f'DROP TABLE IF EXISTS "{table}"')
+            cur.execute(f"DROP TABLE IF EXISTS {table}")
     finally:
         conn.close()
 
@@ -105,6 +128,7 @@ def test_snowflake_insert_roundtrip(tmp_path: Path) -> None:
     )
 
     try:
+        _create_table(creds, table)
         result = run_sync(sync, source, SnowflakeDestination(), profile, tmp_path)
 
         assert result.success == 3, f"expected 3 loaded rows, got {result.success}"

--- a/tests/integration/dwh/test_snowflake_smoke.py
+++ b/tests/integration/dwh/test_snowflake_smoke.py
@@ -1,0 +1,142 @@
+"""Snowflake DWH smoke test — reference shape for the harness (#674 / #671).
+
+Drives the full pipeline against a *real* Snowflake account:
+seeded DuckDB ``users`` -> engine -> live Snowflake table -> read back -> verify.
+
+This is the canonical per-warehouse leg. Databricks (#672) and BigQuery (#673)
+mirror this file; only the destination config + read-back/cleanup driver change.
+
+Runs only when the ``DRT_SMOKE_SNOWFLAKE_*`` secrets are present (injected by the
+dwh-smoke workflow). Otherwise it skips — safe no-op for forks / local runs.
+See tests/integration/dwh/README.md for the secret list.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from drt.config.models import SnowflakeDestinationConfig, SyncConfig, SyncOptions
+from drt.destinations.snowflake import SnowflakeDestination
+from drt.engine.sync import run_sync
+
+from .conftest import require_env, seed_duckdb_users, unique_table
+
+pytestmark = pytest.mark.dwh_smoke
+
+# Driver gate: skip the whole module if drt-core[snowflake] isn't installed.
+snowflake_connector = pytest.importorskip("snowflake.connector")
+
+# Env var NAMES the destination resolves credentials from. The smoke secrets
+# are passed straight through under these names.
+ACCOUNT_ENV = "DRT_SMOKE_SNOWFLAKE_ACCOUNT"
+USER_ENV = "DRT_SMOKE_SNOWFLAKE_USER"
+PASSWORD_ENV = "DRT_SMOKE_SNOWFLAKE_PASSWORD"
+
+
+def _readback_count_and_names(creds: dict[str, str], table: str) -> tuple[int, set[str]]:
+    """Open a fresh Snowflake connection and read the rows the sync wrote."""
+    conn = snowflake_connector.connect(
+        account=creds[ACCOUNT_ENV],
+        user=creds[USER_ENV],
+        password=creds[PASSWORD_ENV],
+        warehouse=creds["DRT_SMOKE_SNOWFLAKE_WAREHOUSE"],
+        database=creds["DRT_SMOKE_SNOWFLAKE_DATABASE"],
+        schema=creds["DRT_SMOKE_SNOWFLAKE_SCHEMA"],
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f'SELECT "name" FROM "{table}"')
+            names = {row[0] for row in cur.fetchall()}
+        return len(names), names
+    finally:
+        conn.close()
+
+
+def _drop_table(creds: dict[str, str], table: str) -> None:
+    conn = snowflake_connector.connect(
+        account=creds[ACCOUNT_ENV],
+        user=creds[USER_ENV],
+        password=creds[PASSWORD_ENV],
+        warehouse=creds["DRT_SMOKE_SNOWFLAKE_WAREHOUSE"],
+        database=creds["DRT_SMOKE_SNOWFLAKE_DATABASE"],
+        schema=creds["DRT_SMOKE_SNOWFLAKE_SCHEMA"],
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f'DROP TABLE IF EXISTS "{table}"')
+    finally:
+        conn.close()
+
+
+def test_snowflake_insert_roundtrip(tmp_path: Path) -> None:
+    """3 seeded rows sync into a real Snowflake table and read back intact."""
+    creds = require_env(
+        ACCOUNT_ENV,
+        USER_ENV,
+        PASSWORD_ENV,
+        "DRT_SMOKE_SNOWFLAKE_DATABASE",
+        "DRT_SMOKE_SNOWFLAKE_SCHEMA",
+        "DRT_SMOKE_SNOWFLAKE_WAREHOUSE",
+    )
+
+    source, profile = seed_duckdb_users(tmp_path)
+    table = unique_table("DRT_SMOKE")
+
+    dest = SnowflakeDestinationConfig(
+        **{
+            "type": "snowflake",
+            "account_env": ACCOUNT_ENV,
+            "user_env": USER_ENV,
+            "password_env": PASSWORD_ENV,
+            "database": creds["DRT_SMOKE_SNOWFLAKE_DATABASE"],
+            "schema": creds["DRT_SMOKE_SNOWFLAKE_SCHEMA"],
+            "table": table,
+            "warehouse": creds["DRT_SMOKE_SNOWFLAKE_WAREHOUSE"],
+            "mode": "insert",
+        }
+    )
+    sync = SyncConfig(
+        name="snowflake_smoke",
+        model="ref('users')",
+        destination=dest,
+        sync=SyncOptions(batch_size=10),
+    )
+
+    try:
+        result = run_sync(sync, source, SnowflakeDestination(), profile, tmp_path)
+
+        assert result.success == 3, f"expected 3 loaded rows, got {result.success}"
+        assert result.failed == 0
+
+        count, names = _readback_count_and_names(creds, table)
+        assert count == 3
+        assert names == {"Alice", "Bob", "Carol"}
+    finally:
+        _drop_table(creds, table)
+
+
+def test_snowflake_connection() -> None:
+    """`test_connection` succeeds against the real account (fast credential check)."""
+    creds = require_env(
+        ACCOUNT_ENV,
+        USER_ENV,
+        PASSWORD_ENV,
+        "DRT_SMOKE_SNOWFLAKE_DATABASE",
+        "DRT_SMOKE_SNOWFLAKE_SCHEMA",
+        "DRT_SMOKE_SNOWFLAKE_WAREHOUSE",
+    )
+    dest = SnowflakeDestinationConfig(
+        **{
+            "type": "snowflake",
+            "account_env": ACCOUNT_ENV,
+            "user_env": USER_ENV,
+            "password_env": PASSWORD_ENV,
+            "database": creds["DRT_SMOKE_SNOWFLAKE_DATABASE"],
+            "schema": creds["DRT_SMOKE_SNOWFLAKE_SCHEMA"],
+            "table": "DRT_SMOKE_CONNECTION_CHECK",
+            "warehouse": creds["DRT_SMOKE_SNOWFLAKE_WAREHOUSE"],
+        }
+    )
+    SnowflakeDestination().test_connection(dest)


### PR DESCRIPTION
## What does this PR do?
Adds the credential-agnostic DWH smoke harness from #674. A manually-dispatched + nightly workflow runs a minimal seeded-DuckDB → engine → real-warehouse sync per cloud destination and reads the rows back, mirroring the v0.7.5 DuckDB E2E harness.

Snowflake is the reference leg (`tests/integration/dwh/test_snowflake_smoke.py`); Databricks and BigQuery mirror it — only the destination config + read-back/cleanup driver differ.

**Safe no-op until secrets exist** — gated three ways:
- `pytest.importorskip(...)` — skips unless the warehouse extra is installed
- `require_env(...)` — skips unless the `DRT_SMOKE_*` secrets are set
- workflow jobs are `if: github.repository == 'drt-hub/drt'` + a per-job credential check that no-ops green when the secret is empty

So forks, local runs, and the upstream repo *before secrets are added* are all green without touching a warehouse. Required secret names are documented in `tests/integration/dwh/README.md`.

Cloud secrets + the "verified on a real service ✓" sign-off are yours (#671 / #672 / #673). I can't run these against live warehouses, so the read-back SQL / connector calls follow the documented APIs but haven't hit a real service yet — the first nightly run is the real check.

Verified locally: contributor case → 3 skipped cleanly; `ruff` clean; `mypy drt` clean; full suite collects and existing integration tests pass (24 passed, 3 skipped).

## Related Issue
Closes #674

## Checklist
- [x] Tests pass (`make test`) — added; skip safely without secrets
- [x] Linter passes (`make lint`) — ruff + mypy clean locally
- [ ] Updated `CHANGELOG.md` — N/A `[skip changelog]` (CI/test harness, not user-facing)