### PR TITLE
design(docs): empty/error state system — zero-sync hero + last_error on the sync KPI card

### DIFF
--- a/drt/docs/_html_assets.py
+++ b/drt/docs/_html_assets.py
@@ -134,6 +134,11 @@ td.right, th.right { text-align:right; }
 .status-partial { color:var(--warning); font-weight:500; }
 .status-failed { color:var(--error); font-weight:500; }
 .empty { border:1px dashed var(--line); padding:32px; text-align:center; border-radius:var(--radius); color:var(--muted); }
+.empty--hero { padding:56px 32px; }
+.empty__title { font-size:17px; font-weight:600; color:var(--fg); margin-bottom:6px; }
+.empty--hero pre.code { display:inline-block; text-align:left; margin:14px auto 0; }
+.kpi__error { font-family:var(--mono); font-size:11.5px; color:var(--error); margin-top:4px;
+  overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 
 /* Sync detail — KPI cards, tabs (progressive: stacked without JS), ego lineage */
 .kpi { border:1px solid var(--line); border-radius:var(--radius); padding:12px 16px; }

--- a/drt/docs/html.py
+++ b/drt/docs/html.py
@@ -231,6 +231,15 @@ _INDEX = """\
 <div class="eyebrow">Overview</div>
 <h1>{{ project_name }}</h1>
 <p class="lede">drt {{ drt_version }} &middot; profile <code>{{ profile }}</code> &middot; manifest schema v{{ schema_version }}</p>
+{% if not nav.syncs %}
+<div class="empty empty--hero">
+  <div class="empty__title">No syncs yet</div>
+  <p>This project has no sync definitions. Create one and regenerate:</p>
+  <pre class="code">drt init          # scaffold a sync YAML
+drt run           # execute it
+drt docs generate # rebuild this site</pre>
+</div>
+{% else %}
 <div class="cards">
   <div class="card"><div class="num">{{ nav.syncs|length }}</div><div class="lbl">Syncs</div></div>
   <div class="card"><div class="num">{{ nav.sources|length }}</div><div class="lbl">Sources</div></div>
@@ -279,6 +288,7 @@ _INDEX = """\
 {% else %}
 <div class="empty">No run history yet &mdash; run <code>drt run</code> to populate state.</div>
 {% endif %}
+{% endif %}
 {% endblock %}
 """
 
@@ -292,8 +302,10 @@ Dashed edges are destination lookups.</p>
 {% if dag_svg %}
 <div class="dag">{{ dag_svg|safe }}</div>
 {% else %}
-<div class="empty">No syncs found &mdash; add <code>.yml</code> files to <code>syncs/</code>
-and re-run <code>drt docs generate</code>.</div>
+<div class="empty empty--hero">
+  <div class="empty__title">No syncs found</div>
+  <p>The lineage graph appears once the project has at least one sync.</p>
+</div>
 {% endif %}
 {% endblock %}
 """
@@ -311,6 +323,7 @@ _SYNC = """\
     {% if state %}
     <div>{{ state.last_sync_at }} &middot; <span class="status-{{ state.last_status }}">{{ state.last_status }}</span></div>
     <div class="font-mono">{{ state.rows_synced }} rows</div>
+    {% if state.last_error %}<div class="kpi__error" title="{{ state.last_error }}">{{ state.last_error|truncate(80) }}</div>{% endif %}
     {% else %}<div class="empty" style="padding:8px">No runs yet</div>{% endif %}
   </div>
   <div class="kpi">
@@ -503,9 +516,7 @@ def render_html(manifest: Manifest, output_dir: Path) -> list[Path]:
     if output_dir.exists():
         if output_dir.is_file():
             raise ValueError(f"--output must be a directory, but {output_dir} is a file.")
-        looks_like_docs = (output_dir / "index.html").exists() and (
-            output_dir / "assets"
-        ).is_dir()
+        looks_like_docs = (output_dir / "index.html").exists() and (output_dir / "assets").is_dir()
         is_empty = not any(output_dir.iterdir())
         if not (looks_like_docs or is_empty):
             raise ValueError(


### PR DESCRIPTION
Next design follow-up off the #702 tracker: a small empty/error-state pass.

- **Zero-sync projects get a real empty state** on Overview and DAG — title + the three CLI steps to get going (`drt init` → `drt run` → `drt docs generate`) instead of a wall of zeros. The DAG page keeps the tested `No syncs found` copy.
- **Failed/partial syncs explain themselves at a glance**: the Last-run KPI card on the sync page now shows `last_error` (truncated to one line, full text in the `title` attribute and the State tab).
- Two tiny additions beside the existing `.empty` (`.empty--hero`, `.kpi__error`); tokens untouched.

| | |
|---|---|
| Empty overview | the `/empty` preview in a local render — `render_html(empty_manifest, …)` |
| Error surfacing | `sync/accounts-to-pg.html` in the demo fixture (failed + `psycopg2.OperationalError…`) |

Docs suite green (50 passed / 2 skipped).

@Muawiya-contact same deal as before — no rush, a glance whenever suits. This one deliberately doesn't touch `layout.py` or anything your #701 emission work sits on. ☕

Related: #702 (tracker), #704 (previous batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
