### PR TITLE
refactor(destinations): shared mirror-capability guard + record_preview helper (#722)

### DIFF
--- a/drt/destinations/clickhouse.py
+++ b/drt/destinations/clickhouse.py
@@ -99,21 +99,11 @@ class ClickHouseDestination:
                 # sync.mode: mirror (#340 Step 3) — validate upsert_key
                 # before any INSERT so a misconfigured sync fails fast
                 # rather than after partially populating the table.
-                if sync_options.mode == "mirror" and not config.upsert_key:
-                    from drt.destinations.sql_utils import MIRROR_UPSERT_KEY_MSG
+                # Reject an unserveable mirror config (missing upsert_key, or
+                # tracked/scope which are Postgres/MySQL-only) before any INSERT.
+                from drt.destinations.sql_utils import check_mirror_supported
 
-                    raise ValueError(MIRROR_UPSERT_KEY_MSG)
-                # mirror.strategy: tracked (#686) is Postgres/MySQL-only for
-                # now — fail fast rather than silently falling back to the
-                # destination diff, whose delete semantics differ.
-                if (
-                    sync_options.mode == "mirror"
-                    and sync_options.mirror is not None
-                    and (sync_options.mirror.strategy == "tracked" or sync_options.mirror.scope)
-                ):
-                    from drt.destinations.sql_utils import unsupported_tracked_scope_msg
-
-                    raise ValueError(unsupported_tracked_scope_msg("clickhouse"))
+                check_mirror_supported(config, sync_options, "clickhouse")
 
                 # clickhouse-connect's client.insert(table=...) interpolates
                 # the table raw into "INSERT INTO {table} ..." with no quoting

--- a/drt/destinations/databricks.py
+++ b/drt/destinations/databricks.py
@@ -204,23 +204,16 @@ class DatabricksDestination:
         # upsert_key here so the misconfiguration is surfaced before any
         # row touches Databricks.
         is_mirror = sync_options.mode == "mirror"
-        if is_mirror and not config.upsert_key:
-            from drt.destinations.sql_utils import MIRROR_UPSERT_KEY_MSG
+        # Reject an unserveable mirror config (missing upsert_key, or
+        # tracked/scope which are Postgres/MySQL-only) before writing; close the
+        # connection we just opened before surfacing the error.
+        from drt.destinations.sql_utils import check_mirror_supported
 
+        try:
+            check_mirror_supported(config, sync_options, "databricks")
+        except ValueError:
             conn.close()
-            raise ValueError(MIRROR_UPSERT_KEY_MSG)
-        # mirror.strategy: tracked (#686) is Postgres/MySQL-only for now —
-        # fail fast rather than silently falling back to the destination
-        # diff, which has different (co-writer-unsafe) delete semantics.
-        if (
-            is_mirror
-            and sync_options.mirror is not None
-            and (sync_options.mirror.strategy == "tracked" or sync_options.mirror.scope)
-        ):
-            from drt.destinations.sql_utils import unsupported_tracked_scope_msg
-
-            conn.close()
-            raise ValueError(unsupported_tracked_scope_msg("databricks"))
+            raise
         try:
             with conn.cursor() as cur:
                 columns = list(records[0].keys())

--- a/drt/destinations/jira.py
+++ b/drt/destinations/jira.py
@@ -8,7 +8,6 @@ For each record:
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 from typing import Any
@@ -20,6 +19,7 @@ from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter
 from drt.destinations.retry import resolve_retry, with_retry
 from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_preview as _record_preview
 from drt.templates.renderer import render_template
 
 logger = logging.getLogger(__name__)
@@ -187,6 +187,3 @@ def _to_adf(text: str) -> dict[str, Any]:
     }
 
 
-def _record_preview(row: dict[str, Any]) -> str:
-    """Best-effort JSON preview that tolerates non-serializable values."""
-    return json.dumps(row, default=str)[:200]

--- a/drt/destinations/linear.py
+++ b/drt/destinations/linear.py
@@ -24,7 +24,6 @@ Linear API reference:
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Any
 
@@ -36,6 +35,7 @@ from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter
 from drt.destinations.retry import resolve_retry, with_retry
 from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_preview as _record_preview
 from drt.templates.renderer import render_template
 
 logger = logging.getLogger(__name__)
