### PR TITLE
fix(smoke): mirror test missed in the dual-auth switch (#737)

### DIFF
--- a/tests/integration/dwh/test_snowflake_smoke.py
+++ b/tests/integration/dwh/test_snowflake_smoke.py
@@ -390,7 +390,7 @@ def test_snowflake_mirror_deletes_unobserved_keys(tmp_path: Path) -> None:
         "type": "snowflake",
         "account_env": ACCOUNT_ENV,
         "user_env": USER_ENV,
-        "password_env": PASSWORD_ENV,
+        **_auth_config_kwargs(),
         "database": creds["DRT_SMOKE_SNOWFLAKE_DATABASE"],
         "schema": creds["DRT_SMOKE_SNOWFLAKE_SCHEMA"],
         "table": table,


### PR DESCRIPTION
The post-#745 recovery dispatch showed 4/5 Snowflake smoke tests green under key-pair auth, but `test_snowflake_mirror_deletes_unobserved_keys` (added in the mirror-smoke work) builds its `dest_kwargs` at a different indent, so the bulk `password_env` → `_auth_config_kwargs()` replacement missed it. One-line fix; fails with 'Missing Snowflake credentials' now that the password secret is retired. [skip changelog]