### PR TITLE
docs(dwh): bring smoke/provisioning docs current — key-pair secrets, Free Edition costs

### DIFF
--- a/tests/integration/dwh/README.md
+++ b/tests/integration/dwh/README.md
@@ -48,13 +48,21 @@ the cloud accounts and the "verified ✓" sign-off are the maintainer's
 | --- | --- |
 | `SMOKE_SNOWFLAKE_ACCOUNT` | account identifier |
 | `SMOKE_SNOWFLAKE_USER` | |
-| `SMOKE_SNOWFLAKE_PASSWORD` | |
+| `SMOKE_SNOWFLAKE_PRIVATE_KEY` | PEM private-key contents (key-pair auth — preferred) |
+| `SMOKE_SNOWFLAKE_PASSWORD` | legacy fallback only — see the key-pair note below |
 | `SMOKE_SNOWFLAKE_DATABASE` | a throwaway DB the role can create/drop tables in |
 | `SMOKE_SNOWFLAKE_SCHEMA` | |
 | `SMOKE_SNOWFLAKE_WAREHOUSE` | |
 
 Snowflake prerequisites (#671):
 
+- A **`TYPE = SERVICE` user with an RSA key pair** (#737) — new Snowflake
+  accounts enforce MFA on password sign-ins, so programmatic password auth
+  fails there; `SERVICE` users forbid passwords entirely. The conversion +
+  key-registration steps are in
+  [`provisioning/snowflake.sql`](./provisioning/snowflake.sql). The
+  `SMOKE_SNOWFLAKE_PASSWORD` path remains only for pre-existing accounts
+  where password sign-in still works.
 - A **throwaway database + schema** the role can `CREATE`/`DROP` tables in, plus a
   running **virtual warehouse** for compute. Scope the grants to the throwaway
   schema, not the whole account — the swap leg builds and drops a

--- a/tests/integration/dwh/provisioning/README.md
+++ b/tests/integration/dwh/provisioning/README.md
@@ -31,10 +31,15 @@ adding accounts one at a time never breaks CI.
 
 ## Snowflake — `snowflake.sql`
 
-Card-free 30-day trial. Run [`snowflake.sql`](./snowflake.sql) as
-`ACCOUNTADMIN` in a Worksheet, filling in a strong password. Account identifier
-is under the account menu (bottom-left) → *Copy account identifier*.
-Secrets: `SMOKE_SNOWFLAKE_{ACCOUNT,USER,PASSWORD,DATABASE,SCHEMA,WAREHOUSE}`.
+Card-free 30-day trial (converts to pay-as-you-go on a card afterwards — the
+resource monitor in the script is the hard cap either way). Run
+[`snowflake.sql`](./snowflake.sql) as `ACCOUNTADMIN` in a Worksheet (**Run All**,
+not "run current statement" — partial runs leave the user with no roles),
+filling in a strong password. Account identifier is under the account menu
+(bottom-left) → *Copy account identifier*. Then convert the user to
+`TYPE = SERVICE` + RSA key pair (the script's last section) — new accounts
+enforce MFA on password sign-ins, so key-pair is the programmatic path (#737).
+Secrets: `SMOKE_SNOWFLAKE_{ACCOUNT,USER,PRIVATE_KEY,DATABASE,SCHEMA,WAREHOUSE}`.
 
 ## BigQuery — `bigquery.sh`
 
@@ -46,28 +51,34 @@ fails with `billingNotEnabled` / "not allowed in the free tier":
 ```bash
 gcloud billing accounts list
 gcloud billing projects link <PROJECT> --billing-account=<ACCOUNT_ID>
-``` Effectively $0/month for KB-scale smoke tables.
+```
+
+Effectively $0/month for KB-scale smoke tables.
 Run [`bigquery.sh`](./bigquery.sh) with `gcloud` authenticated; load the
 generated keyfile's contents into `SMOKE_BIGQUERY_KEYFILE_JSON`, then delete
 the local keyfile. Secrets: `SMOKE_BIGQUERY_{PROJECT,DATASET,KEYFILE_JSON}`.
 
 ## Databricks — `databricks.sql` + manual steps
 
-The most expensive leg; consider deferring. [`databricks.sql`](./databricks.sql)
-covers the catalog/schema/grants. The rest is UI/API:
+**Free Edition** — structurally $0, no card, and includes a serverless SQL
+warehouse, PATs, and Unity Catalog (everything the smoke needs).
+[`databricks.sql`](./databricks.sql) covers the catalog/schema/grants. The
+rest is UI/API:
 
-- **Workspace**: a Databricks workspace on a cloud (trial or paid). Host =
+- **Workspace**: sign up for Databricks Free Edition. Host =
   `dbc-xxxx.cloud.databricks.com`.
-- **SQL warehouse**: create a (2X-)Small warehouse with the **minimum auto-stop**
-  (cost guardrail). Its *Connection details* give the HTTP path.
+- **SQL warehouse**: the built-in serverless starter warehouse works as-is.
+  Its *Connection details* give the HTTP path.
 - **PAT**: Settings → Developer → Access tokens → generate (`dapi…`).
+  ⚠️ PATs default to a **90-day lifetime** — calendar the rotation.
 
 Secrets: `SMOKE_DATABRICKS_{HOST,HTTP_PATH,TOKEN,CATALOG,SCHEMA}`.
 
 ## Cost & ownership
 
-Steady-state (correctly configured): Snowflake ~$1–3, BigQuery ~$0, Databricks
-~$8–15 per month. The dominant risk across all three is **leaving compute
-running** — always set auto-suspend/auto-stop + a budget/credit hard cap first.
-Account ownership, card strategy, and the CI-vs-contributor split are maintainer
-decisions kept in private strategy notes.
+Steady-state (correctly configured): Snowflake ~$1–3 (resource monitor hard-caps
+at 5 credits/month), BigQuery ~$0 (budget-alerted), Databricks $0 (Free Edition —
+no billing account exists to bill). On Snowflake/BigQuery the dominant risk is
+**leaving compute running** — always set auto-suspend + a budget/credit hard cap
+first. Account ownership, card strategy, and the CI-vs-contributor split are
+maintainer decisions kept in private strategy notes.

--- a/tests/integration/dwh/provisioning/databricks.sql
+++ b/tests/integration/dwh/provisioning/databricks.sql
@@ -5,10 +5,10 @@
 -- steps — see the "Databricks — manual (UI/API) steps" section in
 -- provisioning/README.md.
 --
--- Cost note: Databricks is the most expensive of the three (Serverless SQL
--- bills DBUs + cloud compute; a warehouse left running is a cost bomb like
--- Snowflake's). Keep AUTO-STOP at its minimum and consider deferring the
--- Databricks leg — see the maintainer strategy notes.
+-- Cost note: the smoke account runs on Databricks Free Edition — structurally
+-- $0 (no billing account exists). On a paid workspace, Serverless SQL bills
+-- DBUs + cloud compute and a warehouse left running is a cost bomb like
+-- Snowflake's — keep AUTO-STOP at its minimum there.
 --
 -- The smoke tests create/populate/drop their own throwaway tables (insert /
 -- replace INSERT OVERWRITE / STRUCT-ARRAY-MAP + VARIANT complex types), so no


### PR DESCRIPTION
Doc-currency sweep after the #737 key-pair migration and the Free Edition decision — three spots still described the pre-migration world:

- **`tests/integration/dwh/README.md`** — the Snowflake secret table still listed `SMOKE_SNOWFLAKE_PASSWORD` as the auth secret; the live secret is `SMOKE_SNOWFLAKE_PRIVATE_KEY` (key-pair auth, #737). PASSWORD is now documented as legacy-fallback only, with the `TYPE = SERVICE` + RSA key-pair prerequisite spelled out (new accounts enforce MFA on password sign-ins).
- **`provisioning/README.md`** — Snowflake section now covers the Snowsight **Run All** gotcha (partial runs leave the user role-less) and the SERVICE conversion; the Databricks section was written when the plan was a paid workspace ("most expensive leg; consider deferring", ~$8–15/mo) — the smoke account actually runs on **Free Edition** (structurally $0, serverless warehouse + PAT + Unity Catalog included, 90-day PAT rotation noted). Cost table updated to the real steady state. Also unjammed a code fence in the BigQuery billing-link snippet.
- **`provisioning/databricks.sql`** — header cost-note comment updated to match.

Docs/comments only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)