### PR TITLE
ci(i18n): weekly staleness audit + bring GOVERNANCE.ja under tracking

### DIFF
--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -1,0 +1,144 @@
+# i18n translation staleness audit.
+#
+# Runs scripts/check-i18n-sync.sh, which audits the CURRENT STATE of the
+# repo (not a PR diff) for translated docs whose English base file has
+# moved on since the translation was last synced:
+#   - root-level    *.{lang}.md          (README.ja.md, CONTRIBUTING.ja.md, …)
+#   - docs/ subdir   docs/**/{lang}/*.md  (docs/ja/configuration.md, …)
+# A translation is "stale" when its `i18n-sync` marker hash no longer
+# matches the latest commit that touched its base file.
+#
+# Real drift this would have caught before it existed: README.ja.md sat
+# stale for three merged PRs (badges + Klaviyo/Airtable/Delta Lake/
+# Iceberg rows) because the translation content was updated but the
+# marker hash bump was forgotten — invisible until someone ran
+# `make check-i18n` by hand.
+#
+# Trigger design — deliberately NOT `on: pull_request`: keeping a
+# translation in sync is a maintainer concern, and a non-Japanese
+# contributor who edits README.md must never have their PR blocked or
+# warned for a JA translation they can't write. Instead this runs
+# post-merge (when a base or translation file lands on main) + weekly,
+# and reports to a maintainer-facing tracking issue — the same model as
+# drift-check.yml and contributors-audit.yml.
+#
+# Note: needs `fetch-depth: 0` — the script resolves each base file's
+# latest commit via `git log`, which a shallow checkout cannot see.
+
+name: i18n-check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'README.md'
+      - 'README.ja.md'
+      - 'CONTRIBUTING.md'
+      - 'CONTRIBUTING.ja.md'
+      - 'GOVERNANCE.md'
+      - 'GOVERNANCE.ja.md'
+      - 'docs/llm/API_REFERENCE.md'
+      - 'docs/ja/**'
+      - 'scripts/check-i18n-sync.sh'
+  schedule:
+    # Monday 02:00 UTC — offset from contributors-audit (00:30) and
+    # drift-check (01:00) so the weekly jobs don't queue on the same minute.
+    - cron: '0 2 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  i18n:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # Full history so `git log -1 -- <base>` can find the latest
+          # commit that touched each English base file.
+          fetch-depth: 0
+
+      - name: Run i18n sync check
+        id: i18n
+        run: |
+          set +e
+          OUTPUT=$(bash scripts/check-i18n-sync.sh 2>&1)
+          EXIT_CODE=$?
+          set -e
+          {
+            echo "exit_code=$EXIT_CODE"
+            echo "report<<EOF"
+            echo "$OUTPUT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          # Also dump to the Action log for quick inspection.
+          echo "$OUTPUT"
+
+      - name: Open / update tracking issue when a translation is stale
+        if: steps.i18n.outputs.exit_code == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="chore(i18n): translations out of sync with their English base"
+          BODY=$(cat <<EOF
+          The \`i18n-check\` workflow found translated docs whose English base file has moved on since the translation was last synced. For each \`STALE\` entry below: update the translation content to match the base file, then bump the \`i18n-sync\` marker hash in the translation's first 5 lines:
+
+          \`\`\`
+          git log -1 --format='%H' -- <base-file>
+          \`\`\`
+
+          Run \`make check-i18n\` locally to reproduce.
+
+          <details>
+          <summary>Full report</summary>
+
+          \`\`\`
+          ${{ steps.i18n.outputs.report }}
+          \`\`\`
+
+          </details>
+
+          ---
+          _Auto-filed by the \`i18n-check\` workflow (post-merge + weekly). It updates this issue in place instead of opening duplicates._
+          EOF
+          )
+
+          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --search "in:title \"translations out of sync\"" \
+            --state open --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --repo "$GITHUB_REPOSITORY" --body "$BODY"
+            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" \
+              --body "i18n audit re-ran on $(date -u +%Y-%m-%d) and still finds stale translations — issue body refreshed with the latest report."
+          else
+            # Ensure the label exists before `gh issue create --label`,
+            # which hard-fails on a missing label. `docs` is the canonical
+            # documentation label in `.github/labels.yml`; the idempotent
+            # --force self-bootstrap lets this workflow file its issue
+            # regardless of whether sync-labels has run yet.
+            gh label create docs \
+              --color "0075ca" \
+              --description "Improvements or additions to documentation" \
+              --force || true
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "$TITLE" \
+              --body "$BODY" \
+              --label "docs"
+          fi
+
+      - name: Close tracking issue when translations are back in sync
+        if: steps.i18n.outputs.exit_code == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --search "in:title \"translations out of sync\"" \
+            --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue close "$EXISTING" --repo "$GITHUB_REPOSITORY" \
+              --comment "All translations are in sync again as of $(date -u +%Y-%m-%d) — closing."
+          fi

--- a/GOVERNANCE.ja.md
+++ b/GOVERNANCE.ja.md
@@ -1,3 +1,5 @@
+<!-- i18n-sync: base=GOVERNANCE.md, hash=c0f6b55b945d8bbaddb83b9ebc579a7314b4efe1 -->
+
 [English](./GOVERNANCE.md) | [日本語](./GOVERNANCE.ja.md)
 
 # ガバナンス
@@ -91,6 +93,12 @@ drt は **lazy consensus** モデルに従います:
 - Owner にメッセージを送る
 
 理由の説明は不要です。後日再度参加することも歓迎します。
+
+## オープンコアモデル
+
+常に無償で提供されるもの (コネクタ、CLI、同期エンジン、MCP サーバー) と、エンタープライズ境界を定義するもの (RBAC、監査ログ、プラグインシステム、クラウドホスティング) の詳細は [OPEN_CORE.md](./OPEN_CORE.md) を参照してください。
+
+この境界は同ドキュメントに示された原則に基づいて決定され、lazy consensus (上記「意思決定の方法」を参照) によって承認されます。
 
 ## 本ドキュメントの変更
 


### PR DESCRIPTION
i18n maintenance follow-up to #683 / #681. Two related changes.

## 1. `.github/workflows/i18n-check.yml` (new) — weekly staleness audit
A maintainer-facing audit that runs `scripts/check-i18n-sync.sh` **post-merge + weekly** (never on PRs) and opens / updates a single tracking issue when any translation's `i18n-sync` marker falls behind its English base — then closes it when everything is back in sync.

- **Why:** `README.ja.md` recently sat stale for three merged PRs because the content was translated but the marker hash bump was forgotten — invisible until someone ran `make check-i18n` by hand (this is exactly what #681 fixed). `check-i18n` already runs in `ci.yml` but is **warn-only by design** (blocking it would punish non-Japanese contributors who edit an English base for a translation they can't write). This workflow surfaces drift to a maintainer **without** ever blocking a PR.
- **Model:** mirrors `drift-check.yml` / `contributors-audit.yml` (post-merge + weekly → tracking issue, self-bootstraps the `docs` label, de-dupes by title).
- **One deliberate difference:** `fetch-depth: 0` — the script resolves each base file's latest commit via `git log`, which a shallow checkout can't see.

## 2. `GOVERNANCE.ja.md` — brought under tracking
It was the one translation `check-i18n` reported as `SKIP` (no marker). Auditing it revealed it was genuinely **stale**: GOVERNANCE.md gained an **Open Core Model** section in #456 that was never translated.

- Added the missing `## オープンコアモデル` section (mirrors the English).
- Added the `i18n-sync` marker (`base=GOVERNANCE.md`), so it's tracked from now on.

## Verification
```
$ make check-i18n
OK    CONTRIBUTING.ja.md  (synced with CONTRIBUTING.md)
OK    GOVERNANCE.ja.md  (synced with GOVERNANCE.md)
OK    README.ja.md  (synced with README.md)
OK    docs/ja/configuration.md  (synced with docs/llm/API_REFERENCE.md)

Checked 4 translation(s).
```
All four translations now tracked and in sync (was 2 tracked + 1 stale + 1 untracked before this chain of PRs). Workflow YAML validated with `yaml.safe_load`.

[skip changelog]
