### PR TITLE
chore(dwh): reproducible provisioning scripts for the smoke accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ credentials.json
 secrets.toml
 service_account.json
 docs/plans/
+
+# DWH smoke provisioning — never commit generated keyfiles
+drt-smoke-bq-key.json
+tests/integration/dwh/provisioning/*.json

--- a/tests/integration/dwh/README.md
+++ b/tests/integration/dwh/README.md
@@ -29,6 +29,14 @@ export DRT_SMOKE_SNOWFLAKE_ACCOUNT=...        # see the secret list below
 pytest -m dwh_smoke tests/integration/dwh/test_snowflake_smoke.py -v
 ```
 
+## Provisioning the accounts
+
+Reproducible setup scripts for the throwaway accounts these secrets come from
+live in [`provisioning/`](./provisioning/) — one per warehouse, plus a
+step-by-step runbook (sign up → provision → collect → register → dispatch).
+They create only the empty vessel + cost guardrails; the tests seed and clean
+up their own tables.
+
 ## Required repo secrets (maintainer-owned)
 
 Add these under **Settings → Secrets and variables → Actions**. Per the split,

--- a/tests/integration/dwh/provisioning/README.md
+++ b/tests/integration/dwh/provisioning/README.md
@@ -1,0 +1,66 @@
+# DWH smoke — account provisioning
+
+Reproducible setup for the throwaway warehouse accounts the [DWH smoke
+harness](../README.md) runs against (epic #654 · legs #671 / #672 / #673).
+
+These scripts create only the **empty vessel** — an isolated database/dataset/
+catalog, a least-privilege role/SA, cost guardrails. The smoke tests create,
+populate, verify, and drop their own throwaway tables (unique names, dropped in
+a `finally`), so **no data needs seeding**.
+
+Nothing here is secret except the passwords/keys you fill in. The credentials
+themselves live only in **GitHub Actions secrets** (and a shared vault) — never
+in git.
+
+## The loop (per warehouse)
+
+1. **Sign up** for the warehouse (use the project's org email, not a personal
+   account, so the account is an org asset).
+2. **Provision** — run the script below. It sets up the empty vessel + an
+   `AUTO_SUSPEND` / budget guardrail (a running warehouse is the classic cost
+   bomb).
+3. **Collect** the values listed at the bottom of each script.
+4. **Register** them as repo secrets (`Settings → Secrets and variables →
+   Actions`, or `gh secret set SMOKE_… --repo drt-hub/drt`).
+5. **Run** the smoke: Actions → `dwh-smoke` → *Run workflow* (`workflow_dispatch`).
+   The job for that warehouse flips from no-op to a real run and goes green.
+   It also runs nightly (03:00 UTC).
+
+Until a warehouse's secrets exist, its `dwh-smoke` job **no-ops green** — so
+adding accounts one at a time never breaks CI.
+
+## Snowflake — `snowflake.sql`
+
+Card-free 30-day trial. Run [`snowflake.sql`](./snowflake.sql) as
+`ACCOUNTADMIN` in a Worksheet, filling in a strong password. Account identifier
+is under the account menu (bottom-left) → *Copy account identifier*.
+Secrets: `SMOKE_SNOWFLAKE_{ACCOUNT,USER,PASSWORD,DATABASE,SCHEMA,WAREHOUSE}`.
+
+## BigQuery — `bigquery.sh`
+
+Needs a **billing-enabled** project (a payment card — even the free tier
+requires billing enabled). Effectively $0/month for KB-scale smoke tables.
+Run [`bigquery.sh`](./bigquery.sh) with `gcloud` authenticated; load the
+generated keyfile's contents into `SMOKE_BIGQUERY_KEYFILE_JSON`, then delete
+the local keyfile. Secrets: `SMOKE_BIGQUERY_{PROJECT,DATASET,KEYFILE_JSON}`.
+
+## Databricks — `databricks.sql` + manual steps
+
+The most expensive leg; consider deferring. [`databricks.sql`](./databricks.sql)
+covers the catalog/schema/grants. The rest is UI/API:
+
+- **Workspace**: a Databricks workspace on a cloud (trial or paid). Host =
+  `dbc-xxxx.cloud.databricks.com`.
+- **SQL warehouse**: create a (2X-)Small warehouse with the **minimum auto-stop**
+  (cost guardrail). Its *Connection details* give the HTTP path.
+- **PAT**: Settings → Developer → Access tokens → generate (`dapi…`).
+
+Secrets: `SMOKE_DATABRICKS_{HOST,HTTP_PATH,TOKEN,CATALOG,SCHEMA}`.
+
+## Cost & ownership
+
+Steady-state (correctly configured): Snowflake ~$1–3, BigQuery ~$0, Databricks
+~$8–15 per month. The dominant risk across all three is **leaving compute
+running** — always set auto-suspend/auto-stop + a budget/credit hard cap first.
+Account ownership, card strategy, and the CI-vs-contributor split are maintainer
+decisions kept in private strategy notes.

--- a/tests/integration/dwh/provisioning/bigquery.sh
+++ b/tests/integration/dwh/provisioning/bigquery.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# BigQuery provisioning for the DWH smoke harness (#654 / #673).
+#
+# Creates a throwaway dataset + a least-privilege service account and mints a
+# keyfile. Idempotent-ish (guards on "already exists"). Requires the gcloud CLI
+# authenticated to a project you own.
+#
+# PREREQUISITE: a billing-enabled GCP project. BigQuery jobs require an active
+# billing account (= a payment card) even for tiny throwaway tables. If you
+# have no card yet, this step is blocked — see the maintainer strategy notes.
+#
+# Cost: the smoke tables are KB-scale and fit inside BigQuery's free tier
+# (1 TB query + 10 GB storage / month), so steady-state cost is ~$0. Set a
+# budget alert anyway (below) as a guardrail.
+#
+# Nothing here is secret except the generated keyfile; keep that out of git.
+
+set -euo pipefail
+
+PROJECT="${DRT_SMOKE_GCP_PROJECT:-drt-smoke}"   # override via env
+DATASET="${DRT_SMOKE_BQ_DATASET:-smoke}"
+LOCATION="${DRT_SMOKE_BQ_LOCATION:-US}"
+SA_NAME="drt-smoke-sa"
+SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+KEYFILE="${DRT_SMOKE_BQ_KEYFILE:-./drt-smoke-bq-key.json}"
+
+echo "Project=${PROJECT} Dataset=${DATASET} Location=${LOCATION}"
+gcloud config set project "${PROJECT}"
+gcloud services enable bigquery.googleapis.com
+
+# ── Throwaway dataset ──────────────────────────────────────────────────────
+bq --location="${LOCATION}" mk --dataset "${PROJECT}:${DATASET}" 2>/dev/null \
+  || echo "dataset ${DATASET} already exists"
+
+# ── Least-privilege service account ────────────────────────────────────────
+gcloud iam service-accounts create "${SA_NAME}" \
+  --display-name="drt DWH smoke" 2>/dev/null || echo "SA already exists"
+
+# jobUser at project level (run load/query/MERGE jobs) ...
+gcloud projects add-iam-policy-binding "${PROJECT}" \
+  --member="serviceAccount:${SA_EMAIL}" \
+  --role="roles/bigquery.jobUser" --condition=None >/dev/null
+
+# ... plus dataEditor scoped to the smoke dataset only (create/insert/drop the
+# target + <table>_drt_tmp). Avoid project-wide dataEditor.
+bq update --dataset \
+  --source <(bq show --format=prettyjson "${PROJECT}:${DATASET}" \
+    | python3 -c "import json,sys;d=json.load(sys.stdin);d.setdefault('access',[]).append({'role':'WRITER','userByEmail':'${SA_EMAIL}'});print(json.dumps(d))") \
+  "${PROJECT}:${DATASET}"
+
+# ── Keyfile (keep OUT of git; load into SMOKE_BIGQUERY_KEYFILE_JSON secret) ──
+gcloud iam service-accounts keys create "${KEYFILE}" --iam-account="${SA_EMAIL}"
+echo "Keyfile written to ${KEYFILE} — register its CONTENTS as SMOKE_BIGQUERY_KEYFILE_JSON, then delete the local file."
+
+# ── Budget alert guardrail (optional; needs billing account id) ─────────────
+# gcloud billing budgets create --billing-account=<ACCOUNT_ID> \
+#   --display-name="drt-smoke" --budget-amount=5USD ...
+
+cat <<EOF
+
+Secret mapping (register as repo secrets):
+  SMOKE_BIGQUERY_PROJECT      = ${PROJECT}
+  SMOKE_BIGQUERY_DATASET      = ${DATASET}
+  SMOKE_BIGQUERY_KEYFILE_JSON = <contents of ${KEYFILE}>
+
+Caveat: if the org enforces iam.disableServiceAccountKeyCreation, key creation
+fails — provision in a project/folder where that policy isn't enforced.
+EOF

--- a/tests/integration/dwh/provisioning/databricks.sql
+++ b/tests/integration/dwh/provisioning/databricks.sql
@@ -1,0 +1,35 @@
+-- Databricks provisioning for the DWH smoke harness (#654 / #672).
+--
+-- The catalog + schema + grants are SQL (run in a Databricks SQL editor on the
+-- SQL warehouse). The warehouse, the PAT, and the workspace itself are UI/API
+-- steps — see the "Databricks — manual (UI/API) steps" section in
+-- provisioning/README.md.
+--
+-- Cost note: Databricks is the most expensive of the three (Serverless SQL
+-- bills DBUs + cloud compute; a warehouse left running is a cost bomb like
+-- Snowflake's). Keep AUTO-STOP at its minimum and consider deferring the
+-- Databricks leg — see the maintainer strategy notes.
+--
+-- The smoke tests create/populate/drop their own throwaway tables (insert /
+-- replace INSERT OVERWRITE / STRUCT-ARRAY-MAP + VARIANT complex types), so no
+-- data needs seeding — only the empty catalog + schema + write grants.
+
+-- ── 1. Throwaway catalog + schema (Unity Catalog three-part name) ──────────
+CREATE CATALOG IF NOT EXISTS drt_smoke;
+CREATE SCHEMA  IF NOT EXISTS drt_smoke.smoke;
+
+-- ── 2. Least-privilege grants to the smoke principal ───────────────────────
+-- Replace <SMOKE_PRINCIPAL> with the user/service principal whose PAT you use.
+-- USE + CREATE TABLE + MODIFY cover insert / INSERT OVERWRITE (replace-swap) /
+-- from_json complex-type writes; the tests drop what they create.
+GRANT USE CATALOG      ON CATALOG drt_smoke        TO `<SMOKE_PRINCIPAL>`;
+GRANT USE SCHEMA       ON SCHEMA  drt_smoke.smoke  TO `<SMOKE_PRINCIPAL>`;
+GRANT CREATE TABLE     ON SCHEMA  drt_smoke.smoke  TO `<SMOKE_PRINCIPAL>`;
+GRANT MODIFY           ON SCHEMA  drt_smoke.smoke  TO `<SMOKE_PRINCIPAL>`;
+
+-- ── Secret mapping (register as SMOKE_DATABRICKS_* repo secrets) ────────────
+--   SMOKE_DATABRICKS_HOST      = <workspace host, e.g. dbc-xxxx.cloud.databricks.com>
+--   SMOKE_DATABRICKS_HTTP_PATH = <SQL warehouse HTTP path, from its Connection details>
+--   SMOKE_DATABRICKS_TOKEN     = <PAT, dapi...>
+--   SMOKE_DATABRICKS_CATALOG   = drt_smoke
+--   SMOKE_DATABRICKS_SCHEMA    = smoke

--- a/tests/integration/dwh/provisioning/snowflake.sql
+++ b/tests/integration/dwh/provisioning/snowflake.sql
@@ -1,0 +1,61 @@
+-- Snowflake provisioning for the DWH smoke harness (#654 / #671).
+--
+-- Creates a throwaway database + schema, an XS warehouse with aggressive
+-- auto-suspend, a least-privilege role, a programmatic user, and a resource
+-- monitor that hard-caps monthly credits. Idempotent — safe to re-run.
+--
+-- Run once, as ACCOUNTADMIN, in a Worksheet on a fresh trial account.
+-- Then collect the six SMOKE_SNOWFLAKE_* values (see provisioning/README.md)
+-- and register them as repo secrets.
+--
+-- Nothing here is secret except the password you fill in below; this file is
+-- committed as reproducible infra (the smoke tests create/populate/drop their
+-- own throwaway tables, so no data needs seeding).
+
+-- ── 1. Throwaway database + schema (the "empty vessel") ────────────────────
+CREATE DATABASE IF NOT EXISTS DRT_SMOKE;
+CREATE SCHEMA   IF NOT EXISTS DRT_SMOKE.PUBLIC;
+
+-- ── 2. XS warehouse — AUTO_SUSPEND is the #1 cost guardrail ─────────────────
+-- A warehouse left running is the classic Snowflake cost bomb. 60s suspend +
+-- per-second billing means a nightly smoke run costs fractions of a credit.
+CREATE WAREHOUSE IF NOT EXISTS DRT_SMOKE_WH
+  WAREHOUSE_SIZE      = 'XSMALL'
+  AUTO_SUSPEND        = 60          -- seconds
+  AUTO_RESUME         = TRUE
+  INITIALLY_SUSPENDED = TRUE;
+
+-- ── 3. Resource monitor — hard cap so "some freedom" can't run away ────────
+CREATE RESOURCE MONITOR IF NOT EXISTS DRT_SMOKE_MON
+  WITH CREDIT_QUOTA   = 5           -- credits/month; smoke uses a tiny fraction
+       FREQUENCY      = MONTHLY
+       START_TIMESTAMP = IMMEDIATELY
+       TRIGGERS ON 100 PERCENT DO SUSPEND;
+ALTER WAREHOUSE DRT_SMOKE_WH SET RESOURCE_MONITOR = DRT_SMOKE_MON;
+
+-- ── 4. Least-privilege role ────────────────────────────────────────────────
+-- CREATE TABLE on the schema is enough: the smoke tests create their own
+-- throwaway tables (insert / replace-swap / VARIANT-OBJECT-ARRAY) and drop
+-- them in a finally block. Table ownership (implied by CREATE) covers the
+-- ALTER TABLE ... SWAP WITH the replace-swap test needs.
+CREATE ROLE IF NOT EXISTS DRT_SMOKE_ROLE;
+GRANT USAGE        ON WAREHOUSE DRT_SMOKE_WH     TO ROLE DRT_SMOKE_ROLE;
+GRANT USAGE        ON DATABASE  DRT_SMOKE        TO ROLE DRT_SMOKE_ROLE;
+GRANT USAGE        ON SCHEMA    DRT_SMOKE.PUBLIC TO ROLE DRT_SMOKE_ROLE;
+GRANT CREATE TABLE ON SCHEMA    DRT_SMOKE.PUBLIC TO ROLE DRT_SMOKE_ROLE;
+
+-- ── 5. Programmatic user (fill in a strong password) ───────────────────────
+CREATE USER IF NOT EXISTS DRT_SMOKE_USER
+  PASSWORD             = '<SET-A-STRONG-PASSWORD>'
+  DEFAULT_ROLE         = DRT_SMOKE_ROLE
+  DEFAULT_WAREHOUSE    = DRT_SMOKE_WH
+  MUST_CHANGE_PASSWORD = FALSE;
+GRANT ROLE DRT_SMOKE_ROLE TO USER DRT_SMOKE_USER;
+
+-- ── Secret mapping (register these; values → SMOKE_SNOWFLAKE_* repo secrets)─
+--   SMOKE_SNOWFLAKE_ACCOUNT   = <account identifier, e.g. orgname-accountname>
+--   SMOKE_SNOWFLAKE_USER      = DRT_SMOKE_USER
+--   SMOKE_SNOWFLAKE_PASSWORD  = <the password above>
+--   SMOKE_SNOWFLAKE_DATABASE  = DRT_SMOKE
+--   SMOKE_SNOWFLAKE_SCHEMA    = PUBLIC
+--   SMOKE_SNOWFLAKE_WAREHOUSE = DRT_SMOKE_WH


### PR DESCRIPTION
## What

Captures the DWH smoke-account setup (#654) as reproducible, committed infra under `tests/integration/dwh/provisioning/`, instead of living only in one-off click-ops / chat.

- **`snowflake.sql`** (#671) — throwaway DB/schema + XS warehouse with `AUTO_SUSPEND=60` + least-privilege role + programmatic user + a `RESOURCE MONITOR` credit hard-cap. Runnable today on a **card-free** trial.
- **`bigquery.sh`** (#673) — `gcloud`/`bq`: throwaway dataset + least-privilege SA (`bigquery.jobUser` at project + dataset-scoped `dataEditor`) + keyfile mint. Needs a billing-enabled project (card).
- **`databricks.sql`** (#672) — Unity Catalog catalog/schema + grants; workspace/warehouse/PAT are UI steps, documented in the README.
- **`provisioning/README.md`** — the per-warehouse runbook (sign up → provision → collect → register secret → `workflow_dispatch`) + cost/guardrail notes.
- Linked from the harness README; `.gitignore` guards the generated BQ keyfile.

## Why

The smoke *run* is already automated (`dwh-smoke.yml`, nightly + dispatch, no-op until secrets exist), but the *provisioning* was undocumented. This makes it reviewable, reproducible, and reusable — a contributor spinning up their own account (as done for the BigQuery/Databricks legs) can run the same scripts.

## Safety

The scripts create only the **empty vessel** + cost guardrails — the tests seed and drop their own throwaway tables, so nothing is pre-loaded. **Nothing secret is committed** (placeholders only); credentials live only in Actions secrets / a vault. `bash -n` clean; no runtime code paths touched.

[skip changelog]
