### PR TITLE
docs(i18n): bump README.ja marker to the Delta Lake/Iceberg commit

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-sync: base=README.md, hash=38ec3286244e8e838ef767a936d61147283dee67 -->
+<!-- i18n-sync: base=README.md, hash=393d18e5ff4750065aac34d1a81607f773b8018a -->
 
 [English](./README.md) | [日本語](./README.ja.md)
 


### PR DESCRIPTION
## What

Bump the `README.ja.md` i18n-sync marker hash `38ec328 → 393d18e` so `make check-i18n` reports **OK** instead of **STALE**.

## Why

`README.ja.md`'s translated content was already up to date — the Website/X badges (#666), Klaviyo (#648), Airtable (#647), and Delta Lake/Iceberg sources (#675) rows are all present. Only the marker hash on line 1 was left behind, so CI's `check-i18n` step flagged it as stale even though nothing was actually out of sync. This is a marker-only correction.

## Verification

```
$ make check-i18n
OK    CONTRIBUTING.ja.md  (synced with CONTRIBUTING.md)
SKIP  GOVERNANCE.ja.md  (no i18n-sync marker)
OK    README.ja.md  (synced with README.md)
```

[skip changelog]
