### PR TITLE
test(smoke): route the Snowflake mirror case through the dual-auth gate (#745 follow-up)

### DIFF
--- a/tests/integration/dwh/test_snowflake_smoke.py
+++ b/tests/integration/dwh/test_snowflake_smoke.py
@@ -390,7 +390,7 @@ def test_snowflake_mirror_deletes_unobserved_keys(tmp_path: Path) -> None:
         "type": "snowflake",
         "account_env": ACCOUNT_ENV,
         "user_env": USER_ENV,
-        "password_env": PASSWORD_ENV,
+        **_auth_config_kwargs(),
         "database": creds["DRT_SMOKE_SNOWFLAKE_DATABASE"],
         "schema": creds["DRT_SMOKE_SNOWFLAKE_SCHEMA"],
         "table": table,


### PR DESCRIPTION
Follow-up to #745. The [main smoke run](https://github.com/drt-hub/drt/actions/runs/29072921195) after the key-pair switch shows `1 failed, 4 passed`: the four legs #745 updated authenticate via `_auth_config_kwargs()` (key-pair preferred), but `test_snowflake_mirror_deletes_unobserved_keys` — added in #733, racing that change — still hard-codes `password_env`. With the password secret retired it dies as `ValueError: Missing Snowflake credentials` before connecting.

One-line fix: build the mirror case's `dest_kwargs` through the same `_auth_config_kwargs()` gate.

Verification: test-only; `ruff` clean; the smoke workflow on this branch should go **5 passed** on the Snowflake leg (dispatching for confirmation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)