### PR TITLE
perf(databricks): chunk scalar INSERTs into multi-row VALUES — one round trip per chunk, not per row (#734)

### DIFF
--- a/drt/destinations/databricks.py
+++ b/drt/destinations/databricks.py
@@ -90,13 +90,9 @@ def _value_clause(
     # information_schema reports column names lower-cased; source record keys may
     # differ in case — fold both sides so wrapping fires for the common pipeline.
     cats = (
-        {str(k).lower(): v for k, v in category_map.items()}
-        if category_map is not None
-        else None
+        {str(k).lower(): v for k, v in category_map.items()} if category_map is not None else None
     )
-    ddl_map = (
-        {str(k).lower(): v for k, v in ddls.items()} if ddls is not None else None
-    )
+    ddl_map = {str(k).lower(): v for k, v in ddls.items()} if ddls is not None else None
     for col in columns:
         key = str(col).lower()
         if cats is not None and cats.get(key) == "json":
@@ -123,9 +119,17 @@ def _bind_row(row: dict[str, Any], columns: list[str], json_columns: list[str]) 
     """Order a row's values to ``columns``; ``json.dumps`` the json columns so the
     ``from_json`` / ``parse_json`` bind receives a JSON string."""
     js = set(json_columns)
-    return [
-        json.dumps(row.get(c), default=str) if c in js else row.get(c) for c in columns
-    ]
+    return [json.dumps(row.get(c), default=str) if c in js else row.get(c) for c in columns]
+
+
+# databricks-sql-connector's native paramstyle allows at most 255 parameter
+# markers per statement — multi-row INSERT chunks must stay under it (#734).
+_NATIVE_PARAM_LIMIT = 255
+
+
+def _rows_per_chunk(n_cols: int) -> int:
+    """How many rows fit in one multi-row INSERT under the native marker limit."""
+    return max(1, _NATIVE_PARAM_LIMIT // max(1, n_cols))
 
 
 class DatabricksDestination:
@@ -229,13 +233,26 @@ class DatabricksDestination:
                 if sync_options.mode == "replace":
                     if sync_options.replace_strategy == "swap":
                         self._load_replace_swap(
-                            cur, records, columns, config, table_fq, sync_options,
-                            result, category_map, ddls,
+                            cur,
+                            records,
+                            columns,
+                            config,
+                            table_fq,
+                            sync_options,
+                            result,
+                            category_map,
+                            ddls,
                         )
                     else:
                         self._load_replace_truncate(
-                            cur, records, columns, table_fq, sync_options, result,
-                            category_map, ddls,
+                            cur,
+                            records,
+                            columns,
+                            table_fq,
+                            sync_options,
+                            result,
+                            category_map,
+                            ddls,
                         )
                     return result
 
@@ -245,23 +262,7 @@ class DatabricksDestination:
 
                 if effective_mode == "insert":
                     sql = f"INSERT INTO {table_fq} ({col_list}) {value_clause}"
-
-                    for i, row in enumerate(records):
-                        try:
-                            cur.execute(sql, _bind_row(row, columns, json_cols))
-                            result.success += 1
-                        except Exception as e:
-                            result.failed += 1
-                            result.row_errors.append(
-                                RowError(
-                                    batch_index=i,
-                                    record_preview=str(row)[:200],
-                                    http_status=None,
-                                    error_message=str(e),
-                                )
-                            )
-                            if sync_options.on_error == "fail":
-                                raise
+                    self._insert_rows(cur, sql, records, sync_options, result, columns, json_cols)
 
                 elif effective_mode == "merge":
                     if not config.upsert_key:
@@ -292,24 +293,19 @@ class DatabricksDestination:
                         f"AS SELECT * FROM {table_fq} WHERE 1=0"
                     )
 
-                    staging_sql = (
-                        f"INSERT INTO {staging_table} ({col_list}) {value_clause}"
+                    staging_sql = f"INSERT INTO {staging_table} ({col_list}) {value_clause}"
+                    # Staging success is accounted after the MERGE (success =
+                    # len(records) - failed), so skip per-row success counting.
+                    self._insert_rows(
+                        cur,
+                        staging_sql,
+                        records,
+                        sync_options,
+                        result,
+                        columns,
+                        json_cols,
+                        count_success=False,
                     )
-                    for i, row in enumerate(records):
-                        try:
-                            cur.execute(staging_sql, _bind_row(row, columns, json_cols))
-                        except Exception as e:
-                            result.failed += 1
-                            result.row_errors.append(
-                                RowError(
-                                    batch_index=i,
-                                    record_preview=str(row)[:200],
-                                    http_status=None,
-                                    error_message=str(e),
-                                )
-                            )
-                            if sync_options.on_error == "fail":
-                                raise
 
                     matched_clause = (
                         f"WHEN MATCHED THEN UPDATE SET {update_clause}" if update_cols else ""
@@ -399,8 +395,7 @@ class DatabricksDestination:
         if not self._swap_shadow_created and not self._swap_direct_write:
             if self._target_exists(cur, config):
                 cur.execute(
-                    f"CREATE OR REPLACE TABLE {shadow_fq} "
-                    f"AS SELECT * FROM {table_fq} WHERE 1=0"
+                    f"CREATE OR REPLACE TABLE {shadow_fq} AS SELECT * FROM {table_fq} WHERE 1=0"
                 )
                 self._swap_shadow_created = True
                 self._swap_table = table_fq
@@ -433,8 +428,10 @@ class DatabricksDestination:
         result: SyncResult,
         columns: list[str],
         json_cols: list[str],
+        *,
+        count_success: bool = True,
     ) -> None:
-        """Execute a parameterised INSERT per row, honouring ``on_error``.
+        """Execute a parameterised INSERT for ``records``, honouring ``on_error``.
 
         Values are ordered to ``columns`` and json columns (``json_cols``) are
         ``json.dumps``'d so the ``from_json`` / ``parse_json`` bind receives a
@@ -442,16 +439,96 @@ class DatabricksDestination:
         ``_bind_row``) keeps binds correct even when a source yields rows with a
         varying key order/set — so ``columns``/``json_cols`` are required, not an
         optional ``list(row.values())`` fallback (#699).
+
+        Scalar-only loads (no json columns) are batched into multi-row
+        ``VALUES (…), (…)`` statements sized to the native 255-marker limit —
+        one warehouse round trip per chunk instead of per row (#734). A failed
+        chunk lands nothing (a multi-row INSERT is atomic), so it is replayed
+        row by row to keep exact per-row ``RowError`` attribution and
+        ``on_error`` semantics. The ``SELECT``-form json inserts don't compose
+        into multi-row ``VALUES`` and stay one statement per row.
+
+        ``count_success=False`` skips ``result.success`` accounting — the MERGE
+        staging path computes success after the merge instead.
         """
+        if json_cols:
+            self._insert_rows_one_by_one(
+                cur,
+                sql,
+                records,
+                sync_options,
+                result,
+                columns,
+                json_cols,
+                base_index=0,
+                count_success=count_success,
+            )
+            return
+
+        row_marker = "(" + ", ".join(["?"] * len(columns)) + ")"
+        rows_per = _rows_per_chunk(len(columns))
+        for start in range(0, len(records), rows_per):
+            chunk = records[start : start + rows_per]
+            if len(chunk) == 1:
+                self._insert_rows_one_by_one(
+                    cur,
+                    sql,
+                    chunk,
+                    sync_options,
+                    result,
+                    columns,
+                    json_cols,
+                    base_index=start,
+                    count_success=count_success,
+                )
+                continue
+            # The single-row statement ends in ``VALUES {row_marker}`` — extend
+            # it with one marker group per additional row in the chunk.
+            chunk_sql = sql + ", " + ", ".join([row_marker] * (len(chunk) - 1))
+            params: list[Any] = []
+            for row in chunk:
+                params.extend(_bind_row(row, columns, json_cols))
+            try:
+                cur.execute(chunk_sql, params)
+                if count_success:
+                    result.success += len(chunk)
+            except Exception:
+                self._insert_rows_one_by_one(
+                    cur,
+                    sql,
+                    chunk,
+                    sync_options,
+                    result,
+                    columns,
+                    json_cols,
+                    base_index=start,
+                    count_success=count_success,
+                )
+
+    def _insert_rows_one_by_one(
+        self,
+        cur: Any,
+        sql: str,
+        records: list[dict[str, Any]],
+        sync_options: SyncOptions,
+        result: SyncResult,
+        columns: list[str],
+        json_cols: list[str],
+        *,
+        base_index: int,
+        count_success: bool,
+    ) -> None:
+        """One INSERT per row — json ``SELECT``-form loads and chunk replay (#734)."""
         for i, row in enumerate(records):
             try:
                 cur.execute(sql, _bind_row(row, columns, json_cols))
-                result.success += 1
+                if count_success:
+                    result.success += 1
             except Exception as e:
                 result.failed += 1
                 result.row_errors.append(
                     RowError(
-                        batch_index=i,
+                        batch_index=base_index + i,
                         record_preview=str(row)[:200],
                         http_status=None,
                         error_message=str(e),
@@ -462,10 +539,7 @@ class DatabricksDestination:
 
     def _target_exists(self, cur: Any, config: DatabricksDestinationConfig) -> bool:
         """Return True if the target table exists (``SHOW TABLES ... LIKE``)."""
-        cur.execute(
-            f"SHOW TABLES IN {config.catalog}.{config.schema_} "
-            f"LIKE '{config.table}'"
-        )
+        cur.execute(f"SHOW TABLES IN {config.catalog}.{config.schema_} LIKE '{config.table}'")
         return bool(cur.fetchall())
 
     def finalize_sync(
@@ -522,10 +596,11 @@ class DatabricksDestination:
         Deletes rows whose ``upsert_key`` was not observed in the source. Under
         native ``?`` binding (#707) the per-statement parameter limit rules out
         inlining every observed key into a single ``NOT IN (?, ?, ...)``, so the
-        keys are staged into a scratch Delta table (one small INSERT each) and
-        removed via anti-join: ``DELETE ... WHERE key NOT IN (SELECT key FROM
-        staging)`` binds *no* key parameters in the DELETE, so it scales past the
-        limit regardless of how many keys were observed. Reuses the MERGE path's
+        keys are staged into a scratch Delta table (chunked multi-row INSERTs
+        sized to the marker limit, #734) and removed via anti-join: ``DELETE ...
+        WHERE key NOT IN (SELECT key FROM staging)`` binds *no* key parameters
+        in the DELETE, so it scales past the limit regardless of how many keys
+        were observed. Reuses the MERGE path's
         staging approach (Delta has no session-local temp tables; the principal
         needs ``CREATE`` on the schema plus ``MODIFY`` on the target).
 
@@ -555,9 +630,14 @@ class DatabricksDestination:
                     f"CREATE OR REPLACE TABLE {keys_table} AS "
                     f"SELECT {key_cols} FROM {table_fq} WHERE 1=0"
                 )
-                insert_key_sql = f"INSERT INTO {keys_table} ({key_cols}) VALUES {row_marker}"
-                for key in keys:
-                    cur.execute(insert_key_sql, list(key))
+                insert_key_prefix = f"INSERT INTO {keys_table} ({key_cols}) VALUES "
+                rows_per = _rows_per_chunk(len(upsert_cols))
+                for start in range(0, len(keys), rows_per):
+                    chunk = keys[start : start + rows_per]
+                    cur.execute(
+                        insert_key_prefix + ", ".join([row_marker] * len(chunk)),
+                        [v for key in chunk for v in key],
+                    )
                 cur.execute(
                     f"DELETE FROM {table_fq} WHERE {where_cols} "
                     f"NOT IN (SELECT {key_cols} FROM {keys_table})"
@@ -596,8 +676,7 @@ class DatabricksDestination:
         try:
             with conn.cursor() as cur:
                 cur.execute(
-                    f"SHOW TABLES IN {config.catalog}.{config.schema_} "
-                    f"LIKE '{shadow_name}'"
+                    f"SHOW TABLES IN {config.catalog}.{config.schema_} LIKE '{shadow_name}'"
                 )
                 rows = cur.fetchall()
         finally:

--- a/tests/unit/test_databricks_destination.py
+++ b/tests/unit/test_databricks_destination.py
@@ -186,10 +186,13 @@ class TestDatabricksDestinationLoad:
         assert result.success == 2
         assert result.failed == 0
         cur = conn._cur
-        assert cur.execute.call_count == 2
+        # #734: scalar rows are batched into one multi-row VALUES INSERT.
+        assert cur.execute.call_count == 1
         first_sql = cur.execute.call_args_list[0][0][0]
         assert "INSERT INTO main.default.user_scores" in first_sql
         assert "id, score" in first_sql
+        assert first_sql.count("(?, ?)") == 2  # one marker group per row
+        assert cur.execute.call_args_list[0][0][1] == [1, 0.95, 2, 0.80]
         conn.close.assert_called_once()
 
     def test_merge_mode_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -231,7 +234,13 @@ class TestDatabricksDestinationLoad:
     def test_insert_row_error_on_error_skip(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _set_creds(monkeypatch)
         conn = _fake_conn()
-        conn._cur.execute.side_effect = [Exception("type mismatch"), None]
+        # #734: the multi-row chunk fails first, then the row-by-row replay
+        # pins the failure on row 0 while row 1 goes through.
+        conn._cur.execute.side_effect = [
+            Exception("type mismatch"),  # chunked INSERT
+            Exception("type mismatch"),  # replay: row 0
+            None,  # replay: row 1
+        ]
         modules = _mocked_databricks_modules(conn)
 
         records = [
@@ -243,6 +252,7 @@ class TestDatabricksDestinationLoad:
         assert result.failed == 1
         assert result.success == 1
         assert len(result.row_errors) == 1
+        assert result.row_errors[0].batch_index == 0
         assert "type mismatch" in result.row_errors[0].error_message
 
     def test_insert_row_error_on_error_fail_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -284,15 +294,16 @@ class TestDatabricksDestinationLoad:
         conn = _fake_conn()
         cur = conn._cur
 
-        # Fail the FIRST staging INSERT (row 0), let everything else through.
-        # The CREATE OR REPLACE TABLE statement runs first, then per-row
-        # INSERT INTO __drt_staging_..., then MERGE INTO, then DROP TABLE.
+        # Fail the chunked staging INSERT, then row 0 of the row-by-row
+        # replay (#734) — so the failure is attributed to row 0 and row 1
+        # still lands. CREATE OR REPLACE TABLE runs first, then the staging
+        # INSERTs, then MERGE INTO, then DROP TABLE.
         insert_call_count = {"n": 0}
 
         def execute_side_effect(sql: str, *args: Any) -> None:
             if "INSERT INTO main.default.__drt_staging_user_scores" in sql:
                 insert_call_count["n"] += 1
-                if insert_call_count["n"] == 1:
+                if insert_call_count["n"] <= 2:  # chunk, then replay row 0
                     raise Exception("staging type mismatch")
             return None
 
@@ -305,13 +316,12 @@ class TestDatabricksDestinationLoad:
         ]
         config = _config(mode="merge", upsert_key=["id"])
         with patch.dict("sys.modules", modules):
-            result = DatabricksDestination().load(
-                records, config, _options(on_error="skip")
-            )
+            result = DatabricksDestination().load(records, config, _options(on_error="skip"))
 
         assert result.failed == 1
         assert result.success == 1
         assert len(result.row_errors) == 1
+        assert result.row_errors[0].batch_index == 0
         assert "staging type mismatch" in result.row_errors[0].error_message
         # The MERGE statement still ran (against the staging table that
         # ended up with one row).
@@ -433,12 +443,13 @@ class TestDatabricksMirrorMode:
         sqls = [(c.args[0] if c.args else "") for c in calls]
         keys_tbl = "main.default.__drt_mirror_keys_user_scores"
         assert any(s.startswith(f"CREATE OR REPLACE TABLE {keys_tbl}") for s in sqls)
-        key_inserts = [
-            c.args[1]
-            for c in calls
-            if c.args and c.args[0].startswith(f"INSERT INTO {keys_tbl}")
+        key_insert_calls = [
+            c for c in calls if c.args and c.args[0].startswith(f"INSERT INTO {keys_tbl}")
         ]
-        assert sorted(key_inserts) == [[1], [2]]  # each observed key staged
+        # #734: both observed keys staged in one chunked multi-row INSERT.
+        assert len(key_insert_calls) == 1
+        assert key_insert_calls[0].args[0].count("(?)") == 2
+        assert sorted(key_insert_calls[0].args[1]) == [1, 2]
         delete_call = next(c for c in calls if c.args and c.args[0].startswith("DELETE FROM"))
         assert delete_call.args[0] == (
             f"DELETE FROM main.default.user_scores WHERE id NOT IN (SELECT id FROM {keys_tbl})"
@@ -473,9 +484,7 @@ class TestDatabricksMirrorMode:
         )
         assert len(delete_call.args) == 1  # anti-join binds no key params
         key_inserts = [
-            c.args[1]
-            for c in calls
-            if c.args and c.args[0].startswith(f"INSERT INTO {keys_tbl}")
+            c.args[1] for c in calls if c.args and c.args[0].startswith(f"INSERT INTO {keys_tbl}")
         ]
         assert key_inserts == [["a", 1]]  # the composite key staged as a tuple
 
@@ -490,13 +499,14 @@ class TestDatabricksMirrorMode:
         conn = _fake_conn()
         cur = conn._cur
 
-        # First record's staging INSERT fails; second succeeds.
+        # #734: the chunked staging INSERT fails, then row 0 of the replay
+        # fails — so record id=1 is the failure and id=2 survives.
         insert_call_count = {"n": 0}
 
         def execute_side_effect(sql: str, *args: Any) -> None:
             if "INSERT INTO main.default.__drt_staging_user_scores" in sql:
                 insert_call_count["n"] += 1
-                if insert_call_count["n"] == 1:
+                if insert_call_count["n"] <= 2:  # chunk, then replay row 0
                     raise Exception("staging type mismatch")
             return None
 
@@ -513,9 +523,10 @@ class TestDatabricksMirrorMode:
             )
             dest.finalize_sync(config, _options(mode="mirror"))
 
-        # #707: observed keys are staged (one INSERT each) into the mirror-keys
-        # table and removed via anti-join — so it's the mirror-keys INSERTs, not
-        # the DELETE params, that must reflect only id=2 (id=1 failed staging).
+        # #707: observed keys are staged (chunked multi-row INSERTs, #734) into
+        # the mirror-keys table and removed via anti-join — so it's the
+        # mirror-keys INSERTs, not the DELETE params, that must reflect only
+        # id=2 (id=1 failed staging).
         key_inserts = [
             call.args[1]
             for call in cur.execute.call_args_list
@@ -600,21 +611,18 @@ class TestDatabricksReplaceMode:
     def _swap_opts(**kw: Any) -> SyncOptions:
         return _options(mode="replace", replace_strategy="swap", **kw)
 
-    def test_replace_truncate_truncates_then_inserts(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_replace_truncate_truncates_then_inserts(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _set_creds(monkeypatch)
         conn = _fake_conn()
         modules = _mocked_databricks_modules(conn)
         records = [{"id": 1, "score": 0.95}, {"id": 2, "score": 0.80}]
         with patch.dict("sys.modules", modules):
-            result = DatabricksDestination().load(
-                records, _config(), _options(mode="replace")
-            )
+            result = DatabricksDestination().load(records, _config(), _options(mode="replace"))
         assert result.success == 2
         sqls = _sqls(conn._cur)
         assert any(s.startswith(f"TRUNCATE TABLE {_FQ}") for s in sqls)
-        assert sum(f"INSERT INTO {_FQ} (" in s for s in sqls) == 2
+        # #734: both rows land in one chunked multi-row INSERT.
+        assert sum(f"INSERT INTO {_FQ} (" in s for s in sqls) == 1
 
     def test_replace_truncate_only_once_across_batches(
         self, monkeypatch: pytest.MonkeyPatch
@@ -628,9 +636,7 @@ class TestDatabricksReplaceMode:
             dest.load([{"id": 2}], _config(), _options(mode="replace"))
         assert sum(s.startswith("TRUNCATE TABLE") for s in _sqls(conn._cur)) == 1
 
-    def test_replace_swap_creates_shadow_and_inserts(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_replace_swap_creates_shadow_and_inserts(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _set_creds(monkeypatch)
         conn = _fake_conn()
         conn._cur.fetchall.return_value = [("user_scores",)]  # target exists
@@ -642,8 +648,7 @@ class TestDatabricksReplaceMode:
         assert result.success == 1
         sqls = _sqls(conn._cur)
         assert any(
-            f"CREATE OR REPLACE TABLE {_SHADOW} AS SELECT * FROM {_FQ} WHERE 1=0" in s
-            for s in sqls
+            f"CREATE OR REPLACE TABLE {_SHADOW} AS SELECT * FROM {_FQ} WHERE 1=0" in s for s in sqls
         )
         assert any(f"INSERT INTO {_SHADOW} (" in s for s in sqls)
 
@@ -682,9 +687,7 @@ class TestDatabricksReplaceMode:
         assert any(f"INSERT INTO {_FQ} (" in s for s in sqls)
         assert fin is None
 
-    def test_replace_swap_on_error_fail_drops_shadow(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_replace_swap_on_error_fail_drops_shadow(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _set_creds(monkeypatch)
         conn = _fake_conn()
         cur = conn._cur
@@ -754,9 +757,7 @@ class TestDatabricksOrphanCleanup:
         conn._cur.execute.side_effect = Exception("permission denied")
         modules = _mocked_databricks_modules(conn)
         with patch.dict("sys.modules", modules):
-            dropped, failed = DatabricksDestination().drop_orphan_swap_tables(
-                _config(), [_SHADOW]
-            )
+            dropped, failed = DatabricksDestination().drop_orphan_swap_tables(_config(), [_SHADOW])
         assert dropped == []
         assert failed == [_SHADOW]
 
@@ -791,3 +792,124 @@ def test_scope_rejected_on_databricks(monkeypatch: pytest.MonkeyPatch) -> None:
     with patch.dict("sys.modules", _mocked_databricks_modules(conn)):
         with pytest.raises(ValueError, match="mirror.scope are not yet supported"):
             dest.load([{"id": 1, "parent_id": 10}], config, opts)
+
+
+class TestDatabricksChunkedInserts:
+    """#734 — scalar loads batch into multi-row ``VALUES`` chunks under the
+    native 255-marker limit; a failed chunk replays row-by-row to keep exact
+    ``RowError`` attribution; json ``SELECT``-form loads stay one per row."""
+
+    def test_rows_per_chunk_math(self) -> None:
+        from drt.destinations.databricks import _rows_per_chunk
+
+        assert _rows_per_chunk(1) == 255
+        assert _rows_per_chunk(2) == 127
+        assert _rows_per_chunk(255) == 1
+        assert _rows_per_chunk(300) == 1  # wider than the limit still progresses
+
+    def test_insert_chunks_at_native_param_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """200 two-column rows -> a 127-row chunk + a 73-row chunk."""
+        _set_creds(monkeypatch)
+        conn = _fake_conn()
+        modules = _mocked_databricks_modules(conn)
+        records = [{"id": i, "score": float(i)} for i in range(200)]
+        with patch.dict("sys.modules", modules):
+            result = DatabricksDestination().load(records, _config(), _options())
+
+        assert result.success == 200
+        assert result.failed == 0
+        calls = conn._cur.execute.call_args_list
+        assert len(calls) == 2
+        assert calls[0].args[0].count("(?, ?)") == 127  # 254 markers <= 255
+        assert len(calls[0].args[1]) == 254
+        assert calls[1].args[0].count("(?, ?)") == 73
+        assert len(calls[1].args[1]) == 146
+
+    def test_chunk_failure_replays_and_attributes_row(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed chunk lands nothing (atomic); the replay pins the RowError
+        on the exact record (original batch index) and the rest still load."""
+        _set_creds(monkeypatch)
+        conn = _fake_conn()
+        conn._cur.execute.side_effect = [
+            Exception("bad row"),  # chunked INSERT (3 rows)
+            None,  # replay: row 0
+            Exception("bad row"),  # replay: row 1
+            None,  # replay: row 2
+        ]
+        modules = _mocked_databricks_modules(conn)
+        records = [
+            {"id": 1, "score": 0.1},
+            {"id": 2, "score": 0.2},
+            {"id": 3, "score": 0.3},
+        ]
+        with patch.dict("sys.modules", modules):
+            result = DatabricksDestination().load(records, _config(), _options(on_error="skip"))
+
+        assert result.success == 2
+        assert result.failed == 1
+        assert [e.batch_index for e in result.row_errors] == [1]
+
+    def test_chunk_failure_on_error_fail_raises_from_replay(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_creds(monkeypatch)
+        conn = _fake_conn()
+        conn._cur.execute.side_effect = Exception("bad row")
+        modules = _mocked_databricks_modules(conn)
+        records = [{"id": 1, "score": 0.1}, {"id": 2, "score": 0.2}]
+        with patch.dict("sys.modules", modules):
+            with pytest.raises(Exception, match="bad row"):
+                DatabricksDestination().load(records, _config(), _options(on_error="fail"))
+        conn.close.assert_called_once()
+
+    def test_json_columns_stay_row_by_row(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``SELECT``-form (from_json) inserts don't compose into multi-row
+        ``VALUES`` — they stay one statement per row (#734)."""
+        _set_creds(monkeypatch)
+        monkeypatch.setattr(
+            DatabricksDestination,
+            "_resolve_schema",
+            lambda self, config: {"attrs": "json"},
+        )
+        monkeypatch.setattr(
+            DatabricksDestination,
+            "_resolve_ddls",
+            lambda self, config: {"attrs": "map<string,string>"},
+        )
+        conn = _fake_conn()
+        modules = _mocked_databricks_modules(conn)
+        records = [{"id": 1, "attrs": {"a": "1"}}, {"id": 2, "attrs": {"b": "2"}}]
+        with patch.dict("sys.modules", modules):
+            result = DatabricksDestination().load(records, _config(), _options())
+
+        assert result.success == 2
+        calls = conn._cur.execute.call_args_list
+        assert len(calls) == 2  # one SELECT-form INSERT per row
+        assert all("from_json" in c.args[0] for c in calls)
+
+    def test_mirror_key_staging_chunks_past_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """300 observed single-column keys stage in two INSERTs (255 + 45)."""
+        _set_creds(monkeypatch)
+        conn = _fake_conn()
+        modules = _mocked_databricks_modules(conn)
+        config = _config(mode="merge", upsert_key=["id"])
+        dest = DatabricksDestination()
+        dest._mirror_keys = [(i,) for i in range(300)]
+        with patch.dict("sys.modules", modules):
+            dest.finalize_sync(config, _options(mode="mirror"))
+
+        keys_tbl = "main.default.__drt_mirror_keys_user_scores"
+        key_inserts = [
+            c
+            for c in conn._cur.execute.call_args_list
+            if c.args and c.args[0].startswith(f"INSERT INTO {keys_tbl}")
+        ]
+        assert len(key_inserts) == 2
+        assert sorted(len(c.args[1]) for c in key_inserts) == [45, 255]
+        # Marker groups match the bound values chunk for chunk…
+        assert all(c.args[0].count("(?)") == len(c.args[1]) for c in key_inserts)
+        # …and every key is staged exactly once.
+        staged = [v for c in key_inserts for v in c.args[1]]
+        assert sorted(staged) == list(range(300))


### PR DESCRIPTION
Closes #734.

## Why

The #732 live smoke surfaced it: every Databricks write path issues **one `cur.execute` per row**, and on a SQL warehouse each statement is a full HTTP round trip (~1.9 s observed). The 300-key mirror probe ran **~19 minutes** (≈600 single-row statements: 300 merge-staging + 300 mirror-key INSERTs). A 10k-row production merge+mirror sync would be ~20k round trips.

## What

- **Scalar-only loads chunk into multi-row `VALUES (…), (…)`** statements sized to the native paramstyle's 255-marker limit (`_rows_per_chunk = max(1, 255 // n_cols)`) — e.g. 2-column rows go 127 per statement, mirror single-column keys 255 per statement (a **127–255× round-trip reduction** on the paths that dominated the smoke).
- **All four write paths** get it through one seam: the insert-mode and merge-staging inline loops now route through the shared `_insert_rows` (dedup — they were copies of it), which `replace` already used; the mirror key staging chunks the same way.
- **Per-row semantics preserved**: a multi-row INSERT is atomic — a failed chunk lands nothing and is **replayed row-by-row**, so `RowError.batch_index` still points at the exact record and `on_error: skip | fail` behaves byte-for-byte as before (fail still records the RowError then raises).
- **SELECT-form json loads (#317 `from_json`/`parse_json`) stay one statement per row** — they don't compose into multi-row `VALUES`. Flagged in #734 as the acceptable first-pass carve-out.

## Tests

- 6 existing tests updated for the new statement shapes (chunk + replay sequences, single chunked mirror-key INSERT).
- New `TestDatabricksChunkedInserts` (6 cases): chunk-size math; 200 rows → 127+73 chunks with marker/param counts; chunk-failure replay attributing the right `batch_index` under `on_error: skip`; `on_error: fail` raising from the replay with the connection closed; json columns staying row-by-row; 300 mirror keys staging as 255+45 with every key exactly once.
- `pytest tests/unit` green (the two `test_cli_version` install-path cases fail only in my side-worktree env — editable install points elsewhere — and pass on a normal checkout/CI), `ruff check`/`format` clean, `mypy drt` clean (141 files).

## Validation note

Unit-only so far (mock suite, like the rest of this destination). The nightly #674 smoke exercises insert / merge / mirror against the real workspace — the 20-key mirror case plus the 3-row roundtrips cover the chunked path end-to-end on the next run; no schema change to the harness needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)