### PR TITLE
test(bigquery): add MERGE-path smoke coverage + provisioning docs (#673, #645)

### DIFF
--- a/tests/integration/dwh/README.md
+++ b/tests/integration/dwh/README.md
@@ -61,6 +61,21 @@ the cloud accounts and the "verified ✓" sign-off are the maintainer's
 | `SMOKE_BIGQUERY_DATASET` | a throwaway dataset |
 | `SMOKE_BIGQUERY_KEYFILE_JSON` | full service-account JSON; the workflow writes it to a temp file |
 
+BigQuery prerequisites (#673):
+
+- A **billing-enabled** project (BigQuery jobs require an active billing account,
+  even for tiny throwaway tables).
+- **Service-account keyfile** auth. The BigQuery leg drives two write paths — the
+  streaming `insert` path and the temp-table `MERGE` path (`<table>_drt_tmp` →
+  `MERGE` → drop, #645) — both against a throwaway dataset.
+- Least-privilege roles for the service account: `roles/bigquery.jobUser` on the
+  project (to run load/query/MERGE jobs) **plus** dataset-scoped
+  `roles/bigquery.dataEditor` on the smoke dataset (to create/insert/drop the
+  target + `_drt_tmp` tables). Avoid granting project-wide `dataEditor`.
+- Caveat: if the org enforces the `iam.disableServiceAccountKeyCreation`
+  constraint, a keyfile can't be minted for the SA — provision the key in a
+  project/folder where that policy is not enforced, or use an exempted SA.
+
 ## Adding a warehouse leg
 
 `test_snowflake_smoke.py` is the reference shape. To add another, copy it and

--- a/tests/integration/dwh/test_bigquery_smoke.py
+++ b/tests/integration/dwh/test_bigquery_smoke.py
@@ -60,9 +60,7 @@ def test_bigquery_insert_roundtrip(tmp_path: Path) -> None:
     try:
         # drt's insert mode streams into an existing table (insert_rows_json);
         # it doesn't create one, so pre-create with the seed schema.
-        client.query(
-            f"CREATE TABLE {fqn} (id INT64, name STRING, email STRING)"
-        ).result()
+        client.query(f"CREATE TABLE {fqn} (id INT64, name STRING, email STRING)").result()
 
         result = run_sync(sync, source, BigQueryDestination(), profile, tmp_path)
         assert result.success == 3, f"expected 3 loaded rows, got {result.success}"
@@ -80,3 +78,102 @@ def test_bigquery_insert_roundtrip(tmp_path: Path) -> None:
         assert names == {"Alice", "Bob", "Carol"}
     finally:
         client.query(f"DROP TABLE IF EXISTS {fqn}").result()
+
+
+def test_bigquery_merge_roundtrip(tmp_path: Path) -> None:
+    """MERGE mode upserts via a temp table + cleans it up (#645).
+
+    Drives the second BigQuery write path (``mode: merge``) end-to-end: the
+    engine loads the batch into ``<table>_drt_tmp`` (``load_table_from_json``),
+    runs one ``MERGE INTO target USING tmp`` (UPDATE matched / INSERT unmatched),
+    then drops the temp table. The target is pre-seeded with a stale ``id=1`` row
+    so the run exercises both MERGE branches (UPDATE id=1, INSERT id=2,3), and we
+    assert the ``_drt_tmp`` staging table no longer exists afterwards.
+    """
+    from google.cloud.exceptions import NotFound
+
+    creds = require_env(
+        "DRT_SMOKE_BIGQUERY_PROJECT",
+        "DRT_SMOKE_BIGQUERY_DATASET",
+        "DRT_SMOKE_BIGQUERY_KEYFILE",
+    )
+    source, profile = seed_duckdb_users(tmp_path)
+    table = unique_table("drt_smoke")
+    project = creds["DRT_SMOKE_BIGQUERY_PROJECT"]
+    dataset = creds["DRT_SMOKE_BIGQUERY_DATASET"]
+    keyfile = creds["DRT_SMOKE_BIGQUERY_KEYFILE"]
+    fqn = f"`{project}`.`{dataset}`.`{table}`"
+    # Matches the destination's temp-table naming: f"{project}.{dataset}.{table}_drt_tmp".
+    tmp_table_id = f"{project}.{dataset}.{table}_drt_tmp"
+
+    dest = BigQueryDestinationConfig(
+        **{
+            "type": "bigquery",
+            "project": project,
+            "dataset": dataset,
+            "table": table,
+            "mode": "merge",
+            "upsert_key": ["id"],
+            "method": "keyfile",
+            "keyfile": keyfile,
+        }
+    )
+    sync = SyncConfig(
+        name="bigquery_merge_smoke",
+        model="ref('users')",
+        destination=dest,
+        sync=SyncOptions(batch_size=10),
+    )
+
+    client = bigquery.Client.from_service_account_json(keyfile, project=project)
+    try:
+        client.query(f"CREATE TABLE {fqn} (id INT64, name STRING, email STRING)").result()
+        # Pre-seed a stale id=1 via DML INSERT (immediately queryable, unlike a
+        # streaming insert) so the MERGE has a matched row to UPDATE.
+        client.query(
+            f"INSERT INTO {fqn} (id, name, email) VALUES (1, 'STALE', 'stale@example.com')"
+        ).result()
+
+        result = run_sync(sync, source, BigQueryDestination(), profile, tmp_path)
+        assert result.success == 3, f"expected 3 upserted rows, got {result.success}"
+        assert result.failed == 0
+
+        # MERGE results are visible to SQL immediately (no streaming buffer).
+        rows = list(client.query(f"SELECT id, name FROM {fqn}").result())
+        by_id = {row["id"]: row["name"] for row in rows}
+        assert by_id == {
+            1: "Alice",
+            2: "Bob",
+            3: "Carol",
+        }, f"expected id=1 UPDATED to Alice + id=2,3 INSERTed, got {by_id}"
+
+        # Temp staging table must be dropped (#645).
+        with pytest.raises(NotFound):
+            client.get_table(tmp_table_id)
+    finally:
+        client.query(f"DROP TABLE IF EXISTS {fqn}").result()
+        client.query(f"DROP TABLE IF EXISTS `{tmp_table_id}`").result()
+
+
+def test_bigquery_connection() -> None:
+    """`test_connection` succeeds against the real project (fast credential check).
+
+    Mirrors `test_snowflake_connection` — runs the destination's `SELECT 1`
+    connectivity probe, no table needed.
+    """
+    creds = require_env(
+        "DRT_SMOKE_BIGQUERY_PROJECT",
+        "DRT_SMOKE_BIGQUERY_DATASET",
+        "DRT_SMOKE_BIGQUERY_KEYFILE",
+    )
+    dest = BigQueryDestinationConfig(
+        **{
+            "type": "bigquery",
+            "project": creds["DRT_SMOKE_BIGQUERY_PROJECT"],
+            "dataset": creds["DRT_SMOKE_BIGQUERY_DATASET"],
+            "table": "drt_smoke_connection_check",
+            "method": "keyfile",
+            "keyfile": creds["DRT_SMOKE_BIGQUERY_KEYFILE"],
+        }
+    )
+    BigQueryDestination().test_connection(dest)


### PR DESCRIPTION
## What

Adds the missing BigQuery leg coverage to the DWH smoke harness, per the plan agreed on #654.
The BigQuery smoke previously covered only the streaming `insert` path; this adds the two tests
@masukai green-lit:

- **`test_bigquery_merge_roundtrip`** — drives `mode: merge` end-to-end against a real project:
  `load_table_from_json` into `<table>_drt_tmp` → single `MERGE` (UPDATE matched `id=1` / INSERT
  not-matched `id=2,3`) → temp-table drop. Pre-seeds a stale `id=1` so **both** MERGE branches run,
  and asserts the `_drt_tmp` staging table is cleaned up afterwards (#645).
- **`test_bigquery_connection`** — fast credential check via `test_connection` (`SELECT 1`),
  mirroring `test_snowflake_connection`.

Also adds BigQuery provisioning notes to `tests/integration/dwh/README.md` (billing-enabled
project, keyfile auth, least-privilege roles, `disableServiceAccountKeyCreation` caveat).

## Why

Part of #673 (BigQuery DWH smoke validation), under epic #654. With the existing
`test_bigquery_insert_roundtrip` covering the streaming leg, merge + connection close out the
BigQuery verification set. Composite-key MERGE is intentionally left as an optional follow-up to
keep this PR's scope tight (single-`id` `upsert_key`, matching the reference shape).

## Gating (safe no-op)

Both tests use the same double gate as the rest of the harness — `pytest.importorskip` (driver) +
`require_env` (credentials) — so a plain `pytest` run, every fork, and CI without
`DRT_SMOKE_BIGQUERY_*` secrets all skip cleanly without opening a connection.

## Verification

Ran green locally against a real BigQuery project (`drt_smoke` dataset) — `insert` + `merge` +
`connection` all pass; created tables (`drt_smoke_*` and `_drt_tmp`) are dropped in `finally`, so
the dataset returns to its prior state. `ruff` + CI `mypy drt` clean.

The cloud secrets (`SMOKE_BIGQUERY_*`) and the official "verified on a real service ✓" sign-off
remain @masukai's per the #654 split — happy to hand off once this is in.

Part of #673 · Epic #654 · Cleanup #645
