### PR TITLE
chore(snowflake): key-pair periphery — drt profile prompt + LLM docs (#737 follow-up)

### DIFF
--- a/docs/llm/API_REFERENCE.md
+++ b/docs/llm/API_REFERENCE.md
@@ -86,6 +86,10 @@ GH_TOKEN = "ghp_xxxx"
 
 [sources.snowflake]
 SNOWFLAKE_PASSWORD = "dev-password"
+# Key-pair auth (#737, preferred — new accounts enforce MFA on passwords):
+# point private_key_env at a var holding the PEM private key contents.
+SNOWFLAKE_PRIVATE_KEY = """-----BEGIN PRIVATE KEY-----
+..."""
 ```
 
 ---

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -59,7 +59,7 @@ my-project/
 | PostgreSQL | `drt-core[postgres]` | Connection string via env |
 | Redshift | `drt-core[redshift]` | PostgreSQL wire protocol via psycopg2. Supports `schema` (search_path). Port defaults to 5439. |
 | ClickHouse | `drt-core[clickhouse]` | HTTP interface via `clickhouse-connect`. Supports host, port, database, user, password_env. |
-| Snowflake | `drt-core[snowflake]` | Supports account, user, password_env, database, schema, warehouse, role |
+| Snowflake | `drt-core[snowflake]` | Supports account, user, private_key_env (key-pair, preferred — #737) / password_env, database, schema, warehouse, role |
 | MySQL | `drt-core[mysql]` | Uses pymysql. Supports host, port, dbname, user, password_env |
 | Databricks | `drt-core[databricks]` | SQL Warehouse via databricks-sql-connector. Supports Unity Catalog, access_token_env |
 | SQL Server | `drt-core[sqlserver]` | Microsoft SQL Server via pure-Python pymssql. Supports host, port, database, user, password_env |

--- a/drt/cli/commands/profile.py
+++ b/drt/cli/commands/profile.py
@@ -77,7 +77,15 @@ _ADD_FIELD_SPECS: dict[str, list[tuple[str, str, str | None]]] = {
         ("database", "Database", None),
         ("schema", "Schema", "PUBLIC"),
         ("warehouse", "Warehouse", None),
-        ("password_env", "Env var holding the password", "SNOWFLAKE_PASSWORD"),
+        # Key-pair auth (#737) resolves first; when its env var is unset at
+        # connect time the connector falls back to the password env var, so
+        # writing both keys is safe for either auth style.
+        (
+            "private_key_env",
+            "Env var holding the private key PEM (key-pair auth)",
+            "SNOWFLAKE_PRIVATE_KEY",
+        ),
+        ("password_env", "Env var holding the password (fallback)", "SNOWFLAKE_PASSWORD"),
     ],
 }
 
@@ -108,9 +116,7 @@ def profile_list() -> None:
 
     profiles = load_raw_profiles()
     if not profiles:
-        console.print(
-            "[dim]No profiles found. Run `drt init` or `drt profile add <name>`.[/dim]"
-        )
+        console.print("[dim]No profiles found. Run `drt init` or `drt profile add <name>`.[/dim]")
         return
 
     table = Table(show_header=True, header_style="bold", box=None, padding=(0, 2))

--- a/tests/unit/test_cli_profile.py
+++ b/tests/unit/test_cli_profile.py
@@ -118,9 +118,7 @@ def test_show_unknown_profile_errors(drt_home: Path) -> None:
 
 
 def test_remove_with_yes_flag(drt_home: Path) -> None:
-    _write_profiles(
-        drt_home, {"dev": {"type": "duckdb"}, "prod": {"type": "bigquery"}}
-    )
+    _write_profiles(drt_home, {"dev": {"type": "duckdb"}, "prod": {"type": "bigquery"}})
     result = runner.invoke(app, ["profile", "remove", "dev", "--yes"])
     assert result.exit_code == 0
     assert "Removed 'dev'" in result.output
@@ -181,9 +179,7 @@ def test_add_preserves_observability_and_existing(drt_home: Path) -> None:
 
 def test_add_duckdb(drt_home: Path) -> None:
     # Prompts: type, then database (has a default → blank accepts it).
-    result = runner.invoke(
-        app, ["profile", "add", "local"], input="duckdb\n./my.duckdb\n"
-    )
+    result = runner.invoke(app, ["profile", "add", "local"], input="duckdb\n./my.duckdb\n")
     assert result.exit_code == 0, result.output
     assert "Wrote profile 'local'" in result.output
 
@@ -245,9 +241,7 @@ def test_add_migrates_flat_layout_to_nested(drt_home: Path) -> None:
 
 def test_remove_migrates_flat_layout_to_nested(drt_home: Path) -> None:
     """`remove` on a legacy flat profiles.yml rewrites it under `profiles:`."""
-    _write_flat_profiles(
-        drt_home, {"dev": {"type": "duckdb"}, "prod": {"type": "bigquery"}}
-    )
+    _write_flat_profiles(drt_home, {"dev": {"type": "duckdb"}, "prod": {"type": "bigquery"}})
 
     result = runner.invoke(app, ["profile", "remove", "dev", "--yes"])
     assert result.exit_code == 0, result.output
@@ -270,9 +264,7 @@ def test_test_connection_ok(drt_home: Path, monkeypatch: pytest.MonkeyPatch) -> 
         def test_connection(self, profile: object) -> bool:
             return True
 
-    monkeypatch.setattr(
-        "drt.connectors.registry.get_source", lambda profile: _FakeSource()
-    )
+    monkeypatch.setattr("drt.connectors.registry.get_source", lambda profile: _FakeSource())
     result = runner.invoke(app, ["profile", "test", "dev"])
     assert result.exit_code == 0
     assert "connection OK" in result.output
@@ -285,17 +277,13 @@ def test_test_connection_failure(drt_home: Path, monkeypatch: pytest.MonkeyPatch
         def test_connection(self, profile: object) -> bool:
             raise RuntimeError("could not connect")
 
-    monkeypatch.setattr(
-        "drt.connectors.registry.get_source", lambda profile: _FakeSource()
-    )
+    monkeypatch.setattr("drt.connectors.registry.get_source", lambda profile: _FakeSource())
     result = runner.invoke(app, ["profile", "test", "dev"])
     assert result.exit_code == 1
     assert "could not connect" in result.output
 
 
-def test_test_connection_returns_false(
-    drt_home: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_test_connection_returns_false(drt_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A source whose test_connection returns False (no exception) → exit 1."""
     _write_profiles(drt_home, {"dev": {"type": "duckdb", "database": ":memory:"}})
 
@@ -303,9 +291,7 @@ def test_test_connection_returns_false(
         def test_connection(self, profile: object) -> bool:
             return False
 
-    monkeypatch.setattr(
-        "drt.connectors.registry.get_source", lambda profile: _FakeSource()
-    )
+    monkeypatch.setattr("drt.connectors.registry.get_source", lambda profile: _FakeSource())
     result = runner.invoke(app, ["profile", "test", "dev"])
     assert result.exit_code == 1
     assert "returned false" in result.output
@@ -316,3 +302,19 @@ def test_test_unknown_profile_errors(drt_home: Path) -> None:
     result = runner.invoke(app, ["profile", "test", "missing"])
     assert result.exit_code == 1
     assert "not found" in result.output
+
+
+def test_add_snowflake_prompts_keypair_and_password(drt_home: Path) -> None:
+    """#737 periphery: the snowflake add-spec offers key-pair auth first,
+    with password as the fallback prompt — both env-var names are written
+    (resolution prefers the key env var and falls back when it's unset)."""
+    # type, account, user, database, schema, warehouse, private_key_env, password_env
+    result = runner.invoke(
+        app,
+        ["profile", "add", "sf"],
+        input="snowflake\nacme-xy12345\nDRT_SERVICE\nANALYTICS\nPUBLIC\nCOMPUTE_WH\n\n\n",
+    )
+    assert result.exit_code == 0, result.output
+    entry = yaml.safe_load((drt_home / "profiles.yml").read_text())["profiles"]["sf"]
+    assert entry["private_key_env"] == "SNOWFLAKE_PRIVATE_KEY"
+    assert entry["password_env"] == "SNOWFLAKE_PASSWORD"


### PR DESCRIPTION
Periphery sweep after #745/#746 (pre-v0.7.11): three surfaces still described Snowflake auth as password-only.

- **`drt profile add` snowflake spec** now prompts for `private_key_env` (default `SNOWFLAKE_PRIVATE_KEY`) ahead of `password_env` (fallback). Both names are written; the connector resolves the key env var first and falls back to password when it's unset, so either auth style works without editing the profile.
- **`docs/llm/CONTEXT.md`** connector matrix row and **`docs/llm/API_REFERENCE.md`** secrets.toml example gain the key-pair form.

Verification: new `test_add_snowflake_prompts_keypair_and_password` + existing profile CLI suite green (21 passed); `ruff`/`mypy drt` clean; `check_drift.sh` 0 new items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)