### PR TITLE
refactor(mcp): derive drt_list_connectors inventory from the connectors SSoT (#718)

### DIFF
--- a/drt/config/connectors.py
+++ b/drt/config/connectors.py
@@ -63,3 +63,49 @@ DESTINATIONS = [
     ("twilio", "Twilio"),
     ("zendesk", "Zendesk"),
 ]
+
+
+# pip extra required per connector type. Types not listed ship in drt-core
+# (DuckDB, SQLite, REST API, and every webhook / SaaS destination). The extra
+# name equals the type except where noted.
+_EXTRAS: dict[str, str] = {
+    "bigquery": "bigquery",
+    "postgres": "postgres",
+    "redshift": "redshift",
+    "clickhouse": "clickhouse",
+    "snowflake": "snowflake",
+    "mysql": "mysql",
+    "databricks": "databricks",
+    "sqlserver": "sqlserver",
+    "deltalake": "deltalake",
+    "iceberg": "iceberg",
+    "s3": "s3",
+    "gcs": "gcs",
+    "azure_blob": "azure",  # extra name differs from the type
+    "parquet": "parquet",
+    "google_sheets": "sheets",  # extra name differs from the type
+}
+
+
+def install_target(connector_type: str) -> str:
+    """pip install target for a connector type; ``"(core)"`` when no extra is needed."""
+    extra = _EXTRAS.get(connector_type)
+    return f"drt-core[{extra}]" if extra else "(core)"
+
+
+def connector_inventory() -> dict[str, list[dict[str, str]]]:
+    """Sources + destinations as ``{name, type, install}`` dicts, derived from
+    the ``SOURCES`` / ``DESTINATIONS`` SSoT above.
+
+    Consumed by the MCP ``drt_list_connectors`` tool so the inventory can't
+    drift out of lockstep with the registry (which ``test_cli_list_connectors``
+    already keeps aligned with these lists).
+    """
+    return {
+        "sources": [
+            {"name": name, "type": t, "install": install_target(t)} for t, name in SOURCES
+        ],
+        "destinations": [
+            {"name": name, "type": t, "install": install_target(t)} for t, name in DESTINATIONS
+        ],
+    }

--- a/drt/mcp/server.py
+++ b/drt/mcp/server.py
@@ -371,71 +371,12 @@ def create_server(project_dir: Path | None = None) -> Any:
             Dict with 'sources' and 'destinations' lists, each containing
             connector name, type key, and install extras (if any).
         """
-        # Keep both lists in lockstep with drt/connectors/registry.py —
-        # scripts/check_drift.sh (mcp-inventory-dest / mcp-inventory-src)
-        # fails the weekly drift audit when a registered connector is
-        # missing here.
-        return {
-            "sources": [
-                {"name": "BigQuery", "type": "bigquery", "install": "drt-core[bigquery]"},
-                {"name": "DuckDB", "type": "duckdb", "install": "(core)"},
-                {"name": "SQLite", "type": "sqlite", "install": "(core)"},
-                {"name": "PostgreSQL", "type": "postgres", "install": "drt-core[postgres]"},
-                {"name": "Redshift", "type": "redshift", "install": "drt-core[redshift]"},
-                {"name": "ClickHouse", "type": "clickhouse", "install": "drt-core[clickhouse]"},
-                {"name": "Snowflake", "type": "snowflake", "install": "drt-core[snowflake]"},
-                {"name": "MySQL", "type": "mysql", "install": "drt-core[mysql]"},
-                {"name": "Databricks", "type": "databricks", "install": "drt-core[databricks]"},
-                {"name": "SQL Server", "type": "sqlserver", "install": "drt-core[sqlserver]"},
-                {"name": "REST API", "type": "rest_api", "install": "(core)"},
-                {"name": "Delta Lake", "type": "deltalake", "install": "drt-core[deltalake]"},
-                {"name": "Iceberg", "type": "iceberg", "install": "drt-core[iceberg]"},
-            ],
-            "destinations": [
-                {"name": "REST API", "type": "rest_api", "install": "(core)"},
-                {"name": "Slack", "type": "slack", "install": "(core)"},
-                {"name": "Discord", "type": "discord", "install": "(core)"},
-                {"name": "Microsoft Teams", "type": "teams", "install": "(core)"},
-                {"name": "GitHub Actions", "type": "github_actions", "install": "(core)"},
-                {"name": "HubSpot", "type": "hubspot", "install": "(core)"},
-                {"name": "Amplitude", "type": "amplitude", "install": "(core)"},
-                {"name": "Klaviyo", "type": "klaviyo", "install": "(core)"},
-                {"name": "Mixpanel", "type": "mixpanel", "install": "(core)"},
-                {"name": "Zendesk", "type": "zendesk", "install": "(core)"},
-                {
-                    "name": "Elasticsearch / OpenSearch",
-                    "type": "elasticsearch",
-                    "install": "(core)",
-                },
-                {"name": "Google Sheets", "type": "google_sheets", "install": "drt-core[sheets]"},
-                {"name": "PostgreSQL", "type": "postgres", "install": "drt-core[postgres]"},
-                {"name": "MySQL", "type": "mysql", "install": "drt-core[mysql]"},
-                {"name": "ClickHouse", "type": "clickhouse", "install": "drt-core[clickhouse]"},
-                {"name": "Snowflake", "type": "snowflake", "install": "drt-core[snowflake]"},
-                {
-                    "name": "Databricks Delta Lake",
-                    "type": "databricks",
-                    "install": "drt-core[databricks]",
-                },
-                {"name": "BigQuery", "type": "bigquery", "install": "drt-core[bigquery]"},
-                {"name": "Amazon S3", "type": "s3", "install": "drt-core[s3]"},
-                {"name": "Google Cloud Storage", "type": "gcs", "install": "drt-core[gcs]"},
-                {"name": "Azure Blob Storage", "type": "azure_blob", "install": "drt-core[azure]"},
-                {"name": "Parquet", "type": "parquet", "install": "drt-core[parquet]"},
-                {"name": "CSV/JSON/JSONL", "type": "file", "install": "(core)"},
-                {"name": "Jira", "type": "jira", "install": "(core)"},
-                {"name": "Linear", "type": "linear", "install": "(core)"},
-                {"name": "SendGrid", "type": "sendgrid", "install": "(core)"},
-                {"name": "Notion", "type": "notion", "install": "(core)"},
-                {"name": "Airtable", "type": "airtable", "install": "(core)"},
-                {"name": "Twilio SMS", "type": "twilio", "install": "(core)"},
-                {"name": "Intercom", "type": "intercom", "install": "(core)"},
-                {"name": "Email SMTP", "type": "email_smtp", "install": "(core)"},
-                {"name": "Google Ads", "type": "google_ads", "install": "(core)"},
-                {"name": "Salesforce Bulk", "type": "salesforce_bulk", "install": "(core)"},
-                {"name": "Staged Upload", "type": "staged_upload", "install": "(core)"},
-            ],
-        }
+        # Derived from the drt.config.connectors SSoT (kept in lockstep with
+        # drt/connectors/registry.py by test_cli_list_connectors), so this
+        # inventory can never fall out of sync with the registry.
+        from drt.config.connectors import connector_inventory
+
+        return connector_inventory()
 
     # -----------------------------------------------------------------------
     # drt_dlq

--- a/scripts/check_drift.sh
+++ b/scripts/check_drift.sh
@@ -185,24 +185,18 @@ for tool in $mcp_tools; do
 done
 
 # ---------------------------------------------------------------------------
-# Check 8: registered connector → drt_list_connectors inventory
-# The sources and destinations blocks are matched separately so a type
-# key present in one list can't mask its absence from the other (e.g.
-# "snowflake" in sources must not satisfy the destinations check).
+# Check 8: drt_list_connectors must DERIVE its inventory from the
+# drt.config.connectors SSoT (not a hand-maintained literal). The SSoT is
+# kept aligned with the registry by test_cli_list_connectors, so a derived
+# inventory can't drift — whereas a re-hardcoded one silently can (that's how
+# salesforce_bulk once fell out of the MCP list). Flag any regression to a
+# literal. Actual name/type parity is asserted in tests/unit/test_mcp.py.
 # ---------------------------------------------------------------------------
 list_connectors_fn=$(awk '/def drt_list_connectors/,/^    # ----/' "$MCP_SERVER")
-inventory_src_block=$(echo "$list_connectors_fn" | awk '/"sources": \[/,/"destinations": \[/')
-inventory_dest_block=$(echo "$list_connectors_fn" | awk '/"destinations": \[/,0')
-for dest in $destinations; do
-    if ! echo "$inventory_dest_block" | grep -q "\"type\": \"$dest\""; then
-        report "mcp-inventory-dest" "$dest" "not in drt_list_connectors destinations inventory"
-    fi
-done
-for src in $sources; do
-    if ! echo "$inventory_src_block" | grep -q "\"type\": \"$src\""; then
-        report "mcp-inventory-src" "$src" "not in drt_list_connectors sources inventory"
-    fi
-done
+if ! echo "$list_connectors_fn" | grep -q "connector_inventory"; then
+    report "mcp-inventory" "drt_list_connectors" \
+        "no longer derives from the drt.config.connectors SSoT (re-hardcoded?)"
+fi
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/unit/test_cli_list_connectors.py
+++ b/tests/unit/test_cli_list_connectors.py
@@ -234,3 +234,34 @@ def test_sample_yaml_caps_at_eight_lines_when_required_fields_overflow() -> None
     assert len(lines) == 8
     assert lines[0].endswith("type: synthetic")
     assert lines[-1].endswith("f6: <f6>")  # last required field that fit
+
+
+# ---------------------------------------------------------------------------
+# install_target / connector_inventory (SSoT for the MCP inventory)
+# ---------------------------------------------------------------------------
+
+
+def test_install_target_extras_and_core() -> None:
+    from drt.config.connectors import install_target
+
+    assert install_target("postgres") == "drt-core[postgres]"
+    assert install_target("azure_blob") == "drt-core[azure]"  # extra name != type
+    assert install_target("google_sheets") == "drt-core[sheets]"  # extra name != type
+    assert install_target("slack") == "(core)"
+    assert install_target("duckdb") == "(core)"  # bundled in core despite a [duckdb] extra
+
+
+def test_connector_inventory_covers_every_registered_type() -> None:
+    """The derived inventory lists exactly the SSoT types (which
+    test_DESTINATIONS_matches_registry keeps aligned with the registry) — the
+    structural guard against the drift that once dropped salesforce_bulk."""
+    from drt.config.connectors import connector_inventory
+
+    inv = connector_inventory()
+    assert {c["type"] for c in inv["sources"]} == {t for t, _ in SOURCES}
+    assert {c["type"] for c in inv["destinations"]} == {t for t, _ in DESTINATIONS}
+    # every entry carries name + type + install
+    for entry in inv["sources"] + inv["destinations"]:
+        assert entry.keys() == {"name", "type", "install"}
+    # the connector that fell out of the old hand-maintained list is present
+    assert any(c["type"] == "salesforce_bulk" for c in inv["destinations"])


### PR DESCRIPTION
Follow-up on #718 — the durable fix for the inventory drift class (closes the loop on #714).

## Why

`drt_list_connectors` returned a **hand-maintained literal** that had to be kept in lockstep with the registry by hand. That coupling is exactly what silently dropped `salesforce_bulk` from the MCP inventory (fixed reactively in #714). The audit flagged deriving it from the SSoT as the permanent fix.

## What

- Add `connector_inventory()` + `install_target()` (+ an `_EXTRAS` map) to `drt/config/connectors.py`. `drt_list_connectors` now just returns `connector_inventory()`.
- The `drt.config.connectors` SSoT is already kept aligned with the registry by `test_cli_list_connectors` (`test_DESTINATIONS/SOURCES_matches_registry`), so a derived inventory **cannot** drift.
- **Rework drift `Check 8`**: the old check grepped the inventory for per-type `"type": "..."` literals — meaningless once it's derived. It now asserts the derivation is still in place (greps for `connector_inventory`), so a regression back to a hardcoded list is flagged. Actual name/type parity is asserted in `tests/unit/test_mcp.py::test_list_connectors_matches_connector_ssot`.

## Behaviour note

Display names are now the **canonical SSoT names** — e.g. `Databricks` (was "Databricks Delta Lake"), `Email` (was "Email SMTP"), `Twilio` (was "Twilio SMS"), `Elasticsearch` (was "Elasticsearch / OpenSearch"), `File` (was "CSV/JSON/JSONL"). This matches what `drt sources` / `drt destinations` already print; `type` and `install` are unchanged.

## Verification

- Full unit suite: **1832 passed, 5 skipped** (2 new in `test_cli_list_connectors.py` — `install_target` extras map + `connector_inventory` covers-every-type)
- `ruff` + `mypy` clean · `make check-drift` → 0 drift (Check 8 now guards the derivation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)