### PR TITLE
chore(#723): extract JSON logging to cli/_logging + document source-only connectors

### DIFF
--- a/docs/connectors/duckdb.md
+++ b/docs/connectors/duckdb.md
@@ -1,0 +1,32 @@
+# DuckDB Source
+
+> Read tables/views from a local DuckDB database file (or an in-memory DB) as a
+> drt sync **source**. Bundled in drt-core — no extra install.
+
+## Profile (`~/.drt/profiles.yml`)
+
+```yaml
+warehouse:
+  type: duckdb
+  database: warehouse.duckdb   # file path, or ":memory:"
+```
+
+## Configuration
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `type` | `"duckdb"` | — | Required |
+| `database` | string | `:memory:` | Path to the `.duckdb` file, or `:memory:` for an ephemeral in-process DB |
+
+## Notes
+
+- (core) — DuckDB ships with drt-core; nothing extra to install.
+- Each sync's `model` SQL is executed against this database; reference any table
+  or view it contains.
+- `drt init --template duckdb_to_rest` scaffolds a runnable DuckDB → REST project.
+- `:memory:` only holds data created in the same process, so it's for tests/demos
+  rather than persisted pipelines.
+
+## References
+
+- [DuckDB documentation](https://duckdb.org/docs/)

--- a/docs/connectors/redshift.md
+++ b/docs/connectors/redshift.md
@@ -1,0 +1,42 @@
+# Redshift Source
+
+> Read from an Amazon Redshift cluster as a drt sync **source**. Redshift speaks
+> the PostgreSQL wire protocol, with an explicit `schema`.
+
+## Profile (`~/.drt/profiles.yml`)
+
+```yaml
+redshift_prod:
+  type: redshift
+  host: my-cluster.xxx.us-east-1.redshift.amazonaws.com
+  port: 5439
+  dbname: analytics
+  user: analyst
+  password_env: REDSHIFT_PASSWORD
+  schema: public
+```
+
+## Configuration
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `type` | `"redshift"` | — | Required |
+| `host` | string | — | Cluster endpoint |
+| `port` | int | `5439` | Redshift default port |
+| `dbname` | string | — | Database name |
+| `user` | string | — | Username |
+| `password_env` | string \| null | null | Env var holding the password (preferred) |
+| `password` | string \| null | null | Inline password (not recommended) |
+| `schema` | string | `public` | Default schema for unqualified table names |
+
+## Notes
+
+- Requires the extra: `pip install drt-core[redshift]`.
+- Prefer `password_env` over an inline `password` — it keeps secrets out of the
+  profile file.
+- Each sync's `model` SQL runs against the cluster; qualify tables as
+  `schema.table` or rely on the profile's `schema`.
+
+## References
+
+- [Amazon Redshift documentation](https://docs.aws.amazon.com/redshift/)

--- a/docs/connectors/sqlite.md
+++ b/docs/connectors/sqlite.md
@@ -1,0 +1,31 @@
+# SQLite Source
+
+> Read tables/views from a local SQLite database file (or an in-memory DB) as a
+> drt sync **source**. Bundled in drt-core — no extra install.
+
+## Profile (`~/.drt/profiles.yml`)
+
+```yaml
+warehouse:
+  type: sqlite
+  database: app.db   # file path, or ":memory:"
+```
+
+## Configuration
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `type` | `"sqlite"` | — | Required |
+| `database` | string | `:memory:` | Path to the `.db` file, or `:memory:` for an ephemeral in-process DB |
+
+## Notes
+
+- (core) — uses Python's built-in `sqlite3`; nothing extra to install.
+- Each sync's `model` SQL is executed against this database; reference any table
+  or view it contains.
+- Handy for local development and small operational databases you want to
+  activate out to a SaaS destination.
+
+## References
+
+- [SQLite documentation](https://www.sqlite.org/docs.html)

--- a/docs/connectors/sqlserver.md
+++ b/docs/connectors/sqlserver.md
@@ -1,0 +1,42 @@
+# SQL Server Source
+
+> Read from a Microsoft SQL Server database as a drt sync **source** (via
+> `pymssql`).
+
+## Profile (`~/.drt/profiles.yml`)
+
+```yaml
+mssql_prod:
+  type: sqlserver
+  host: sql.example.com
+  port: 1433
+  database: analytics
+  user: drt_reader
+  password_env: MSSQL_PASSWORD
+  schema: dbo
+```
+
+## Configuration
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `type` | `"sqlserver"` | — | Required |
+| `host` | string | — | Server hostname |
+| `port` | int | `1433` | SQL Server default port |
+| `database` | string | — | Database name |
+| `user` | string | — | Username |
+| `password_env` | string \| null | null | Env var holding the password (preferred) |
+| `password` | string \| null | null | Inline password (not recommended) |
+| `schema` | string | `dbo` | Default schema for unqualified table names |
+
+## Notes
+
+- Requires the extra: `pip install drt-core[sqlserver]` (pulls in `pymssql`).
+- Prefer `password_env` over an inline `password`.
+- Each sync's `model` SQL runs against the database; qualify tables as
+  `schema.table` or rely on the profile's `schema`.
+
+## References
+
+- [SQL Server documentation](https://learn.microsoft.com/en-us/sql/)
+- [pymssql documentation](https://www.pymssql.org/)

--- a/drt/cli/_logging.py
+++ b/drt/cli/_logging.py
@@ -1,0 +1,42 @@
+"""JSON-lines logging for ``drt run --log-format json``.
+
+Extracted from ``drt.cli.commands.run`` so the command module holds the run
+command, not generic logging infrastructure. ``run.py`` re-imports these names
+(and ``drt.cli.main`` re-exports them), so the public import surface is
+unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+
+# Attributes present on a bare LogRecord — anything else on a record came in via
+# the ``extra=`` kwarg and should be merged into the JSON payload.
+_STANDARD_LOG_FIELDS = frozenset(vars(logging.LogRecord("", 0, "", 0, "", (), None)))
+
+
+class _JsonFormatter(logging.Formatter):
+    """Emit each log record as a single JSON object (JSON Lines format)."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        ts = datetime.fromtimestamp(record.created, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        payload: dict[str, object] = {
+            "ts": ts,
+            "level": record.levelname,
+            "msg": record.getMessage(),
+        }
+        # Merge any extra fields passed via the `extra` kwarg
+        for key, value in record.__dict__.items():
+            if key not in _STANDARD_LOG_FIELDS and not key.startswith("_"):
+                payload[key] = value
+        return json.dumps(payload)
+
+
+def _configure_json_logging() -> None:
+    """Replace root logger handlers with a stderr JSON handler."""
+    handler = logging.StreamHandler()
+    handler.setFormatter(_JsonFormatter())
+    logging.root.handlers = [handler]
+    logging.root.setLevel(logging.INFO)

--- a/drt/cli/commands/run.py
+++ b/drt/cli/commands/run.py
@@ -3,8 +3,7 @@
 Extracted from ``drt/cli/main.py`` in Phase 2b PR (a) of the #546 split
 (see #573 for the umbrella). Bundles:
 
-- ``LogFormat`` Enum + ``_JsonFormatter`` + ``_configure_json_logging``
-  (JSON Lines structured logging — only ``run`` uses this today)
+- ``LogFormat`` Enum (the ``--log-format`` option)
 - ``_RunContext`` dataclass (shared state for one sync invocation)
 - ``_exit_code_for_signal`` (POSIX 128 + signum convention)
 - ``_run_one`` (per-sync execution; observer composition; telemetry)
@@ -13,9 +12,9 @@ Extracted from ``drt/cli/main.py`` in Phase 2b PR (a) of the #546 split
 - ``run`` (the @app.command itself; signal handling; parallel/sequential
   dispatch; JSON-mode output)
 
-These pieces live together because ``run`` is the only caller of the
-helpers and the helpers were never reused elsewhere. Keeping them in one
-module avoids creating an ``_logging.py`` / ``_run_context.py`` graveyard.
+The JSON Lines logging itself (``_JsonFormatter`` / ``_configure_json_logging``)
+was factored out to ``drt.cli._logging`` (#723) and is re-imported here; the
+rest stays because ``run`` is their only caller.
 
 Back-compat: ``drt.cli.main`` re-exports each of the underscore-prefixed
 names + ``LogFormat`` so that ``from drt.cli.main import _RunContext``
@@ -31,7 +30,6 @@ import signal
 import threading
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -75,33 +73,8 @@ class LogFormat(str, Enum):
 # JSON logging
 # ---------------------------------------------------------------------------
 
-_STANDARD_LOG_FIELDS = frozenset(vars(logging.LogRecord("", 0, "", 0, "", (), None)))
-
-
-class _JsonFormatter(logging.Formatter):
-    """Emit each log record as a single JSON object (JSON Lines format)."""
-
-    def format(self, record: logging.LogRecord) -> str:
-        ts = datetime.fromtimestamp(record.created, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        payload: dict[str, object] = {
-            "ts": ts,
-            "level": record.levelname,
-            "msg": record.getMessage(),
-        }
-        # Merge any extra fields passed via the `extra` kwarg
-        for key, value in record.__dict__.items():
-            if key not in _STANDARD_LOG_FIELDS and not key.startswith("_"):
-                payload[key] = value
-        return json.dumps(payload)
-
-
-def _configure_json_logging() -> None:
-    """Replace root logger handlers with a stderr JSON handler."""
-    handler = logging.StreamHandler()
-    handler.setFormatter(_JsonFormatter())
-    logging.root.handlers = [handler]
-    logging.root.setLevel(logging.INFO)
-
+# JSON-lines logging (``--log-format json``) lives in ``drt.cli._logging``.
+from drt.cli._logging import _configure_json_logging  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Run context + helpers

--- a/drt/cli/main.py
+++ b/drt/cli/main.py
@@ -140,11 +140,13 @@ def _get_destination(sync: SyncConfig) -> Destination:
 # implementations now live in drt/cli/commands/run.py; re-export so the
 # legacy import path keeps working. New callers should import from
 # drt.cli.commands.run directly.
+from drt.cli._logging import (  # noqa: E402, F401
+    _configure_json_logging,
+    _JsonFormatter,
+)
 from drt.cli.commands.run import (  # noqa: E402, F401
     LogFormat,
-    _configure_json_logging,
     _exit_code_for_signal,
-    _JsonFormatter,
     _print_watermark_summary,
     _run_one,
     _RunContext,


### PR DESCRIPTION
Two small cleanups from the #723 grab-bag. The mcp/server.py tool split (F-6) and schema.py table-drive (F-7) are **deferred** — the tool split is a larger restructure best done on its own, and schema.py collides with #707's Databricks paramstyle work.

## JSON logging → `cli/_logging.py`

`_JsonFormatter` / `_configure_json_logging` / the `_STANDARD_LOG_FIELDS` set move out of `cli/commands/run.py` (which is the *run command*, not generic logging infra) into a dedicated `cli/_logging.py`.

`run.py` re-imports them and `cli/main.py` re-exports them, so the public import surface is **unchanged** — including `from drt.cli.main import _JsonFormatter, _configure_json_logging` used by `test_json_logging.py`. (The stale run.py docstring that said this "avoids creating an `_logging.py` graveyard" is updated.)

## Source-only connector docs

Add `docs/connectors/{duckdb,sqlite,redshift,sqlserver}.md`. These four sources were registered and already listed in the README Sources table + `/drt-init` skill, but had no reference page — the drift check only maps *destinations* → docs. **Now every registered connector has a docs page.** Each doc is derived from the profile config (fields, defaults, install extra).

## Verification

- Full unit suite: **1832 passed, 5 skipped** (incl. `test_json_logging` + `test_cli_log_format`, which import via `drt.cli.main`)
- `ruff` + `mypy` clean · `make check-drift` → 0 drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)