@@ -50,10 +50,6 @@ mutation IssueCreate($input: IssueCreateInput!) {
   }
 }
 """
-
-
-def _record_preview(row: dict[str, Any]) -> str:
-    return json.dumps(row, default=str)[:200]
 
 
 class LinearDestination:

--- a/drt/destinations/row_errors.py
+++ b/drt/destinations/row_errors.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from typing import Any
 
 
 @dataclass
@@ -15,3 +17,13 @@ class RowError:
     http_status: int | None
     error_message: str
     timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+def record_preview(record: dict[str, Any]) -> str:
+    """Best-effort 200-char JSON preview of a record for ``RowError``.
+
+    Tolerates non-serializable values (``default=str``) and caps length so the
+    full record — which may hold PII — is never logged. Shared by the
+    destinations that previously each defined an identical ``_record_preview``.
+    """
+    return json.dumps(record, default=str)[:200]

--- a/drt/destinations/sendgrid.py
+++ b/drt/destinations/sendgrid.py
@@ -28,7 +28,6 @@ SendGrid API reference:
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Any
 
@@ -40,15 +39,12 @@ from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter
 from drt.destinations.retry import resolve_retry, with_retry
 from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_preview as _record_preview
 from drt.templates.renderer import render_template
 
 logger = logging.getLogger(__name__)
 
 _SENDGRID_API_URL = "https://api.sendgrid.com/v3/mail/send"
-
-
-def _record_preview(row: dict[str, Any]) -> str:
-    return json.dumps(row, default=str)[:200]
 
 
 class SendGridDestination:

--- a/drt/destinations/snowflake.py
+++ b/drt/destinations/snowflake.py
@@ -130,23 +130,16 @@ class SnowflakeDestination:
         # upsert_key here so the misconfiguration is surfaced before any
         # row touches Snowflake.
         is_mirror = sync_options.mode == "mirror"
-        if is_mirror and not config.upsert_key:
-            from drt.destinations.sql_utils import MIRROR_UPSERT_KEY_MSG
+        # Reject an unserveable mirror config (missing upsert_key, or
+        # tracked/scope which are Postgres/MySQL-only) before writing; close the
+        # connection we just opened before surfacing the error.
+        from drt.destinations.sql_utils import check_mirror_supported
 
+        try:
+            check_mirror_supported(config, sync_options, "snowflake")
+        except ValueError:
             conn.close()
-            raise ValueError(MIRROR_UPSERT_KEY_MSG)
-        # mirror.strategy: tracked (#686) is Postgres/MySQL-only for now —
-        # fail fast rather than silently falling back to the destination
-        # diff, which has different (co-writer-unsafe) delete semantics.
-        if (
-            is_mirror
-            and sync_options.mirror is not None
-            and (sync_options.mirror.strategy == "tracked" or sync_options.mirror.scope)
-        ):
-            from drt.destinations.sql_utils import unsupported_tracked_scope_msg
-
-            conn.close()
-            raise ValueError(unsupported_tracked_scope_msg("snowflake"))
+            raise
         try:
             with conn.cursor() as cur:
                 columns = list(records[0].keys())

--- a/drt/destinations/sql_utils.py
+++ b/drt/destinations/sql_utils.py
@@ -74,3 +74,25 @@ def unsupported_tracked_scope_msg(dialect: str) -> str:
         f"mirror.strategy: tracked / mirror.scope are not yet supported on {dialect} "
         "(supported: postgres, mysql — see #686 follow-ups)."
     )
+
+
+def check_mirror_supported(config: Any, sync_options: Any, dialect: str) -> None:
+    """Fail fast on a ``sync.mode: mirror`` config a SQL destination can't serve.
+
+    - mirror requires an ``upsert_key`` (to know which rows to DELETE)
+    - ``mirror.strategy: tracked`` / ``mirror.scope`` are Postgres/MySQL-only, so
+      reject them on ``dialect`` rather than silently falling back to the
+      (co-writer-unsafe) destination diff.
+
+    No-op for non-mirror syncs. Callers holding an open connection should close
+    it before re-raising (``try: check_mirror_supported(...) except ValueError:
+    conn.close(); raise``).
+    """
+    if sync_options.mode != "mirror":
+        return
+    if not config.upsert_key:
+        raise ValueError(MIRROR_UPSERT_KEY_MSG)
+    if sync_options.mirror is not None and (
+        sync_options.mirror.strategy == "tracked" or sync_options.mirror.scope
+    ):
+        raise ValueError(unsupported_tracked_scope_msg(dialect))

--- a/tests/unit/test_sql_utils.py
+++ b/tests/unit/test_sql_utils.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import pytest
+
 from drt.destinations.sql_utils import (
     MIRROR_UPSERT_KEY_MSG,
     RowCountable,
     backtick_quote_ident,
+    check_mirror_supported,
     get_row_count_for_destination,
     unsupported_tracked_scope_msg,
 )
@@ -76,3 +81,42 @@ def test_unsupported_tracked_scope_message_names_dialect() -> None:
         "mirror.strategy: tracked / mirror.scope are not yet supported on snowflake "
         "(supported: postgres, mysql — see #686 follow-ups)."
     )
+
+
+# ---------------------------------------------------------------------------
+# check_mirror_supported — shared mirror-capability guard
+# ---------------------------------------------------------------------------
+
+
+def _mirror_opts(strategy: str | None = None, scope: object = None) -> SimpleNamespace:
+    return SimpleNamespace(mode="mirror", mirror=SimpleNamespace(strategy=strategy, scope=scope))
+
+
+def test_check_mirror_supported_noop_for_non_mirror() -> None:
+    # Non-mirror sync: no upsert_key needed, no raise.
+    check_mirror_supported(
+        SimpleNamespace(upsert_key=[]),
+        SimpleNamespace(mode="upsert", mirror=None),
+        "snowflake",
+    )
+
+
+def test_check_mirror_supported_requires_upsert_key() -> None:
+    with pytest.raises(ValueError, match="requires destination.upsert_key"):
+        check_mirror_supported(
+            SimpleNamespace(upsert_key=[]),
+            SimpleNamespace(mode="mirror", mirror=None),
+            "snowflake",
+        )
+
+
+def test_check_mirror_supported_rejects_tracked_and_scope() -> None:
+    cfg = SimpleNamespace(upsert_key=["id"])
+    with pytest.raises(ValueError, match="not yet supported on databricks"):
+        check_mirror_supported(cfg, _mirror_opts(strategy="tracked"), "databricks")
+    with pytest.raises(ValueError, match="not yet supported on clickhouse"):
+        check_mirror_supported(cfg, _mirror_opts(scope=["parent_id"]), "clickhouse")
+
+
+def test_check_mirror_supported_ok_for_plain_mirror() -> None:
+    check_mirror_supported(SimpleNamespace(upsert_key=["id"]), _mirror_opts(), "snowflake")


### PR DESCRIPTION
Two behavior-preserving cleanups continuing the #726 SQL-destination work.

## Mirror-capability guard

`check_mirror_supported(config, sync_options, dialect)` in `sql_utils` centralizes the fail-fast that ClickHouse, Snowflake and Databricks each hand-rolled:
- `sync.mode: mirror` requires an `upsert_key` (to know which rows to DELETE)
- `mirror.strategy: tracked` / `mirror.scope` are Postgres/MySQL-only → reject rather than silently use the co-writer-unsafe destination diff

Snowflake/Databricks keep their `conn.close()`-before-raise via a thin `try/except ValueError`; ClickHouse (no open connection at that point) calls it directly. The raised messages are the **#726 constants, unchanged** — the five mirror-mode test files that assert them still pass.

## record_preview helper

The identical `_record_preview` defined **three times** (linear/jira/sendgrid — all `json.dumps(record, default=str)[:200]`) is replaced by one `record_preview()` in `row_errors.py` (its natural home, next to `RowError`). Each destination imports it aliased to the old name, so call sites are untouched.

## Deferred (still tracked on #722)

The **full RowError-handling sweep** — 59 `RowError(...)` sites across 28 files with three preview formats (`json.dumps` / `str(record)` / `str(row)`). Normalizing all of them *changes* preview output on the non-json sites and touches behavior-sensitive tests (`record_preview == '{"id": 1}'`, `"ghost" in preview`), so it warrants its own dedicated PR with test reconciliation rather than riding along here. `record_preview()` is the canonical helper that sweep will adopt.

## Verification

- Full unit suite: **1832 passed, 5 skipped** (+4 new in `test_sql_utils.py`)
- `ruff` clean · **mypy across the whole package** clean
- `sql_utils.py` + `row_errors.py` at **100%** coverage · `make check-drift` → 0 drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)