### PR TITLE
refactor(destinations): extract dialect-agnostic BaseSqlDestination (#719)

### DIFF
--- a/drt/destinations/mysql.py
+++ b/drt/destinations/mysql.py
@@ -29,6 +29,7 @@ from drt.config.models import DestinationConfig, MySQLDestinationConfig, SyncOpt
 from drt.destinations._serializer import serialize_complex_value
 from drt.destinations.base import SyncResult
 from drt.destinations.row_errors import RowError
+from drt.destinations.sql_base import BaseSqlDestination
 
 
 def _mysql_json_encoder(value: Any) -> str:
@@ -73,42 +74,12 @@ def _serialize_value(
     )
 
 
-class MySQLDestination:
+class MySQLDestination(BaseSqlDestination):
     """Upsert or replace records into a MySQL table.
 
-    Implements ConnectionTestable via test_connection().
+    Implements ConnectionTestable via test_connection(). Per-sync state, schema
+    resolution, and mirror bookkeeping come from ``BaseSqlDestination``.
     """
-
-    def __init__(self) -> None:
-        self._replace_truncated: bool = False
-        self._swap_shadow_created: bool = False
-        self._swap_table: str | None = None
-        # sync.mode: mirror (#340 Step 2) — accumulates upsert_key tuples seen
-        # across batches so finalize_sync can DELETE missing rows.
-        # ``None`` means mirror mode hasn't engaged yet (no batch with
-        # records); finalize_sync treats that as "skip DELETE" — safety
-        # against deleting everything when the source produced no data.
-        self._mirror_keys: list[tuple[Any, ...]] | None = None
-        # mirror.scope (#687) — distinct scope-column value tuples observed
-        # across batches; the destination-strategy DELETE is restricted to
-        # rows whose scope values are in this set.
-        self._mirror_scopes: set[tuple[Any, ...]] | None = None
-        # Layer 3 (#317): INFORMATION_SCHEMA map, fetched once per table per sync.
-        self._schema_cache: dict[str, dict[str, str] | None] = {}
-
-    def _resolve_schema(self, config: MySQLDestinationConfig) -> dict[str, str] | None:
-        """Column → type-category map for the target table, cached per sync.
-
-        Returns ``None`` (Layer 3 inactive) when ``introspect_schema`` is off,
-        ``json_columns`` is set (Layer 2 wins), or introspection isn't available.
-        """
-        if not config.introspect_schema or config.json_columns is not None:
-            return None
-        if config.table not in self._schema_cache:
-            from drt.destinations.schema import describe_columns
-
-            self._schema_cache[config.table] = describe_columns(config)
-        return self._schema_cache[config.table]
 
     def load(
         self,
@@ -120,21 +91,7 @@ class MySQLDestination:
         if not records:
             return SyncResult()
 
-        # mirror.scope (#687) — a scope column absent from the model output
-        # is a config error; fail fast before any row is written.
-        if (
-            sync_options.mode == "mirror"
-            and sync_options.mirror is not None
-            and sync_options.mirror.scope
-        ):
-            missing = [
-                c for c in sync_options.mirror.scope if c not in records[0]
-            ]
-            if missing:
-                raise ValueError(
-                    "mirror.scope columns missing from the model output: "
-                    f"{missing} (available: {sorted(records[0].keys())})"
-                )
+        self._validate_mirror_scope(records, sync_options)
 
         conn = self._connect(config)
         result = SyncResult()
@@ -173,41 +130,10 @@ class MySQLDestination:
                     config,
                     sync_options,
                 )
-                # sync.mode: mirror (#340 Step 2) — accumulate upsert_key
-                # tuples for the finalize_sync DELETE pass. Only keys from
-                # successfully-loaded records are tracked (failed records
-                # don't count as "source state").
+                # sync.mode: mirror (#340 / #687) — record the observed
+                # upsert_key (and scope) tuples for the finalize_sync DELETE.
                 if sync_options.mode == "mirror":
-                    if not config.upsert_key:
-                        from drt.destinations.sql_utils import MIRROR_UPSERT_KEY_MSG
-
-                        raise ValueError(MIRROR_UPSERT_KEY_MSG)
-                    if self._mirror_keys is None:
-                        self._mirror_keys = []
-                    failed_indices = {
-                        re.batch_index for re in result.row_errors
-                    }
-                    # mirror.scope (#687) — also collect distinct scope
-                    # value tuples so the DELETE can be pruned to parents
-                    # observed in this run.
-                    scope_cols = (
-                        sync_options.mirror.scope
-                        if sync_options.mirror is not None
-                        else None
-                    )
-                    if scope_cols and self._mirror_scopes is None:
-                        self._mirror_scopes = set()
-                    for idx, record in enumerate(records):
-                        if idx in failed_indices:
-                            continue
-                        self._mirror_keys.append(
-                            tuple(record.get(k) for k in config.upsert_key)
-                        )
-                        if scope_cols:
-                            assert self._mirror_scopes is not None
-                            self._mirror_scopes.add(
-                                tuple(record.get(c) for c in scope_cols)
-                            )
+                    self._accumulate_mirror_state(records, result, config, sync_options)
         finally:
             conn.close()
 

--- a/drt/destinations/postgres.py
+++ b/drt/destinations/postgres.py
@@ -34,6 +34,7 @@ from drt.config.models import (
 from drt.destinations._serializer import serialize_complex_value
 from drt.destinations.base import SyncResult
 from drt.destinations.row_errors import RowError
+from drt.destinations.sql_base import BaseSqlDestination
 
 try:
     from psycopg2.extras import Json as _Psycopg2Json
@@ -128,45 +129,12 @@ def _with_relation_suffix(table: str, suffix: str) -> str:
     return _join_qualified(schema, f"{relation}{suffix}")
 
 
-class PostgresDestination:
+class PostgresDestination(BaseSqlDestination):
     """Upsert or replace records into a PostgreSQL table.
 
-    Implements ConnectionTestable via test_connection().
+    Implements ConnectionTestable via test_connection(). Per-sync state, schema
+    resolution, and mirror bookkeeping come from ``BaseSqlDestination``.
     """
-
-    def __init__(self) -> None:
-        self._replace_truncated: bool = False
-        self._swap_shadow_created: bool = False
-        self._swap_table: str | None = None
-        # sync.mode: mirror (#340) — accumulates upsert_key tuples seen
-        # across batches so finalize_sync can DELETE missing rows.
-        # ``None`` means mirror mode hasn't engaged yet (no batch with
-        # records); finalize_sync treats that as "skip DELETE" — safety
-        # against deleting everything when the source produced no data.
-        self._mirror_keys: list[tuple[Any, ...]] | None = None
-        # mirror.scope (#687) — distinct scope-column value tuples observed
-        # across batches; the destination-strategy DELETE is restricted to
-        # rows whose scope values are in this set.
-        self._mirror_scopes: set[tuple[Any, ...]] | None = None
-        # Layer 3 (#317): INFORMATION_SCHEMA map, fetched once per table per
-        # sync. ``None`` value = introspection ran but is unavailable; the
-        # key being absent = not yet fetched.
-        self._schema_cache: dict[str, dict[str, str] | None] = {}
-
-    def _resolve_schema(self, config: PostgresDestinationConfig) -> dict[str, str] | None:
-        """Column → type-category map for the target table, cached per sync.
-
-        Returns ``None`` (Layer 3 inactive) when the user disabled
-        ``introspect_schema``, declared ``json_columns`` explicitly (Layer 2
-        wins), or introspection isn't available.
-        """
-        if not config.introspect_schema or config.json_columns is not None:
-            return None
-        if config.table not in self._schema_cache:
-            from drt.destinations.schema import describe_columns
-
-            self._schema_cache[config.table] = describe_columns(config)
-        return self._schema_cache[config.table]
 
     def load(
         self,
@@ -178,21 +146,7 @@ class PostgresDestination:
         if not records:
             return SyncResult()
 
-        # mirror.scope (#687) — a scope column absent from the model output
-        # is a config error; fail fast before any row is written.
-        if (
-            sync_options.mode == "mirror"
-            and sync_options.mirror is not None
-            and sync_options.mirror.scope
-        ):
-            missing = [
-                c for c in sync_options.mirror.scope if c not in records[0]
-            ]
-            if missing:
-                raise ValueError(
-                    "mirror.scope columns missing from the model output: "
-                    f"{missing} (available: {sorted(records[0].keys())})"
-                )
+        self._validate_mirror_scope(records, sync_options)
 
         conn = self._connect(config)
         result = SyncResult()
@@ -231,42 +185,10 @@ class PostgresDestination:
                     config,
                     sync_options,
                 )
-                # sync.mode: mirror (#340) — accumulate upsert_key tuples
-                # for the finalize_sync DELETE pass. Only keys from
-                # successfully-loaded records are tracked (failed records
-                # don't count as "source state").
+                # sync.mode: mirror (#340 / #687) — record the observed
+                # upsert_key (and scope) tuples for the finalize_sync DELETE.
                 if sync_options.mode == "mirror":
-                    if not config.upsert_key:
-                        from drt.destinations.sql_utils import MIRROR_UPSERT_KEY_MSG
-
-                        raise ValueError(MIRROR_UPSERT_KEY_MSG)
-                    if self._mirror_keys is None:
-                        self._mirror_keys = []
-                    # Re-extract from records minus the ones in row_errors.
-                    failed_indices = {
-                        re.batch_index for re in result.row_errors
-                    }
-                    # mirror.scope (#687) — also collect distinct scope
-                    # value tuples so the DELETE can be pruned to parents
-                    # observed in this run.
-                    scope_cols = (
-                        sync_options.mirror.scope
-                        if sync_options.mirror is not None
-                        else None
-                    )
-                    if scope_cols and self._mirror_scopes is None:
-                        self._mirror_scopes = set()
-                    for idx, record in enumerate(records):
-                        if idx in failed_indices:
-                            continue
-                        self._mirror_keys.append(
-                            tuple(record.get(k) for k in config.upsert_key)
-                        )
-                        if scope_cols:
-                            assert self._mirror_scopes is not None
-                            self._mirror_scopes.add(
-                                tuple(record.get(c) for c in scope_cols)
-                            )
+                    self._accumulate_mirror_state(records, result, config, sync_options)
         finally:
             conn.close()
 

--- a/drt/destinations/sql_base.py
+++ b/drt/destinations/sql_base.py
@@ -1,0 +1,112 @@
+"""Shared base for host-based SQL destinations (Postgres, MySQL).
+
+Holds the *dialect-agnostic* orchestration that was duplicated verbatim across
+the concrete SQL destinations: per-sync mutable state, the Layer-3 schema-cache
+resolution (#317), and the ``sync.mode: mirror`` bookkeeping (#340 / #687).
+
+Dialect-specific SQL construction — identifier quoting, INSERT / UPSERT / MERGE
+builders, ``_connect`` — stays on the subclasses, because Postgres composes
+``psycopg2.sql`` objects while MySQL builds backtick-quoted strings. Unifying
+that layer is tracked separately; this base only lifts the parts that are
+byte-identical and carry no dialect.
+
+``config`` is typed ``Any`` in the helpers below on purpose: the fields they
+read (``table`` / ``upsert_key`` / ``json_columns``) live on the concrete
+subclass configs, not on ``BaseSqlDestinationConfig``, and each caller has
+already narrowed the type via ``assert isinstance(config, ...)`` at ``load``
+entry.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from drt.config.models import SyncOptions
+from drt.destinations.base import SyncResult
+
+
+class BaseSqlDestination:
+    """Dialect-agnostic state + mirror/schema helpers for SQL destinations."""
+
+    def __init__(self) -> None:
+        self._replace_truncated: bool = False
+        self._swap_shadow_created: bool = False
+        self._swap_table: str | None = None
+        # sync.mode: mirror (#340) — accumulates upsert_key tuples seen across
+        # batches so finalize_sync can DELETE missing rows. ``None`` means
+        # mirror mode hasn't engaged yet (no batch with records); finalize_sync
+        # treats that as "skip DELETE" — safety against deleting everything
+        # when the source produced no data.
+        self._mirror_keys: list[tuple[Any, ...]] | None = None
+        # mirror.scope (#687) — distinct scope-column value tuples observed
+        # across batches; the destination-strategy DELETE is restricted to
+        # rows whose scope values are in this set.
+        self._mirror_scopes: set[tuple[Any, ...]] | None = None
+        # Layer 3 (#317): INFORMATION_SCHEMA map, fetched once per table per
+        # sync. ``None`` value = introspection ran but is unavailable; the key
+        # being absent = not yet fetched.
+        self._schema_cache: dict[str, dict[str, str] | None] = {}
+
+    def _resolve_schema(self, config: Any) -> dict[str, str] | None:
+        """Column → type-category map for the target table, cached per sync.
+
+        Returns ``None`` (Layer 3 inactive) when ``introspect_schema`` is off,
+        ``json_columns`` is set (Layer 2 wins), or introspection isn't
+        available.
+        """
+        if not config.introspect_schema or config.json_columns is not None:
+            return None
+        if config.table not in self._schema_cache:
+            from drt.destinations.schema import describe_columns
+
+            self._schema_cache[config.table] = describe_columns(config)
+        return self._schema_cache[config.table]
+
+    def _validate_mirror_scope(
+        self,
+        records: list[dict[str, Any]],
+        sync_options: SyncOptions,
+    ) -> None:
+        """mirror.scope (#687): a scope column absent from the model output is a
+        config error — fail fast before any row is written."""
+        if (
+            sync_options.mode == "mirror"
+            and sync_options.mirror is not None
+            and sync_options.mirror.scope
+        ):
+            missing = [c for c in sync_options.mirror.scope if c not in records[0]]
+            if missing:
+                raise ValueError(
+                    "mirror.scope columns missing from the model output: "
+                    f"{missing} (available: {sorted(records[0].keys())})"
+                )
+
+    def _accumulate_mirror_state(
+        self,
+        records: list[dict[str, Any]],
+        result: SyncResult,
+        config: Any,
+        sync_options: SyncOptions,
+    ) -> None:
+        """sync.mode: mirror (#340) — accumulate the ``upsert_key`` tuples (and,
+        for mirror.scope #687, the scope-value tuples) of successfully-loaded
+        records, so ``finalize_sync`` can DELETE the rows the source no longer
+        produces. Failed records don't count as observed source state.
+        """
+        if not config.upsert_key:
+            from drt.destinations.sql_utils import MIRROR_UPSERT_KEY_MSG
+
+            raise ValueError(MIRROR_UPSERT_KEY_MSG)
+        if self._mirror_keys is None:
+            self._mirror_keys = []
+        failed_indices = {re.batch_index for re in result.row_errors}
+        scope_cols = sync_options.mirror.scope if sync_options.mirror is not None else None
+        if scope_cols and self._mirror_scopes is None:
+            self._mirror_scopes = set()
+        for idx, record in enumerate(records):
+            if idx in failed_indices:
+                continue
+            self._mirror_keys.append(tuple(record.get(k) for k in config.upsert_key))
+            if scope_cols:
+                assert self._mirror_scopes is not None
+                self._mirror_scopes.add(tuple(record.get(c) for c in scope_cols))

--- a/tests/unit/test_sql_base.py
+++ b/tests/unit/test_sql_base.py
@@ -1,0 +1,90 @@
+"""Tests for the dialect-agnostic BaseSqlDestination helpers (#719)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from drt.destinations.base import SyncResult
+from drt.destinations.row_errors import RowError
+from drt.destinations.sql_base import BaseSqlDestination
+
+
+def _mirror(scope: list[str] | None = None) -> SimpleNamespace:
+    return SimpleNamespace(mode="mirror", mirror=SimpleNamespace(scope=scope))
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+
+def test_init_defaults() -> None:
+    d = BaseSqlDestination()
+    assert d._mirror_keys is None
+    assert d._mirror_scopes is None
+    assert d._schema_cache == {}
+    assert d._swap_table is None
+    assert d._replace_truncated is False
+    assert d._swap_shadow_created is False
+
+
+# ---------------------------------------------------------------------------
+# _validate_mirror_scope (#687)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_mirror_scope_raises_on_missing_column() -> None:
+    d = BaseSqlDestination()
+    with pytest.raises(ValueError, match="mirror.scope columns missing"):
+        d._validate_mirror_scope([{"id": 1}], _mirror(scope=["parent_id"]))
+
+
+def test_validate_mirror_scope_ok_when_present() -> None:
+    d = BaseSqlDestination()
+    d._validate_mirror_scope([{"parent_id": 1, "id": 2}], _mirror(scope=["parent_id"]))
+
+
+def test_validate_mirror_scope_noop_when_not_mirror() -> None:
+    d = BaseSqlDestination()
+    d._validate_mirror_scope([{"id": 1}], SimpleNamespace(mode="upsert", mirror=None))
+
+
+# ---------------------------------------------------------------------------
+# _accumulate_mirror_state (#340 / #687)
+# ---------------------------------------------------------------------------
+
+
+def test_accumulate_requires_upsert_key() -> None:
+    d = BaseSqlDestination()
+    cfg = SimpleNamespace(upsert_key=[])
+    with pytest.raises(ValueError, match="requires destination.upsert_key"):
+        d._accumulate_mirror_state([{"id": 1}], SyncResult(), cfg, _mirror())
+
+
+def test_accumulate_keys_skips_failed_rows() -> None:
+    d = BaseSqlDestination()
+    cfg = SimpleNamespace(upsert_key=["id"])
+    result = SyncResult()
+    result.row_errors.append(
+        RowError(batch_index=1, record_preview="", http_status=None, error_message="x")
+    )
+    d._accumulate_mirror_state(
+        [{"id": 10}, {"id": 20}, {"id": 30}], result, cfg, _mirror()
+    )
+    assert d._mirror_keys == [(10,), (30,)]  # index 1 (failed) skipped
+    assert d._mirror_scopes is None
+
+
+def test_accumulate_collects_distinct_scopes() -> None:
+    d = BaseSqlDestination()
+    cfg = SimpleNamespace(upsert_key=["id"])
+    d._accumulate_mirror_state(
+        [{"id": 1, "parent_id": "a"}, {"id": 2, "parent_id": "a"}],
+        SyncResult(),
+        cfg,
+        _mirror(scope=["parent_id"]),
+    )
+    assert d._mirror_keys == [(1,), (2,)]
+    assert d._mirror_scopes == {("a",)}


### PR DESCRIPTION
Addresses #719 — the **agnostic first cut** (see scope note below).

> ⚠️ **Stacked on #726** (uses `sql_utils.MIRROR_UPSERT_KEY_MSG`). Base is the #722 branch; it'll retarget to `main` once #726 merges. Review the [second commit](https://github.com/drt-hub/drt/pull/719/commits) for the #719 diff only.

## What

Postgres and MySQL carried **byte-identical** copies of their per-sync state, Layer-3 schema-cache resolution (#317), and `sync.mode: mirror` bookkeeping (#340/#687). Lift those into a shared `BaseSqlDestination` both now inherit:

- `__init__` — mirror keys/scopes, swap-table state, schema cache
- `_resolve_schema` — introspection cache (#317)
- `_validate_mirror_scope` — fail-fast when a scope column is missing from the model output (#687)
- `_accumulate_mirror_state` — collect observed `upsert_key` / scope tuples of successfully-loaded rows (#340/#687)

Each `load()` now calls the shared helpers instead of inlining ~45 identical lines. **The moved code is verbatim** — behavior is unchanged and the full suite (including every mirror-mode test for both dialects) passes untouched.

## Scope — agnostic layer only

Deliberately limited to the dialect-**agnostic** logic. SQL construction stays on the subclasses, because the two build SQL through incompatible paradigms — Postgres composes `psycopg2.sql` objects, MySQL builds backtick-quoted strings. Unifying `load()` / `finalize` across those needs hook-signature normalization (the abstract `_load_replace` / `_build_*` methods take dialect-specific config types), so it's a documented follow-up on #719.

`config` is typed `Any` in the base helpers on purpose: `table` / `upsert_key` / `json_columns` live on the concrete subclass configs (not `BaseSqlDestinationConfig`), and `load()` has already narrowed the type via `assert isinstance(config, ...)`.

## Verification

- Full unit suite: **1811 passed, 5 skipped** (no regressions)
- 7 new tests in `tests/unit/test_sql_base.py`
- `ruff` + `mypy` clean · `make check-drift` → 0 drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)