### PR TITLE
docs(skills): refresh release skills with the v0.7.10/v0.7.11-proven flow

### DIFF
--- a/.claude/commands/drt-patch-release.md
+++ b/.claude/commands/drt-patch-release.md
@@ -59,7 +59,9 @@ gh run watch <run-id> --exit-status
 curl -s https://pypi.org/pypi/drt-core/json | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['info']['version'])"
 # should print X.Y.Z
 
-gh release create vX.Y.Z --latest --title "vX.Y.Z" --notes "..."
+# The publish workflow's SBOM step already auto-created a bare release
+# for the tag — `gh release create` fails 422. EDIT it instead:
+gh release edit vX.Y.Z --latest --title "vX.Y.Z" --notes "..."
 gh release list --limit 3   # confirm vX.Y.Z shows Latest
 ```
 - Release notes: copy the `[X.Y.Z]` CHANGELOG section, add install snippet and `Full Changelog` compare link

--- a/.claude/commands/drt-release-check.md
+++ b/.claude/commands/drt-release-check.md
@@ -1,81 +1,86 @@
-Check that all documentation and version references are consistent before a drt release.
+Check that all documentation and version references are consistent before a drt release, then cut it. Battle-tested against v0.7.9–v0.7.11.
 
-## Steps
+## Phase 0 — Completeness sweep (do this FIRST)
 
-1. **Version consistency** — verify the same version string in:
+1. **Enumerate every merged PR since the last tag** — the `[Unreleased]` block is regularly incomplete:
+   ```bash
+   git log v{PREV}..origin/main --oneline
+   ```
+   Build a matrix: every `(#NNN)` PR number must appear in the new CHANGELOG section. Entries that cite the *issue* number should gain the PR link too. Conventional exemptions: changelog-meta PRs (edits to CHANGELOG itself) and ROADMAP-only planning PRs.
+
+2. **Periphery sweep for new config fields / auth options** — the drift audit does not cover everything. Hand-kept surfaces that silently lag:
+   - `drt/cli/commands/profile.py` `_ADD_FIELD_SPECS` (interactive `drt profile add` prompts)
+   - `docs/llm/CONTEXT.md` connector support matrix
+   - `docs/llm/API_REFERENCE.md` profile / sync examples
+   - (`drt/cli/_connector_detail.py` is pydantic-model-derived — auto-correct, no action needed)
+
+   Quick check: `grep -rn "<new_field>" skills/ .claude/ docs/llm/ drt/cli/`
+   (v0.7.11 example: #745 added `private_key_env` to configs/docs/connectors/vscode-schema but missed exactly these three — caught by this grep, fixed in #748.)
+
+3. **Automated gates**: `python scripts/check_changelog_monotonic.py` · `bash scripts/check_drift.sh` · `make test && make lint`
+
+## Phase 1 — Version + docs consistency
+
+4. **Version bump — 4 manifests + 1 label must agree**:
    - `pyproject.toml` (project.version)
    - `.claude-plugin/marketplace.json`
    - `.claude-plugin/plugin.json`
    - `skills/drt/.claude-plugin/plugin.json`
+   - `docs/llm/CONTEXT.md` "Current version" line
 
-2. **CHANGELOG** — verify there is an entry for the current version with today's date
+5. **CHANGELOG** — cut `[Unreleased]` as `## [X.Y.Z] - YYYY-MM-DD`; leave an empty `## [Unreleased]` header above it.
 
-3. **README.md** — verify:
-   - Roadmap table: current version has ✅
-   - Connectors table: new destinations/sources are listed with correct status
-   - Quickstart section is up to date
+6. **ROADMAP.md** — add the shipped section: heading `## vX.Y.Z — <theme> ✅ Shipped YYYY-MM-DD`, a "Released as **vX.Y.Z** … See [CHANGELOG.md](CHANGELOG.md#xyz---yyyy-mm-dd) and the GitHub Release" line, one narrative paragraph, then `---`. ⚠️ Insert position: the recent-release cluster is **newest-first** — insert immediately BEFORE the previous release's section, not at the chronological end of the file.
 
-4. **CLAUDE.md** — verify:
-   - Current Status reflects the latest version
-   - Sources/Destinations lists are complete
-   - Roadmap Reference is current
+7. **CLAUDE.md** — new Current Status bullet at the top (dense, issue-linked, ends "No breaking changes — drop-in upgrade from vPREV").
 
-5. **SECURITY.md** — verify current version is in Supported Versions
+8. **README.md** — roadmap table ✅ for the new version; connectors table lists new destinations/sources; Quickstart current.
 
-6. **docs/llm/CONTEXT.md** — verify:
-   - Current version is correct
-   - Destinations table includes all destinations
-   - Sources table includes all sources
+9. **SECURITY.md** — current version in Supported Versions.
 
-7. **docs/llm/API_REFERENCE.md** — verify:
-   - All source types have profile config examples
-   - All destination types have config examples
-   - All destination types have complete sync examples
+10. **Skills** — `.claude/commands/drt-create-sync.md` + `skills/drt/skills/drt-create-sync/SKILL.md` list all destinations; `drt-init` (both copies) lists all `init_wizard.py` source types.
 
-8. **Skills** — verify:
-   - `.claude/commands/drt-create-sync.md` lists all destinations
-   - `skills/drt/skills/drt-create-sync/SKILL.md` lists all destinations
-   - `.claude/commands/drt-init.md` lists all source types supported by init_wizard.py
-   - `skills/drt/skills/drt-init/SKILL.md` lists all source types supported by init_wizard.py
+11. **Connector wiring** — dispatch is the centralized registry (`drt/connectors/registry.py`); the CLI list + install extras derive from `drt/config/connectors.py` (`connector_inventory()` SSoT), guarded by registry-parity tests and `check_drift.sh` Check 8. (`_get_source` / `_get_destination` in `drt/cli/main.py` are legacy re-export wrappers only — don't audit them by hand.)
 
-9. **dagster-drt dependency** — verify:
-    - `integrations/dagster-drt/pyproject.toml` has `drt-core>=` matching or exceeding the version being released
-    - If drt-core has breaking changes, dagster-drt tests still pass
+12. **MCP Server** — `drt_list_connectors` derives from the SSoT (auto). Check that new CLI capabilities have MCP parity or a tracked follow-up issue (the #718 pattern).
 
-10. **CLI wiring** — verify all connectors are wired:
-    - `_get_source()` in `drt/cli/main.py` handles every source type in `ProfileConfig`
-    - `_get_destination()` in `drt/cli/main.py` handles every destination type in `DestinationConfig`
-    - `init_wizard.py` source type choices include all implemented sources
-    - Return type annotations match the implementations
+13. **dagster-drt dependency** — `integrations/dagster-drt/pyproject.toml` `drt-core>=` floor still valid; if drt-core broke API, dagster-drt tests must still pass.
 
-11. **MCP Server** — verify:
-    - `drt/mcp/server.py` tool descriptions are accurate
-    - All MCP tools listed in README.md match actual implementations
+14. **GitHub Topics** — new connectors as topics (`gh api repos/drt-hub/drt/topics`, 20 max — swap out an old one if full).
 
-12. **GitHub Topics** — verify:
-    - New connectors (sources/destinations) are added as topics: `gh api repos/drt-hub/drt/topics`
-    - Max 20 topics — remove outdated ones if needed before adding
-    - Add with: `gh repo edit drt-hub/drt --add-topic <name>`
+15. **GitHub Milestone** — issues closed or moved; no open PRs blocking.
 
-13. **CI** — verify all tests pass: `make test && make lint`
+## Phase 2 — Ship (release-PR + tag flow, proven on v0.7.10 / v0.7.11)
 
-14. **GitHub Milestone** — verify:
-    - All milestone issues are closed or moved
-    - No open PRs blocking the release
+16. **Release PR**: branch `chore/release-vX.Y.Z` carrying all of the above (work in a `git worktree` if another session shares the checkout). Wait for CI green.
 
-15. **GitHub Release — drt-core** — create (or verify exists):
-    - `gh release create v{VERSION}` with title `v{VERSION}`
-    - Release notes: "What's New" sections matching CHANGELOG entry
-    - Mark as `--latest` for the primary release
-    - Include `Full Changelog` compare link
+17. **Pre-merge re-sweep** — ⚠️ parallel sessions / contributors may merge while the PR is open:
+    ```bash
+    git fetch && git log origin/chore/release-vX.Y.Z..origin/main --oneline
+    ```
+    If main moved: rebase, sweep the new PRs into the CHANGELOG section (repeat until quiet), then merge — admin, with explicit owner approval.
 
-16. **GitHub Release — dagster-drt** (if version bumped) — create (or verify exists):
-    - `gh release create dagster-drt-v{VERSION} --latest=false` with title `dagster-drt v{VERSION}`
-    - Release notes: features, requirements, PyPI link
-    - **MUST pass `--latest=false`** (gh defaults to auto-detect by date, which will steal Latest from drt-core)
+18. **Tag** (irreversible — PyPI refuses the same version twice; a failed publish means bump to X.Y.Z+1, never retag):
+    ```bash
+    git tag -a vX.Y.Z <merge-sha> -m "drt-core vX.Y.Z — <one-line theme + key issue refs>"
+    git push origin vX.Y.Z
+    ```
+    `publish-drt-core.yml` re-verifies (lint/type/tests against the tag) then publishes via Trusted Publishing.
 
-17. **Verify Latest flag** — after all releases are created:
-    - `gh release list --limit 5` — confirm drt-core `v{VERSION}` shows `Latest`, dagster-drt does not
-    - If wrong: `gh release edit dagster-drt-v{VERSION} --latest=false && gh release edit v{VERSION} --latest`
+19. **Verify publish**: watch the run to completion, then
+    ```bash
+    curl -s https://pypi.org/pypi/drt-core/json | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['version'])"
+    ```
+    must print X.Y.Z.
 
-Report any inconsistencies found and suggest fixes.
+20. **GitHub Release — EDIT, don't create**: the publish workflow's SBOM step (`softprops/action-gh-release`) already auto-created a bare release with the SBOM attached, so `gh release create` fails `422 tag_name already exists`. Instead:
+    ```bash
+    gh release edit vX.Y.Z --title "vX.Y.Z" --notes-file notes.md
+    ```
+    Notes format (match v0.7.10 / v0.7.11): bold one-line headline → `## Highlights` with emoji `###` sections (YAML snippets for config-visible features) → `### 🛠️ Also in this release` → "No breaking changes — drop-in upgrade from vPREV." → `## Install / upgrade` → `**Full Changelog**` compare link. Confirm the SBOM asset survived the edit.
+
+21. **dagster-drt release** (only if its version bumped): `gh release create dagster-drt-vX.Y.Z --latest=false` — MUST pass `--latest=false` or date-based auto-detect steals Latest from drt-core.
+
+22. **Post-release**: `gh release list --limit 5` (drt-core shows Latest) · notify-drt-web fires automatically on release-published (expect a sync PR in drt-web) · sync local main, delete release branches / worktrees.
+
+Report any inconsistencies found and fix them before tagging.


### PR DESCRIPTION
The release skills lagged how releases actually ship now. Updates from the v0.7.11 run:

**`drt-release-check.md`** (restructured into Phase 0 sweep → Phase 1 consistency → Phase 2 ship):
- **PR-completeness matrix**: every `(#NNN)` in `git log v<prev>..main` must appear in the new CHANGELOG section (changelog-meta / ROADMAP-only PRs exempt by convention); issue-cited entries gain PR links.
- **Periphery sweep** for new config fields: `drt profile add` `_ADD_FIELD_SPECS`, `docs/llm/CONTEXT.md` matrix, `API_REFERENCE.md` examples are hand-kept (the exact #745→#748 gap); `_connector_detail.py` is pydantic-derived.
- **ROADMAP insert position** (newest-first cluster) + CLAUDE.md status-bullet step.
- **Pre-merge re-sweep** for parallel-session merges (three were needed on #740).
- **GitHub Release: edit, don't create** — the SBOM step auto-creates the release; `gh release create` fails 422.
- Connector-wiring check now points at `drt/connectors/registry.py` + `connector_inventory()` SSoT instead of the retired `cli/main.py` dispatchers.
- Automated gates named explicitly (`check_changelog_monotonic.py`, `check_drift.sh`).

**`drt-patch-release.md`**: same create→edit correction in step 7.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)