### PR TITLE
feat(examples): docs-demo — showcase fixture for drt docs generate (10 syncs, lookup lineage, mixed run states)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ docs/plans/
 # DWH smoke provisioning — never commit generated keyfiles
 drt-smoke-bq-key.json
 tests/integration/dwh/provisioning/*.json
+
+# the docs-demo example ships a hand-authored state fixture
+!examples/docs-demo/.drt/
+!examples/docs-demo/.drt/state.json

--- a/examples/docs-demo/.drt/state.json
+++ b/examples/docs-demo/.drt/state.json
@@ -1,0 +1,82 @@
+{
+  "users_to_pg": {
+    "sync_name": "users_to_pg",
+    "last_run_at": "2026-07-09T23:55:12Z",
+    "records_synced": 1248,
+    "status": "success",
+    "error": null,
+    "last_cursor_value": "2026-07-09T23:50:00Z"
+  },
+  "orders_to_pg": {
+    "sync_name": "orders_to_pg",
+    "last_run_at": "2026-07-09T23:00:48Z",
+    "records_synced": 502,
+    "status": "partial",
+    "error": "3 rows skipped: null customer_id",
+    "last_cursor_value": null
+  },
+  "products_to_pg": {
+    "sync_name": "products_to_pg",
+    "last_run_at": "2026-07-09T20:30:00Z",
+    "records_synced": 312,
+    "status": "success",
+    "error": null,
+    "last_cursor_value": null
+  },
+  "sessions_to_pg": {
+    "sync_name": "sessions_to_pg",
+    "last_run_at": "2026-07-09T22:10:30Z",
+    "records_synced": 940,
+    "status": "success",
+    "error": null,
+    "last_cursor_value": "2026-07-09T22:00:00Z"
+  },
+  "accounts_to_pg": {
+    "sync_name": "accounts_to_pg",
+    "last_run_at": "2026-07-09T21:05:00Z",
+    "records_synced": 0,
+    "status": "failed",
+    "error": "psycopg2.OperationalError: connection timed out after 30s",
+    "last_cursor_value": null
+  },
+  "inventory_to_pg": {
+    "sync_name": "inventory_to_pg",
+    "last_run_at": "2026-07-09T19:15:00Z",
+    "records_synced": 77,
+    "status": "success",
+    "error": null,
+    "last_cursor_value": "2026-07-09T19:00:00Z"
+  },
+  "alerts_to_slack": {
+    "sync_name": "alerts_to_slack",
+    "last_run_at": "2026-07-09T22:55:33Z",
+    "records_synced": 0,
+    "status": "failed",
+    "error": "slack_sdk.errors.SlackApiError: channel_not_found",
+    "last_cursor_value": null
+  },
+  "errors_to_slack": {
+    "sync_name": "errors_to_slack",
+    "last_run_at": "2026-07-09T18:00:00Z",
+    "records_synced": 14,
+    "status": "partial",
+    "error": "rate limited, 2 retries",
+    "last_cursor_value": null
+  },
+  "users_to_hubspot": {
+    "sync_name": "users_to_hubspot",
+    "last_run_at": "2026-07-09T22:00:11Z",
+    "records_synced": 1248,
+    "status": "success",
+    "error": null,
+    "last_cursor_value": "2026-07-09T21:45:00Z"
+  },
+  "leads_to_hubspot": {
+    "sync_name": "leads_to_hubspot",
+    "last_run_at": "2026-07-09T16:00:00Z",
+    "records_synced": 430,
+    "status": "success",
+    "error": null,
+    "last_cursor_value": "2026-07-09T15:30:00Z"
+  }
+}

--- a/examples/docs-demo/README.md
+++ b/examples/docs-demo/README.md
@@ -1,0 +1,24 @@
+# docs-demo — showcase fixture for `drt docs generate`
+
+A fictional but **fully valid** drt project used to demonstrate the generated
+docs site (sync catalog + lineage). Nothing here connects anywhere: hosts and
+credentials are env-var references that are never resolved, and
+`.drt/state.json` is hand-authored so the catalog shows a realistic mix of
+`success` / `partial` / `failed` runs.
+
+```bash
+cd examples/docs-demo
+drt docs generate --format html   # writes target/docs/
+open target/docs/index.html      # works on file:// — no server needed
+```
+
+What it exercises on purpose:
+
+- 10 syncs across postgres / slack / hubspot destinations
+- lookup lineage, including **two lookups into one sync** (`orders_to_pg`)
+- `field_mappings`, `mask`, modes `full` / `incremental` / `upsert`
+- run state with errors (`partial` + `failed`), tags, model SQL
+
+This fixture backs the public demo of the docs site (see drt-web) and the
+`test_docs_demo_example` guard, so keep it valid: `drt validate` should pass
+here after any edit.

--- a/examples/docs-demo/drt_project.yml
+++ b/examples/docs-demo/drt_project.yml
@@ -1,0 +1,7 @@
+name: acme-analytics
+version: "0.1"
+profile: bq_prod
+source:
+  type: bigquery
+  project: acme-demo
+  dataset: analytics

--- a/examples/docs-demo/syncs/accounts_to_pg.yml
+++ b/examples/docs-demo/syncs/accounts_to_pg.yml
@@ -1,0 +1,12 @@
+name: accounts_to_pg
+description: "Full refresh of the account dimension."
+tags: [core]
+model: ref('accounts')
+destination:
+  type: postgres
+  host_env: DEMO_PG_HOST
+  dbname: acme_app
+  table: public.accounts
+  upsert_key: [account_id]
+sync:
+  mode: full

--- a/examples/docs-demo/syncs/alerts_to_slack.yml
+++ b/examples/docs-demo/syncs/alerts_to_slack.yml
@@ -1,0 +1,12 @@
+name: alerts_to_slack
+description: "Post anomaly alerts to #alerts."
+tags: [ops]
+model: ref('anomaly_alerts')
+destination:
+  type: slack
+  webhook_url_env: SLACK_WEBHOOK_URL
+  message_template: ":rotating_light: {{ row.title }} — {{ row.detail }}"
+sync:
+  mode: full
+  batch_size: 1
+  on_error: skip

--- a/examples/docs-demo/syncs/errors_to_slack.yml
+++ b/examples/docs-demo/syncs/errors_to_slack.yml
@@ -1,0 +1,11 @@
+name: errors_to_slack
+description: "Stream pipeline errors to the on-call channel."
+tags: [ops]
+model: ref('pipeline_errors')
+destination:
+  type: slack
+  webhook_url_env: SLACK_WEBHOOK_URL
+  message_template: ":x: {{ row.pipeline }} failed: {{ row.message }}"
+sync:
+  mode: full
+  batch_size: 1

--- a/examples/docs-demo/syncs/inventory_to_pg.yml
+++ b/examples/docs-demo/syncs/inventory_to_pg.yml
@@ -1,0 +1,13 @@
+name: inventory_to_pg
+description: "Warehouse inventory deltas."
+tags: [ops]
+model: ref('inventory_deltas')
+destination:
+  type: postgres
+  host_env: DEMO_PG_HOST
+  dbname: acme_app
+  table: public.inventory
+  upsert_key: [sku]
+sync:
+  mode: incremental
+  cursor_field: changed_at

--- a/examples/docs-demo/syncs/leads_to_hubspot.yml
+++ b/examples/docs-demo/syncs/leads_to_hubspot.yml
@@ -1,0 +1,10 @@
+name: leads_to_hubspot
+description: "Sync qualified leads for the GTM team."
+tags: [gtm]
+model: ref('qualified_leads')
+destination:
+  type: hubspot
+  object_type: contacts
+sync:
+  mode: incremental
+  cursor_field: scored_at

--- a/examples/docs-demo/syncs/orders_to_pg.yml
+++ b/examples/docs-demo/syncs/orders_to_pg.yml
@@ -1,0 +1,37 @@
+name: orders_to_pg
+description: "Sync orders, enriched via user + product lookups."
+tags: [core]
+model: |
+  SELECT
+    o.order_id,
+    o.customer_id,
+    o.product_id,
+    o.amount,
+    CASE
+      WHEN o.amount >= 1000 THEN 'enterprise'
+      WHEN o.amount >= 100  THEN 'pro'
+      ELSE 'starter'
+    END AS tier
+  FROM {{ ref('orders') }} o
+  WHERE o.updated_at > {{ watermark }}
+destination:
+  type: postgres
+  host_env: DEMO_PG_HOST
+  dbname: acme_app
+  table: public.orders
+  upsert_key: [order_id]
+  lookups:
+    user:
+      table: public.users
+      match: { customer_id: id }
+      select: email
+    product:
+      table: public.products
+      match: { product_id: id }
+      select: sku
+sync:
+  mode: upsert
+  field_mappings:
+    order_id: id
+    amount: amount_usd
+  on_error: skip

--- a/examples/docs-demo/syncs/products_to_pg.yml
+++ b/examples/docs-demo/syncs/products_to_pg.yml
@@ -1,0 +1,11 @@
+name: products_to_pg
+description: "Product catalog snapshot."
+model: ref('products')
+destination:
+  type: postgres
+  host_env: DEMO_PG_HOST
+  dbname: acme_app
+  table: public.products
+  upsert_key: [id]
+sync:
+  mode: full

--- a/examples/docs-demo/syncs/sessions_to_pg.yml
+++ b/examples/docs-demo/syncs/sessions_to_pg.yml
@@ -1,0 +1,18 @@
+name: sessions_to_pg
+description: "Session rollups keyed by user."
+tags: [analytics]
+model: ref('session_rollups')
+destination:
+  type: postgres
+  host_env: DEMO_PG_HOST
+  dbname: acme_app
+  table: public.sessions
+  upsert_key: [session_id]
+  lookups:
+    user:
+      table: public.users
+      match: { user_id: id }
+      check_only: true
+sync:
+  mode: incremental
+  cursor_field: started_at

--- a/examples/docs-demo/syncs/users_to_hubspot.yml
+++ b/examples/docs-demo/syncs/users_to_hubspot.yml
@@ -1,0 +1,12 @@
+name: users_to_hubspot
+description: "Upsert users as HubSpot contacts."
+tags: [gtm, pii]
+model: ref('crm_contacts')
+destination:
+  type: hubspot
+  object_type: contacts
+sync:
+  mode: incremental
+  cursor_field: updated_at
+  mask:
+    email: hash

--- a/examples/docs-demo/syncs/users_to_pg.yml
+++ b/examples/docs-demo/syncs/users_to_pg.yml
@@ -1,0 +1,17 @@
+name: users_to_pg
+description: "Mirror warehouse users into the app database."
+tags: [core, pii]
+model: |
+  SELECT id, name, email, created_at
+  FROM {{ ref('users') }}
+destination:
+  type: postgres
+  host_env: DEMO_PG_HOST
+  dbname: acme_app
+  table: public.users
+  upsert_key: [id]
+sync:
+  mode: incremental
+  cursor_field: created_at
+  mask:
+    email: hash

--- a/tests/unit/test_docs_demo_example.py
+++ b/tests/unit/test_docs_demo_example.py
@@ -1,0 +1,27 @@
+"""Guard for examples/docs-demo — the showcase fixture must stay renderable."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from drt.docs.builder import build_manifest
+from drt.docs.html import render_html
+
+EXAMPLE = Path(__file__).resolve().parents[2] / "examples" / "docs-demo"
+
+
+def test_docs_demo_example_builds_and_renders(tmp_path: Path) -> None:
+    manifest = build_manifest(EXAMPLE, include_state=True)
+
+    assert len(manifest.syncs) == 10, "a sync stopped validating — check load_syncs_safe errors"
+    assert [s.type for s in manifest.sources] == ["bigquery"]
+    lookups = {(e.from_, e.to) for e in manifest.edges if e.kind == "lookup"}
+    assert ("users_to_pg", "orders_to_pg") in lookups
+    assert ("products_to_pg", "orders_to_pg") in lookups  # the two-into-one case
+    assert sum(1 for s in manifest.syncs if s.state is not None) == 10
+    statuses = {s.state.last_status for s in manifest.syncs if s.state}
+    assert {"success", "partial", "failed"} <= statuses
+
+    written = render_html(manifest, tmp_path / "docs")
+    assert (tmp_path / "docs" / "index.html").exists()
+    assert len(written) >= 20


### PR DESCRIPTION
Foundation for the docs-site public demo (plan: showcase the generated site via drt-web, announce after #701's DAG lands).

`examples/docs-demo/` is a fictional but **fully valid** project tuned so `drt docs generate` has something worth showing:

- 10 syncs over postgres / slack / hubspot — modes `full`/`incremental`/`upsert`, `field_mappings`, `mask`
- lookup lineage including the **two-lookups-into-one-sync** case (`orders_to_pg` ← users + products)
- hand-authored `.drt/state.json` (gitignore negation added) → a realistic `success`/`partial`/`failed` mix in Recent Runs; hosts are unresolved env references, nothing connects anywhere
- `test_docs_demo_example` guards it: 10 syncs must validate, lineage edges must exist, site must render — the fixture can't silently rot

Once merged, the drt-web sync workflow can `drt docs generate` here and publish the output under its `static/` (tracked on the drt-web side).

Related: #702 (tracker, showcase line), #510.

@Muawiya-contact FYI more than review — this fixture doubles as a real-shape input for your #701 layout A/B (it's the same shape I offered there, now committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
