### PR TITLE
refactor(destinations): make columns required in Snowflake/Databricks _insert_rows, drop the values() fallback (#699)

### DIFF
--- a/drt/destinations/databricks.py
+++ b/drt/destinations/databricks.py
@@ -437,23 +437,21 @@ class DatabricksDestination:
         records: list[dict[str, Any]],
         sync_options: SyncOptions,
         result: SyncResult,
-        columns: list[str] | None = None,
-        json_cols: list[str] | None = None,
+        columns: list[str],
+        json_cols: list[str],
     ) -> None:
         """Execute a parameterised INSERT per row, honouring ``on_error``.
 
-        When ``columns`` is given, values are ordered to it and json columns
-        (``json_cols``) are ``json.dumps``'d so the ``from_json`` / ``parse_json``
-        bind receives a JSON string (Layer 3, #317).
+        Values are ordered to ``columns`` and json columns (``json_cols``) are
+        ``json.dumps``'d so the ``from_json`` / ``parse_json`` bind receives a
+        JSON string (Layer 3, #317). Ordering by ``columns`` (via ``row.get`` in
+        ``_bind_row``) keeps binds correct even when a source yields rows with a
+        varying key order/set — so ``columns``/``json_cols`` are required, not an
+        optional ``list(row.values())`` fallback (#699).
         """
         for i, row in enumerate(records):
             try:
-                values = (
-                    _bind_row(row, columns, json_cols or [])
-                    if columns is not None
-                    else list(row.values())
-                )
-                cur.execute(sql, values)
+                cur.execute(sql, _bind_row(row, columns, json_cols))
                 result.success += 1
             except Exception as e:
                 result.failed += 1

--- a/drt/destinations/snowflake.py
+++ b/drt/destinations/snowflake.py
@@ -353,23 +353,21 @@ class SnowflakeDestination:
         records: list[dict[str, Any]],
         sync_options: SyncOptions,
         result: SyncResult,
-        columns: list[str] | None = None,
-        json_cols: list[str] | None = None,
+        columns: list[str],
+        json_cols: list[str],
     ) -> None:
         """Execute a parameterised INSERT per row, honouring ``on_error``.
 
-        When ``columns`` is given, values are ordered to it and JSON columns
-        (``json_cols``) are ``json.dumps``'d to feed the ``PARSE_JSON`` bind
-        sites; otherwise the row's values are bound positionally (legacy path).
+        Values are ordered to ``columns`` and JSON columns (``json_cols``) are
+        ``json.dumps``'d to feed the ``PARSE_JSON`` bind sites. Ordering by
+        ``columns`` (via ``row.get`` in ``_bind_row``) keeps binds correct even
+        when a source yields rows with a varying key order/set — so
+        ``columns``/``json_cols`` are required, not an optional
+        ``list(row.values())`` fallback (#699).
         """
         for i, row in enumerate(records):
             try:
-                bound = (
-                    _bind_row(row, columns, json_cols or [])
-                    if columns is not None
-                    else list(row.values())
-                )
-                cur.execute(sql, bound)
+                cur.execute(sql, _bind_row(row, columns, json_cols))
                 result.success += 1
             except Exception as e:
                 result.failed += 1

--- a/tests/unit/test_databricks_schema_aware.py
+++ b/tests/unit/test_databricks_schema_aware.py
@@ -225,3 +225,19 @@ def test_from_json_ddl_single_quotes_are_escaped() -> None:
     )
     assert "it''s" in clause
     assert "from_json(%s, 'struct<n: string, it''s: int>')" in clause
+
+
+def test_bind_row_orders_by_columns_regardless_of_row_key_order() -> None:
+    """The order-safe path (#699): ``_bind_row`` orders values by ``columns`` via
+    ``row.get``, so rows with a varying key order/set (REST especially) never
+    misalign. This is why the old ``list(row.values())`` fallback was unsafe and
+    is now removed — ``columns``/``json_cols`` are required."""
+    columns = ["id", "name", "email"]
+    same_order = {"id": 1, "name": "Alice", "email": "a@x.com"}
+    diff_order = {"email": "b@x.com", "id": 2, "name": "Bob"}  # keys reordered
+    missing_key = {"id": 3, "name": "Carol"}  # no "email"
+    assert _bind_row(same_order, columns, []) == [1, "Alice", "a@x.com"]
+    # ordered by columns, NOT by dict insertion order:
+    assert _bind_row(diff_order, columns, []) == [2, "Bob", "b@x.com"]
+    # a missing key becomes None in its column slot, never a shifted misalignment:
+    assert _bind_row(missing_key, columns, []) == [3, "Carol", None]

--- a/tests/unit/test_snowflake_destination.py
+++ b/tests/unit/test_snowflake_destination.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from drt.config.models import SnowflakeDestinationConfig, SyncOptions
-from drt.destinations.snowflake import SnowflakeDestination
+from drt.destinations.snowflake import SnowflakeDestination, _bind_row
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -568,3 +568,19 @@ class TestSnowflakeSchemaIntrospection:
         assert "VALUES (%s, %s)" in sql
         assert "PARSE_JSON" not in sql
         assert bound == [1, 0.5]
+
+
+def test_bind_row_orders_by_columns_regardless_of_row_key_order() -> None:
+    """The order-safe path (#699): ``_bind_row`` orders values by ``columns`` via
+    ``row.get``, so rows with a varying key order/set (REST especially) never
+    misalign. This is why the old ``list(row.values())`` fallback was unsafe and
+    is now removed — ``columns``/``json_cols`` are required."""
+    columns = ["id", "name", "email"]
+    same_order = {"id": 1, "name": "Alice", "email": "a@x.com"}
+    diff_order = {"email": "b@x.com", "id": 2, "name": "Bob"}  # keys reordered
+    missing_key = {"id": 3, "name": "Carol"}  # no "email"
+    assert _bind_row(same_order, columns, []) == [1, "Alice", "a@x.com"]
+    # ordered by columns, NOT by dict insertion order:
+    assert _bind_row(diff_order, columns, []) == [2, "Bob", "b@x.com"]
+    # a missing key becomes None in its column slot, never a shifted misalignment:
+    assert _bind_row(missing_key, columns, []) == [3, "Carol", None]


### PR DESCRIPTION
Closes #699. Follow-up from the #680 review (deferred cleanup, agreed by @yodakanohoshi + @masukai).

`_insert_rows` in both `snowflake.py` and `databricks.py` now takes `columns` + `json_cols` as **required** params; the `list(row.values())` fallback is removed. The live path was already always `_bind_row(row, columns, json_cols)` — which orders by `columns` via `row.get`, so it's correct even when a source yields rows with varying key order/set (REST). The fallback was dead + untested (the codecov patch-miss from #680), and `list(row.values())` was the ordering foot-gun. All four call sites already passed both args, so this is signature + body only — no behaviour change on the live path.

Added `test_bind_row_orders_by_columns_regardless_of_row_key_order` to both destinations: reordered keys and a missing key bind by `columns` (missing → `None`), pinning the order-safe path as the only path.

ruff + mypy clean; 113 destination tests pass.

- [x] Tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [ ] CHANGELOG — N/A `[skip changelog]` (internal cleanup, no user-facing change)