### PR TITLE
test(databricks): DWH smoke — insert + swap-overwrite + complex-type/VARIANT + connection (#672)

### DIFF
--- a/tests/integration/dwh/README.md
+++ b/tests/integration/dwh/README.md
@@ -61,12 +61,16 @@ Databricks prerequisites (#672):
   created **Delta** (`USING DELTA`): the `replace_strategy: swap` leg relies on
   Delta `INSERT OVERWRITE` snapshot-isolation atomicity.
 - A running **SQL warehouse**; its HTTP path is `SMOKE_DATABRICKS_HTTP_PATH`.
+  The complex-type leg uses a `VARIANT` column, so the warehouse must be on a
+  channel that supports VARIANT (current serverless/pro warehouses do).
 - Least-privilege grants for the token principal: `USE CATALOG` + `USE SCHEMA`,
   plus `CREATE TABLE` / `MODIFY` on the smoke schema — the swap leg builds and
-  drops a `<table>__drt_swap` shadow. Scope the grants to the throwaway schema,
-  not the whole catalog.
-- The `insert` + `replace_strategy: swap` + `test_connection` legs run against
-  the same throwaway schema and drop everything they create in `finally`.
+  drops a `<table>__drt_swap` shadow, and the complex-type leg creates ARRAY /
+  STRUCT / VARIANT tables. Scope the grants to the throwaway schema, not the
+  whole catalog.
+- The `insert` + `replace_strategy: swap` + complex-type (`from_json` /
+  `parse_json`) + `test_connection` legs all run against the same throwaway
+  schema and drop everything they create in `finally`.
 
 **BigQuery** (#673)
 | Secret | Notes |

--- a/tests/integration/dwh/README.md
+++ b/tests/integration/dwh/README.md
@@ -54,6 +54,22 @@ the cloud accounts and the "verified ✓" sign-off are the maintainer's
 | `SMOKE_DATABRICKS_CATALOG` | |
 | `SMOKE_DATABRICKS_SCHEMA` | |
 
+Databricks prerequisites (#672):
+
+- A **Unity Catalog** catalog + schema the token principal can write to (Hive
+  Metastore works too — set the catalog to `hive_metastore`). All tables are
+  created **Delta** (`USING DELTA`): the `replace_strategy: swap` and complex-type
+  legs rely on Delta semantics.
+- A running **SQL warehouse**; its HTTP path is `SMOKE_DATABRICKS_HTTP_PATH`.
+- Least-privilege grants for the token principal: `USE CATALOG` + `USE SCHEMA`,
+  plus `CREATE TABLE` / `MODIFY` on the smoke schema — the swap leg builds and
+  drops a `<table>__drt_swap` shadow, and the complex-type leg creates ARRAY /
+  STRUCT / VARIANT tables. Scope the grants to the throwaway schema, not the
+  whole catalog.
+- The `insert` + `replace_strategy: swap` + complex-type (`from_json` /
+  `parse_json`) + `test_connection` legs all run against the same throwaway
+  schema and drop everything they create in `finally`.
+
 **BigQuery** (#673)
 | Secret | Notes |
 | --- | --- |

--- a/tests/integration/dwh/README.md
+++ b/tests/integration/dwh/README.md
@@ -58,17 +58,15 @@ Databricks prerequisites (#672):
 
 - A **Unity Catalog** catalog + schema the token principal can write to (Hive
   Metastore works too — set the catalog to `hive_metastore`). All tables are
-  created **Delta** (`USING DELTA`): the `replace_strategy: swap` and complex-type
-  legs rely on Delta semantics.
+  created **Delta** (`USING DELTA`): the `replace_strategy: swap` leg relies on
+  Delta `INSERT OVERWRITE` snapshot-isolation atomicity.
 - A running **SQL warehouse**; its HTTP path is `SMOKE_DATABRICKS_HTTP_PATH`.
 - Least-privilege grants for the token principal: `USE CATALOG` + `USE SCHEMA`,
   plus `CREATE TABLE` / `MODIFY` on the smoke schema — the swap leg builds and
-  drops a `<table>__drt_swap` shadow, and the complex-type leg creates ARRAY /
-  STRUCT / VARIANT tables. Scope the grants to the throwaway schema, not the
-  whole catalog.
-- The `insert` + `replace_strategy: swap` + complex-type (`from_json` /
-  `parse_json`) + `test_connection` legs all run against the same throwaway
-  schema and drop everything they create in `finally`.
+  drops a `<table>__drt_swap` shadow. Scope the grants to the throwaway schema,
+  not the whole catalog.
+- The `insert` + `replace_strategy: swap` + `test_connection` legs run against
+  the same throwaway schema and drop everything they create in `finally`.
 
 **BigQuery** (#673)
 | Secret | Notes |

--- a/tests/integration/dwh/test_databricks_smoke.py
+++ b/tests/integration/dwh/test_databricks_smoke.py
@@ -3,30 +3,28 @@
 seeded DuckDB ``users`` -> engine -> live Databricks Delta table -> read back.
 Runs only when ``DRT_SMOKE_DATABRICKS_*`` secrets are present; skips otherwise.
 
-Covers the #672 verification set on a real account:
+Covers, per the #672 split (BigQuery #673 / PR #700 is the reference shape):
 
 - ``test_databricks_insert_roundtrip`` — the streaming ``mode: insert`` leg.
 - ``test_databricks_replace_swap_roundtrip`` — ``INSERT OVERWRITE`` atomicity for
   ``replace_strategy: swap`` (#644): a pre-seeded stale row is replaced by the
   atomic finalize-time overwrite and the ``__drt_swap`` shadow is cleaned up.
-- ``test_databricks_complex_type_serialization`` — complex-type / VARIANT-
-  equivalent serialization (#317 Databricks leg): STRUCT / ARRAY reconstructed
-  via ``from_json`` and a VARIANT column via ``parse_json``.
 - ``test_databricks_connection`` — fast credential check via ``test_connection``.
+
+Complex-type / VARIANT serialization (the other #672 bullet, #317 Databricks
+leg) is intentionally left as an optional follow-up to keep this leg's scope
+aligned with #700 (which likewise deferred composite-key MERGE).
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import pytest
 
-from drt.config.credentials import DuckDBProfile
 from drt.config.models import DatabricksDestinationConfig, SyncConfig, SyncOptions
 from drt.destinations.databricks import DatabricksDestination
 from drt.engine.sync import run_sync
-from drt.sources.duckdb import DuckDBSource
 
 from .conftest import require_env, seed_duckdb_users, unique_table
 
@@ -47,49 +45,32 @@ def _connect(creds: dict[str, str]):
     )
 
 
-def _require_creds() -> dict[str, str]:
-    """The five env vars every Databricks smoke test needs (or skip)."""
-    return require_env(
+def test_databricks_insert_roundtrip(tmp_path: Path) -> None:
+    creds = require_env(
         HOST_ENV,
         HTTP_PATH_ENV,
         TOKEN_ENV,
         "DRT_SMOKE_DATABRICKS_CATALOG",
         "DRT_SMOKE_DATABRICKS_SCHEMA",
     )
+    source, profile = seed_duckdb_users(tmp_path)
+    table = unique_table("drt_smoke")
+    catalog = creds["DRT_SMOKE_DATABRICKS_CATALOG"]
+    schema = creds["DRT_SMOKE_DATABRICKS_SCHEMA"]
+    fqn = f"`{catalog}`.`{schema}`.`{table}`"
 
-
-def _dest_config(
-    creds: dict[str, str], table: str, **overrides: Any
-) -> DatabricksDestinationConfig:
-    """Build a Databricks destination config against the smoke catalog/schema."""
-    return DatabricksDestinationConfig(
+    dest = DatabricksDestinationConfig(
         **{
             "type": "databricks",
             "host_env": HOST_ENV,
             "http_path_env": HTTP_PATH_ENV,
             "token_env": TOKEN_ENV,
-            "catalog": creds["DRT_SMOKE_DATABRICKS_CATALOG"],
-            "schema": creds["DRT_SMOKE_DATABRICKS_SCHEMA"],
+            "catalog": catalog,
+            "schema": schema,
             "table": table,
             "mode": "insert",
-            **overrides,
         }
     )
-
-
-def _fqn(creds: dict[str, str], table: str) -> str:
-    catalog = creds["DRT_SMOKE_DATABRICKS_CATALOG"]
-    schema = creds["DRT_SMOKE_DATABRICKS_SCHEMA"]
-    return f"`{catalog}`.`{schema}`.`{table}`"
-
-
-def test_databricks_insert_roundtrip(tmp_path: Path) -> None:
-    creds = _require_creds()
-    source, profile = seed_duckdb_users(tmp_path)
-    table = unique_table("drt_smoke")
-    fqn = _fqn(creds, table)
-
-    dest = _dest_config(creds, table, mode="insert")
     sync = SyncConfig(
         name="databricks_smoke",
         model="ref('users')",
@@ -131,20 +112,39 @@ def test_databricks_insert_roundtrip(tmp_path: Path) -> None:
 def test_databricks_replace_swap_roundtrip(tmp_path: Path) -> None:
     """``replace_strategy: swap`` — atomic ``INSERT OVERWRITE`` from a shadow (#644).
 
-    Pre-seeds a stale row the source never emits, runs ``sync.mode: replace`` with
-    ``replace_strategy: swap``, and asserts (a) the stale row is gone — the
-    finalize-time ``INSERT OVERWRITE`` atomically replaced the table's data — and
-    (b) the ``<table>__drt_swap`` shadow was dropped in ``finalize_sync``.
+    The Databricks analogue of ``test_bigquery_merge_roundtrip`` (#700): drives one
+    non-``insert`` write mode end-to-end. Pre-seeds a stale row the source never
+    emits, runs ``sync.mode: replace`` with ``replace_strategy: swap``, then asserts
+    (a) the stale row is gone — the finalize-time ``INSERT OVERWRITE`` atomically
+    replaced the table's data — and (b) the ``<table>__drt_swap`` shadow was dropped
+    in ``finalize_sync``.
     """
-    creds = _require_creds()
+    creds = require_env(
+        HOST_ENV,
+        HTTP_PATH_ENV,
+        TOKEN_ENV,
+        "DRT_SMOKE_DATABRICKS_CATALOG",
+        "DRT_SMOKE_DATABRICKS_SCHEMA",
+    )
     source, profile = seed_duckdb_users(tmp_path)
     table = unique_table("drt_smoke")
-    fqn = _fqn(creds, table)
     catalog = creds["DRT_SMOKE_DATABRICKS_CATALOG"]
     schema = creds["DRT_SMOKE_DATABRICKS_SCHEMA"]
+    fqn = f"`{catalog}`.`{schema}`.`{table}`"
     shadow_fqn = f"`{catalog}`.`{schema}`.`{table}__drt_swap`"
 
-    dest = _dest_config(creds, table, mode="insert")
+    dest = DatabricksDestinationConfig(
+        **{
+            "type": "databricks",
+            "host_env": HOST_ENV,
+            "http_path_env": HTTP_PATH_ENV,
+            "token_env": TOKEN_ENV,
+            "catalog": catalog,
+            "schema": schema,
+            "table": table,
+            "mode": "insert",
+        }
+    )
     sync = SyncConfig(
         name="databricks_swap_smoke",
         model="ref('users')",
@@ -152,9 +152,9 @@ def test_databricks_replace_swap_roundtrip(tmp_path: Path) -> None:
         sync=SyncOptions(mode="replace", replace_strategy="swap", batch_size=10),
     )
 
-    # Pre-create the target (Delta) and seed a stale row. The swap must exist for
-    # the shadow path to engage — a first run with no target falls through to a
-    # direct write and never builds a shadow.
+    # Pre-create the target (Delta) and seed a stale row. The target must exist
+    # for the shadow path to engage — a first run with no target falls through to
+    # a direct write and never builds a shadow.
     conn = _connect(creds)
     try:
         with conn.cursor() as cur:
@@ -191,102 +191,28 @@ def test_databricks_replace_swap_roundtrip(tmp_path: Path) -> None:
             conn.close()
 
 
-def test_databricks_complex_type_serialization(tmp_path: Path) -> None:
-    """Complex-type / VARIANT-equivalent serialization on a real account (#317 leg).
-
-    Seeds a DuckDB source whose rows carry a Python ``list`` and ``dict`` and syncs
-    them into a Databricks table with ARRAY / STRUCT / VARIANT columns. The write
-    path introspects ``information_schema`` and wraps the binds
-    (``from_json(%s, '<ddl>')`` for STRUCT/ARRAY, ``parse_json(%s)`` for VARIANT).
-    Reading typed sub-fields back proves the values reconstructed as real complex
-    types rather than opaque JSON strings.
-    """
-    creds = _require_creds()
-    table = unique_table("drt_smoke")
-    fqn = _fqn(creds, table)
-
-    # Source: DuckDB LIST -> Python list, STRUCT -> Python dict. The `meta` STRUCT
-    # targets a Databricks VARIANT (parse_json); `tags`/`attrs` target ARRAY/STRUCT
-    # (from_json). One row is enough to exercise all three wrap sites.
-    duckdb = pytest.importorskip("duckdb")
-    db_path = str(tmp_path / "complex_source.duckdb")
-    dconn = duckdb.connect(db_path)
-    try:
-        dconn.execute(
-            "CREATE TABLE events ("
-            "  id INTEGER,"
-            "  tags VARCHAR[],"
-            "  attrs STRUCT(theme VARCHAR, level INTEGER),"
-            "  meta STRUCT(source VARCHAR, verified BOOLEAN)"
-            ")"
-        )
-        dconn.execute(
-            "INSERT INTO events VALUES "
-            "(1, ['a', 'b'], {'theme': 'dark', 'level': 3}, "
-            "{'source': 'crm', 'verified': true})"
-        )
-    finally:
-        dconn.close()
-    source = DuckDBSource()
-    profile = DuckDBProfile(type="duckdb", database=db_path)
-
-    dest = _dest_config(creds, table, mode="insert")
-    sync = SyncConfig(
-        name="databricks_complex_smoke",
-        model="ref('events')",
-        destination=dest,
-        sync=SyncOptions(batch_size=10),
-    )
-
-    conn = _connect(creds)
-    try:
-        with conn.cursor() as cur:
-            cur.execute(
-                f"CREATE TABLE {fqn} ("
-                "  id INT,"
-                "  tags ARRAY<STRING>,"
-                "  attrs STRUCT<theme: STRING, level: INT>,"
-                "  meta VARIANT"
-                ") USING DELTA"
-            )
-    finally:
-        conn.close()
-
-    try:
-        result = run_sync(sync, source, DatabricksDestination(), profile, tmp_path)
-        assert result.success == 1, f"expected 1 loaded row, got {result.success}"
-        assert result.failed == 0
-
-        conn = _connect(creds)
-        try:
-            with conn.cursor() as cur:
-                # Access typed sub-fields: array element, struct field, and a
-                # VARIANT path (`meta:source`). If serialization had stored a raw
-                # JSON string, these typed accessors would fail or return null.
-                cur.execute(
-                    "SELECT element_at(tags, 1), attrs.theme, attrs.level, "
-                    f"CAST(meta:source AS STRING) FROM {fqn} WHERE id = 1"
-                )
-                row = cur.fetchone()
-        finally:
-            conn.close()
-        assert row is not None, "row did not land"
-        first_tag, theme, level, meta_source = row
-        assert first_tag == "a"
-        assert theme == "dark"
-        assert int(level) == 3
-        assert meta_source == "crm"
-    finally:
-        conn = _connect(creds)
-        try:
-            with conn.cursor() as cur:
-                cur.execute(f"DROP TABLE IF EXISTS {fqn}")
-        finally:
-            conn.close()
-
-
 def test_databricks_connection() -> None:
-    """`test_connection` succeeds against the real account (fast credential check)."""
-    creds = _require_creds()
-    dest = _dest_config(creds, "drt_smoke_connection_check")
+    """`test_connection` succeeds against the real account (fast credential check).
+
+    Mirrors ``test_snowflake_connection`` / ``test_bigquery_connection``.
+    """
+    creds = require_env(
+        HOST_ENV,
+        HTTP_PATH_ENV,
+        TOKEN_ENV,
+        "DRT_SMOKE_DATABRICKS_CATALOG",
+        "DRT_SMOKE_DATABRICKS_SCHEMA",
+    )
+    dest = DatabricksDestinationConfig(
+        **{
+            "type": "databricks",
+            "host_env": HOST_ENV,
+            "http_path_env": HTTP_PATH_ENV,
+            "token_env": TOKEN_ENV,
+            "catalog": creds["DRT_SMOKE_DATABRICKS_CATALOG"],
+            "schema": creds["DRT_SMOKE_DATABRICKS_SCHEMA"],
+            "table": "drt_smoke_connection_check",
+            "mode": "insert",
+        }
+    )
     DatabricksDestination().test_connection(dest)

--- a/tests/integration/dwh/test_databricks_smoke.py
+++ b/tests/integration/dwh/test_databricks_smoke.py
@@ -3,17 +3,17 @@
 seeded DuckDB ``users`` -> engine -> live Databricks Delta table -> read back.
 Runs only when ``DRT_SMOKE_DATABRICKS_*`` secrets are present; skips otherwise.
 
-Covers, per the #672 split (BigQuery #673 / PR #700 is the reference shape):
+Covers the #672 verification set (BigQuery #673 / PR #700 is the reference shape):
 
 - ``test_databricks_insert_roundtrip`` — the streaming ``mode: insert`` leg.
 - ``test_databricks_replace_swap_roundtrip`` — ``INSERT OVERWRITE`` atomicity for
   ``replace_strategy: swap`` (#644): a pre-seeded stale row is replaced by the
   atomic finalize-time overwrite and the ``__drt_swap`` shadow is cleaned up.
+- ``test_databricks_complex_type_serialization`` — complex-type / VARIANT
+  serialization (#317 Databricks leg): ARRAY / STRUCT reconstructed via
+  ``from_json`` and a VARIANT column via ``parse_json``, proven by reading
+  typed sub-fields back.
 - ``test_databricks_connection`` — fast credential check via ``test_connection``.
-
-Complex-type / VARIANT serialization (the other #672 bullet, #317 Databricks
-leg) is intentionally left as an optional follow-up to keep this leg's scope
-aligned with #700 (which likewise deferred composite-key MERGE).
 """
 
 from __future__ import annotations
@@ -22,9 +22,11 @@ from pathlib import Path
 
 import pytest
 
+from drt.config.credentials import DuckDBProfile
 from drt.config.models import DatabricksDestinationConfig, SyncConfig, SyncOptions
 from drt.destinations.databricks import DatabricksDestination
 from drt.engine.sync import run_sync
+from drt.sources.duckdb import DuckDBSource
 
 from .conftest import require_env, seed_duckdb_users, unique_table
 
@@ -187,6 +189,119 @@ def test_databricks_replace_swap_roundtrip(tmp_path: Path) -> None:
             with conn.cursor() as cur:
                 cur.execute(f"DROP TABLE IF EXISTS {fqn}")
                 cur.execute(f"DROP TABLE IF EXISTS {shadow_fqn}")
+        finally:
+            conn.close()
+
+
+def test_databricks_complex_type_serialization(tmp_path: Path) -> None:
+    """Complex-type / VARIANT serialization on a real account (#317 Databricks leg).
+
+    Seeds a DuckDB source whose row carries a Python ``list`` and ``dict`` and
+    syncs it into a Databricks table with ARRAY / STRUCT / VARIANT columns. The
+    write path introspects ``information_schema`` and wraps the binds
+    (``from_json(%s, '<ddl>')`` for STRUCT/ARRAY, ``parse_json(%s)`` for VARIANT).
+    Reading typed sub-fields back proves the values reconstructed as real complex
+    types rather than opaque JSON strings.
+    """
+    creds = require_env(
+        HOST_ENV,
+        HTTP_PATH_ENV,
+        TOKEN_ENV,
+        "DRT_SMOKE_DATABRICKS_CATALOG",
+        "DRT_SMOKE_DATABRICKS_SCHEMA",
+    )
+    table = unique_table("drt_smoke")
+    catalog = creds["DRT_SMOKE_DATABRICKS_CATALOG"]
+    schema = creds["DRT_SMOKE_DATABRICKS_SCHEMA"]
+    fqn = f"`{catalog}`.`{schema}`.`{table}`"
+
+    # Source: DuckDB LIST -> Python list, STRUCT -> Python dict. `tags`/`attrs`
+    # target ARRAY/STRUCT (from_json); `meta` targets VARIANT (parse_json). One
+    # row is enough to exercise all three wrap sites.
+    duckdb = pytest.importorskip("duckdb")
+    db_path = str(tmp_path / "complex_source.duckdb")
+    dconn = duckdb.connect(db_path)
+    try:
+        dconn.execute(
+            "CREATE TABLE events ("
+            "  id INTEGER,"
+            "  tags VARCHAR[],"
+            "  attrs STRUCT(theme VARCHAR, level INTEGER),"
+            "  meta STRUCT(source VARCHAR, verified BOOLEAN)"
+            ")"
+        )
+        dconn.execute(
+            "INSERT INTO events VALUES "
+            "(1, ['a', 'b'], {'theme': 'dark', 'level': 3}, "
+            "{'source': 'crm', 'verified': true})"
+        )
+    finally:
+        dconn.close()
+    source = DuckDBSource()
+    profile = DuckDBProfile(type="duckdb", database=db_path)
+
+    dest = DatabricksDestinationConfig(
+        **{
+            "type": "databricks",
+            "host_env": HOST_ENV,
+            "http_path_env": HTTP_PATH_ENV,
+            "token_env": TOKEN_ENV,
+            "catalog": catalog,
+            "schema": schema,
+            "table": table,
+            "mode": "insert",
+        }
+    )
+    sync = SyncConfig(
+        name="databricks_complex_smoke",
+        model="ref('events')",
+        destination=dest,
+        sync=SyncOptions(batch_size=10),
+    )
+
+    conn = _connect(creds)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"CREATE TABLE {fqn} ("
+                "  id INT,"
+                "  tags ARRAY<STRING>,"
+                "  attrs STRUCT<theme: STRING, level: INT>,"
+                "  meta VARIANT"
+                ") USING DELTA"
+            )
+    finally:
+        conn.close()
+
+    try:
+        result = run_sync(sync, source, DatabricksDestination(), profile, tmp_path)
+        assert result.success == 1, f"expected 1 loaded row, got {result.success}"
+        assert result.failed == 0
+
+        conn = _connect(creds)
+        try:
+            with conn.cursor() as cur:
+                # Access typed sub-fields: array element, struct fields, and a
+                # VARIANT path (`meta:source`). If serialization had stored raw
+                # JSON strings, these typed accessors would fail or return null.
+                cur.execute(
+                    "SELECT element_at(tags, 1), attrs.theme, attrs.level, "
+                    f"CAST(meta:source AS STRING) FROM {fqn} WHERE id = 1"
+                )
+                row = cur.fetchone()
+        finally:
+            conn.close()
+        assert row is not None, "row did not land"
+        first_tag, theme, level, meta_source = row
+        assert first_tag == "a"
+        assert theme == "dark"
+        assert int(level) == 3
+        assert meta_source == "crm"
+    finally:
+        conn = _connect(creds)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(f"DROP TABLE IF EXISTS {fqn}")
         finally:
             conn.close()
 

--- a/tests/integration/dwh/test_databricks_smoke.py
+++ b/tests/integration/dwh/test_databricks_smoke.py
@@ -2,17 +2,31 @@
 
 seeded DuckDB ``users`` -> engine -> live Databricks Delta table -> read back.
 Runs only when ``DRT_SMOKE_DATABRICKS_*`` secrets are present; skips otherwise.
+
+Covers the #672 verification set on a real account:
+
+- ``test_databricks_insert_roundtrip`` — the streaming ``mode: insert`` leg.
+- ``test_databricks_replace_swap_roundtrip`` — ``INSERT OVERWRITE`` atomicity for
+  ``replace_strategy: swap`` (#644): a pre-seeded stale row is replaced by the
+  atomic finalize-time overwrite and the ``__drt_swap`` shadow is cleaned up.
+- ``test_databricks_complex_type_serialization`` — complex-type / VARIANT-
+  equivalent serialization (#317 Databricks leg): STRUCT / ARRAY reconstructed
+  via ``from_json`` and a VARIANT column via ``parse_json``.
+- ``test_databricks_connection`` — fast credential check via ``test_connection``.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
+from drt.config.credentials import DuckDBProfile
 from drt.config.models import DatabricksDestinationConfig, SyncConfig, SyncOptions
 from drt.destinations.databricks import DatabricksDestination
 from drt.engine.sync import run_sync
+from drt.sources.duckdb import DuckDBSource
 
 from .conftest import require_env, seed_duckdb_users, unique_table
 
@@ -33,32 +47,49 @@ def _connect(creds: dict[str, str]):
     )
 
 
-def test_databricks_insert_roundtrip(tmp_path: Path) -> None:
-    creds = require_env(
+def _require_creds() -> dict[str, str]:
+    """The five env vars every Databricks smoke test needs (or skip)."""
+    return require_env(
         HOST_ENV,
         HTTP_PATH_ENV,
         TOKEN_ENV,
         "DRT_SMOKE_DATABRICKS_CATALOG",
         "DRT_SMOKE_DATABRICKS_SCHEMA",
     )
-    source, profile = seed_duckdb_users(tmp_path)
-    table = unique_table("drt_smoke")
-    catalog = creds["DRT_SMOKE_DATABRICKS_CATALOG"]
-    schema = creds["DRT_SMOKE_DATABRICKS_SCHEMA"]
-    fqn = f"`{catalog}`.`{schema}`.`{table}`"
 
-    dest = DatabricksDestinationConfig(
+
+def _dest_config(
+    creds: dict[str, str], table: str, **overrides: Any
+) -> DatabricksDestinationConfig:
+    """Build a Databricks destination config against the smoke catalog/schema."""
+    return DatabricksDestinationConfig(
         **{
             "type": "databricks",
             "host_env": HOST_ENV,
             "http_path_env": HTTP_PATH_ENV,
             "token_env": TOKEN_ENV,
-            "catalog": catalog,
-            "schema": schema,
+            "catalog": creds["DRT_SMOKE_DATABRICKS_CATALOG"],
+            "schema": creds["DRT_SMOKE_DATABRICKS_SCHEMA"],
             "table": table,
             "mode": "insert",
+            **overrides,
         }
     )
+
+
+def _fqn(creds: dict[str, str], table: str) -> str:
+    catalog = creds["DRT_SMOKE_DATABRICKS_CATALOG"]
+    schema = creds["DRT_SMOKE_DATABRICKS_SCHEMA"]
+    return f"`{catalog}`.`{schema}`.`{table}`"
+
+
+def test_databricks_insert_roundtrip(tmp_path: Path) -> None:
+    creds = _require_creds()
+    source, profile = seed_duckdb_users(tmp_path)
+    table = unique_table("drt_smoke")
+    fqn = _fqn(creds, table)
+
+    dest = _dest_config(creds, table, mode="insert")
     sync = SyncConfig(
         name="databricks_smoke",
         model="ref('users')",
@@ -71,9 +102,7 @@ def test_databricks_insert_roundtrip(tmp_path: Path) -> None:
     conn = _connect(creds)
     try:
         with conn.cursor() as cur:
-            cur.execute(
-                f"CREATE TABLE {fqn} (id INT, name STRING, email STRING) USING DELTA"
-            )
+            cur.execute(f"CREATE TABLE {fqn} (id INT, name STRING, email STRING) USING DELTA")
     finally:
         conn.close()
 
@@ -97,3 +126,167 @@ def test_databricks_insert_roundtrip(tmp_path: Path) -> None:
                 cur.execute(f"DROP TABLE IF EXISTS {fqn}")
         finally:
             conn.close()
+
+
+def test_databricks_replace_swap_roundtrip(tmp_path: Path) -> None:
+    """``replace_strategy: swap`` — atomic ``INSERT OVERWRITE`` from a shadow (#644).
+
+    Pre-seeds a stale row the source never emits, runs ``sync.mode: replace`` with
+    ``replace_strategy: swap``, and asserts (a) the stale row is gone — the
+    finalize-time ``INSERT OVERWRITE`` atomically replaced the table's data — and
+    (b) the ``<table>__drt_swap`` shadow was dropped in ``finalize_sync``.
+    """
+    creds = _require_creds()
+    source, profile = seed_duckdb_users(tmp_path)
+    table = unique_table("drt_smoke")
+    fqn = _fqn(creds, table)
+    catalog = creds["DRT_SMOKE_DATABRICKS_CATALOG"]
+    schema = creds["DRT_SMOKE_DATABRICKS_SCHEMA"]
+    shadow_fqn = f"`{catalog}`.`{schema}`.`{table}__drt_swap`"
+
+    dest = _dest_config(creds, table, mode="insert")
+    sync = SyncConfig(
+        name="databricks_swap_smoke",
+        model="ref('users')",
+        destination=dest,
+        sync=SyncOptions(mode="replace", replace_strategy="swap", batch_size=10),
+    )
+
+    # Pre-create the target (Delta) and seed a stale row. The swap must exist for
+    # the shadow path to engage — a first run with no target falls through to a
+    # direct write and never builds a shadow.
+    conn = _connect(creds)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f"CREATE TABLE {fqn} (id INT, name STRING, email STRING) USING DELTA")
+            cur.execute(f"INSERT INTO {fqn} VALUES (99, 'Stale', 'stale@example.com')")
+    finally:
+        conn.close()
+
+    try:
+        result = run_sync(sync, source, DatabricksDestination(), profile, tmp_path)
+        assert result.success == 3, f"expected 3 loaded rows, got {result.success}"
+        assert result.failed == 0
+
+        conn = _connect(creds)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT name FROM {fqn}")
+                names = {row[0] for row in cur.fetchall()}
+                # Shadow must be gone — finalize_sync drops it after the overwrite.
+                cur.execute(f"SHOW TABLES IN `{catalog}`.`{schema}` LIKE '{table}__drt_swap'")
+                shadow_rows = cur.fetchall()
+        finally:
+            conn.close()
+        # Stale row replaced atomically; only the 3 source rows remain.
+        assert names == {"Alice", "Bob", "Carol"}
+        assert shadow_rows == [], "swap shadow was not cleaned up in finalize_sync"
+    finally:
+        conn = _connect(creds)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(f"DROP TABLE IF EXISTS {fqn}")
+                cur.execute(f"DROP TABLE IF EXISTS {shadow_fqn}")
+        finally:
+            conn.close()
+
+
+def test_databricks_complex_type_serialization(tmp_path: Path) -> None:
+    """Complex-type / VARIANT-equivalent serialization on a real account (#317 leg).
+
+    Seeds a DuckDB source whose rows carry a Python ``list`` and ``dict`` and syncs
+    them into a Databricks table with ARRAY / STRUCT / VARIANT columns. The write
+    path introspects ``information_schema`` and wraps the binds
+    (``from_json(%s, '<ddl>')`` for STRUCT/ARRAY, ``parse_json(%s)`` for VARIANT).
+    Reading typed sub-fields back proves the values reconstructed as real complex
+    types rather than opaque JSON strings.
+    """
+    creds = _require_creds()
+    table = unique_table("drt_smoke")
+    fqn = _fqn(creds, table)
+
+    # Source: DuckDB LIST -> Python list, STRUCT -> Python dict. The `meta` STRUCT
+    # targets a Databricks VARIANT (parse_json); `tags`/`attrs` target ARRAY/STRUCT
+    # (from_json). One row is enough to exercise all three wrap sites.
+    duckdb = pytest.importorskip("duckdb")
+    db_path = str(tmp_path / "complex_source.duckdb")
+    dconn = duckdb.connect(db_path)
+    try:
+        dconn.execute(
+            "CREATE TABLE events ("
+            "  id INTEGER,"
+            "  tags VARCHAR[],"
+            "  attrs STRUCT(theme VARCHAR, level INTEGER),"
+            "  meta STRUCT(source VARCHAR, verified BOOLEAN)"
+            ")"
+        )
+        dconn.execute(
+            "INSERT INTO events VALUES "
+            "(1, ['a', 'b'], {'theme': 'dark', 'level': 3}, "
+            "{'source': 'crm', 'verified': true})"
+        )
+    finally:
+        dconn.close()
+    source = DuckDBSource()
+    profile = DuckDBProfile(type="duckdb", database=db_path)
+
+    dest = _dest_config(creds, table, mode="insert")
+    sync = SyncConfig(
+        name="databricks_complex_smoke",
+        model="ref('events')",
+        destination=dest,
+        sync=SyncOptions(batch_size=10),
+    )
+
+    conn = _connect(creds)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"CREATE TABLE {fqn} ("
+                "  id INT,"
+                "  tags ARRAY<STRING>,"
+                "  attrs STRUCT<theme: STRING, level: INT>,"
+                "  meta VARIANT"
+                ") USING DELTA"
+            )
+    finally:
+        conn.close()
+
+    try:
+        result = run_sync(sync, source, DatabricksDestination(), profile, tmp_path)
+        assert result.success == 1, f"expected 1 loaded row, got {result.success}"
+        assert result.failed == 0
+
+        conn = _connect(creds)
+        try:
+            with conn.cursor() as cur:
+                # Access typed sub-fields: array element, struct field, and a
+                # VARIANT path (`meta:source`). If serialization had stored a raw
+                # JSON string, these typed accessors would fail or return null.
+                cur.execute(
+                    "SELECT element_at(tags, 1), attrs.theme, attrs.level, "
+                    f"CAST(meta:source AS STRING) FROM {fqn} WHERE id = 1"
+                )
+                row = cur.fetchone()
+        finally:
+            conn.close()
+        assert row is not None, "row did not land"
+        first_tag, theme, level, meta_source = row
+        assert first_tag == "a"
+        assert theme == "dark"
+        assert int(level) == 3
+        assert meta_source == "crm"
+    finally:
+        conn = _connect(creds)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(f"DROP TABLE IF EXISTS {fqn}")
+        finally:
+            conn.close()
+
+
+def test_databricks_connection() -> None:
+    """`test_connection` succeeds against the real account (fast credential check)."""
+    creds = _require_creds()
+    dest = _dest_config(creds, "drt_smoke_connection_check")
+    DatabricksDestination().test_connection(dest)


### PR DESCRIPTION
## What

Adds the Databricks leg coverage that #672 calls for to the DWH smoke harness (#674), mirroring the BigQuery shape from #700. On top of the existing `insert` roundtrip, the leg now covers:

- **`test_databricks_replace_swap_roundtrip`** — `INSERT OVERWRITE` atomicity for `replace_strategy: swap` (#644). Pre-seeds a stale row the source never emits, then checks (a) the finalize-time `INSERT OVERWRITE` replaced the table's data — only the 3 source rows remain — and (b) the `<table>__drt_swap` shadow was dropped in `finalize_sync`.
- **`test_databricks_complex_type_serialization`** — complex-type / VARIANT serialization (#317 Databricks leg). Seeds a DuckDB source whose row carries a Python `list` + `dict`, syncs into `ARRAY` / `STRUCT` / `VARIANT` columns, and reads typed sub-fields back (`element_at(tags, 1)`, `attrs.theme`, `meta:source`) to confirm the values reconstruct via `from_json` / `parse_json` as real complex types rather than opaque JSON strings.
- **`test_databricks_connection`** — fast credential check via `test_connection` (`SELECT 1`), mirroring the Snowflake / BigQuery legs.

README gains Databricks provisioning notes (Unity Catalog / Delta, SQL warehouse HTTP path incl. the VARIANT channel requirement, least-privilege `CREATE`/`MODIFY` grants scoped to a throwaway schema).

All four tests have been run against a live Databricks workspace (combined locally with #706) and pass — see Verification below.

## Gating (safe no-op)

Same double gate as the rest of the harness — `pytest.importorskip("databricks.sql")` + `require_env` — so a plain `pytest` run, forks, and CI without `DRT_SMOKE_DATABRICKS_*` secrets all skip cleanly (verified: `4 skipped`).

## Depends on #706 — merge that first

Running this suite against a real workspace surfaced a pre-existing issue: the destination's pyformat `%s` binds aren't compatible with databricks-sql-connector >=3.0's native-paramstyle default, so parameterised writes fail server-side with `PARSE_SYNTAX_ERROR` (details in #706). The fix is destination code, so it ships separately; this PR stays test-only. Until #706 merges, the three roundtrip tests fail against a live account (the connection test passes) — CI is unaffected either way since the secrets aren't set yet.

## Verification

Against a live workspace (catalog `workspace`, schema `drt_smoke`):

- **This branch + #706 merged locally: all 4 tests pass** (~90s), on connector 3.7.5 and 4.3.0.
- Without #706: the three roundtrips reproduce the `PARSE_SYNTAX_ERROR`; `test_databricks_connection` passes.
- The smoke schema is empty afterwards — every leg drops what it creates in `finally`.

Cloud secrets (`SMOKE_DATABRICKS_*`) and the official "verified on a real service ✓" sign-off remain @masukai's per the #654 split.

Part of #672 · Epic #654 · Cleanup #644 · Serialization #317 · Depends on #706