### PR TITLE
test(smoke): add Snowflake mirror + BigQuery complex-type DWH smoke (#654)

### DIFF
--- a/tests/integration/dwh/test_bigquery_smoke.py
+++ b/tests/integration/dwh/test_bigquery_smoke.py
@@ -11,12 +11,15 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
+from drt.config.credentials import DuckDBProfile
 from drt.config.models import BigQueryDestinationConfig, SyncConfig, SyncOptions
 from drt.destinations.bigquery import BigQueryDestination
 from drt.engine.sync import run_sync
+from drt.sources.duckdb import DuckDBSource
 
 from .conftest import require_env, seed_duckdb_users, unique_table
 
@@ -177,3 +180,91 @@ def test_bigquery_connection() -> None:
         }
     )
     BigQueryDestination().test_connection(dest)
+
+
+def test_bigquery_complex_type_roundtrip(tmp_path: Path) -> None:
+    """Nested / repeated fields roundtrip via ``insert_rows_json`` on a real project.
+
+    BigQuery handles ARRAY / STRUCT natively — unlike the Snowflake / Databricks
+    legs there's no ``PARSE_JSON`` / ``from_json`` wrapping — so this proves the
+    destination passes a Python ``list`` + ``dict`` straight through into a live
+    ``ARRAY<STRING>`` / ``STRUCT`` table, read back as typed sub-fields.
+    """
+    creds = require_env(
+        "DRT_SMOKE_BIGQUERY_PROJECT",
+        "DRT_SMOKE_BIGQUERY_DATASET",
+        "DRT_SMOKE_BIGQUERY_KEYFILE",
+    )
+    table = unique_table("drt_smoke")
+    project = creds["DRT_SMOKE_BIGQUERY_PROJECT"]
+    dataset = creds["DRT_SMOKE_BIGQUERY_DATASET"]
+    keyfile = creds["DRT_SMOKE_BIGQUERY_KEYFILE"]
+    fqn = f"`{project}`.`{dataset}`.`{table}`"
+
+    # Source: DuckDB LIST -> Python list (ARRAY), STRUCT -> Python dict (RECORD).
+    duckdb = pytest.importorskip("duckdb")
+    db_path = str(tmp_path / "complex_source.duckdb")
+    dconn = duckdb.connect(db_path)
+    try:
+        dconn.execute(
+            "CREATE TABLE events ("
+            "  id INTEGER,"
+            "  tags VARCHAR[],"
+            "  attrs STRUCT(theme VARCHAR, level INTEGER)"
+            ")"
+        )
+        dconn.execute("INSERT INTO events VALUES (1, ['a', 'b'], {'theme': 'dark', 'level': 3})")
+    finally:
+        dconn.close()
+    source = DuckDBSource()
+    profile = DuckDBProfile(type="duckdb", database=db_path)
+
+    dest_kwargs: dict[str, Any] = {
+        "type": "bigquery",
+        "project": project,
+        "dataset": dataset,
+        "table": table,
+        "mode": "insert",
+        "method": "keyfile",
+        "keyfile": keyfile,
+    }
+    dest = BigQueryDestinationConfig(**dest_kwargs)
+    sync = SyncConfig(
+        name="bigquery_complex_smoke",
+        model="ref('events')",
+        destination=dest,
+        sync=SyncOptions(batch_size=10),
+    )
+
+    client = bigquery.Client.from_service_account_json(keyfile, project=project)
+    try:
+        client.query(
+            f"CREATE TABLE {fqn} "
+            "(id INT64, tags ARRAY<STRING>, attrs STRUCT<theme STRING, level INT64>)"
+        ).result()
+
+        result = run_sync(sync, source, BigQueryDestination(), profile, tmp_path)
+        assert result.success == 1, f"expected 1 loaded row, got {result.success}"
+        assert result.failed == 0
+
+        # Streaming insert lands in a buffer; poll until the typed fields resolve.
+        row = None
+        for _ in range(12):
+            rows = list(
+                client.query(
+                    f"SELECT tags[OFFSET(0)] AS first_tag, attrs.theme AS theme, "
+                    f"attrs.level AS lvl FROM {fqn} WHERE id = 1"
+                ).result()
+            )
+            if rows:
+                row = rows[0]
+                break
+            time.sleep(5)
+        assert row is not None, "row did not land"
+        # Typed sub-fields resolve → the list/dict landed as real ARRAY/STRUCT,
+        # not an opaque JSON string.
+        assert row["first_tag"] == "a"
+        assert row["theme"] == "dark"
+        assert row["lvl"] == 3
+    finally:
+        client.query(f"DROP TABLE IF EXISTS {fqn}").result()

--- a/tests/integration/dwh/test_snowflake_smoke.py
+++ b/tests/integration/dwh/test_snowflake_smoke.py
@@ -18,6 +18,9 @@ Covers the #671 verification set (Priority 1 under epic #654):
   ``dict`` are reconstructed as real semi-structured values, proven by reading
   typed sub-fields (``tags[0]``, ``attrs:theme``, ``meta:source``) back.
 - ``test_snowflake_connection`` — fast credential check via ``test_connection``.
+- ``test_snowflake_mirror_deletes_unobserved_keys`` — ``sync.mode: mirror``
+  end-of-sync DELETE (#340 Snowflake leg): a pre-seeded row the source never
+  emits is removed because its key wasn't observed.
 
 Runs only when the ``DRT_SMOKE_SNOWFLAKE_*`` secrets are present (injected by the
 dwh-smoke workflow). Otherwise it skips — safe no-op for forks / local runs.
@@ -27,6 +30,7 @@ See tests/integration/dwh/README.md for the secret list.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -360,3 +364,67 @@ def test_snowflake_connection() -> None:
         }
     )
     SnowflakeDestination().test_connection(dest)
+
+
+def test_snowflake_mirror_deletes_unobserved_keys(tmp_path: Path) -> None:
+    """``sync.mode: mirror`` end-of-sync DELETE on a real account (#340 Snowflake leg).
+
+    Pre-seeds a stale row (``id=99``) the source never emits, runs a mirror sync,
+    and asserts the source rows land while the stale row is deleted — its key was
+    not in the observed set, so ``finalize_sync``'s ``DELETE … WHERE id NOT IN
+    (observed)`` removes it. This is the mirror leg the mock suite covers but no
+    live smoke did.
+    """
+    creds = require_env(
+        ACCOUNT_ENV,
+        USER_ENV,
+        PASSWORD_ENV,
+        "DRT_SMOKE_SNOWFLAKE_DATABASE",
+        "DRT_SMOKE_SNOWFLAKE_SCHEMA",
+        "DRT_SMOKE_SNOWFLAKE_WAREHOUSE",
+    )
+    source, profile = seed_duckdb_users(tmp_path)  # ids 1..3 (Alice/Bob/Carol)
+    table = unique_table("DRT_SMOKE_MIRROR")
+
+    dest_kwargs: dict[str, Any] = {
+        "type": "snowflake",
+        "account_env": ACCOUNT_ENV,
+        "user_env": USER_ENV,
+        "password_env": PASSWORD_ENV,
+        "database": creds["DRT_SMOKE_SNOWFLAKE_DATABASE"],
+        "schema": creds["DRT_SMOKE_SNOWFLAKE_SCHEMA"],
+        "table": table,
+        "warehouse": creds["DRT_SMOKE_SNOWFLAKE_WAREHOUSE"],
+        "mode": "merge",
+        "upsert_key": ["id"],
+    }
+    dest = SnowflakeDestinationConfig(**dest_kwargs)
+    sync = SyncConfig(
+        name="snowflake_mirror_smoke",
+        model="ref('users')",
+        destination=dest,
+        sync=SyncOptions(mode="mirror", batch_size=10),
+    )
+
+    try:
+        _create_table(creds, table)
+        # Stale row the source never emits — mirror must delete it (id 99 ∉ {1,2,3}).
+        conn = _connect(creds)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"INSERT INTO {table} (id, name, email) "
+                    "VALUES (99, 'Stale', 'stale@example.com')"
+                )
+        finally:
+            conn.close()
+
+        result = run_sync(sync, source, SnowflakeDestination(), profile, tmp_path)
+        assert result.failed == 0, f"mirror sync had failures: {result.errors[:3]}"
+
+        count, names = _readback_count_and_names(creds, table)
+        # Source rows upserted; the unobserved stale row removed by the mirror DELETE.
+        assert names == {"Alice", "Bob", "Carol"}
+        assert count == 3, f"stale row not deleted — expected 3 rows, got {count}"
+    finally:
+        _drop_table(creds, table)


### PR DESCRIPTION
Part of #654 (real-warehouse smoke validation). Closes two live-coverage gaps — both features shipped, but were only mock-tested.

## Snowflake mirror

`snowflake.py`'s `_finalize_mirror` (the #340 Snowflake mirror leg — `DELETE … WHERE key NOT IN (observed)`) had **no live smoke**, only the mock suite. New `test_snowflake_mirror_deletes_unobserved_keys` pre-seeds a stale row the source never emits, runs a `sync.mode: mirror` sync, and asserts it's deleted while the source rows land. This is the exact parity gap the Databricks mirror smoke closed in #707.

## BigQuery complex types

BigQuery handles ARRAY / STRUCT natively — no `PARSE_JSON` / `from_json` wrapping like the Snowflake/Databricks legs — but nothing proved the destination passes a Python `list` + `dict` straight through. New `test_bigquery_complex_type_roundtrip` syncs a DuckDB `LIST` + `STRUCT` into a live `ARRAY<STRING>` / `STRUCT` table and reads the typed sub-fields (`tags[OFFSET(0)]`, `attrs.theme`, `attrs.level`) back, with the usual streaming-buffer poll.

BigQuery has **no mirror path** (confirmed) and **no replace mode**, so neither is applicable there — that's the whole remaining delta vs the Snowflake/Databricks coverage.

## Verification

- Test-only, no product change. Gated like the rest of the harness (skips without `DRT_SMOKE_{SNOWFLAKE,BIGQUERY}_*`).
- CI-safe: `mypy drt` + `ruff` + full unit suite green (**1838 passed**); the added tests are mypy-clean (typed config dicts); the smoke modules skip locally without the drivers.
- **Live validation**: run the `dwh-smoke` workflow on this branch (or wait for the nightly) — the two new cases exercise real Snowflake / BigQuery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)