### PR TITLE
feat(engine): sync.watermark.lag — overlap window for late-arriving rows (closes #759)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`sync.watermark.lag` — overlap window for late-arriving rows** ([#759](https://github.com/drt-hub/drt/issues/759)): incremental syncs can widen the *read* window behind the stored watermark so rows that arrive late (upstream backfills, clock skew, rebuilt marts) are re-synced instead of stranded — `WHERE cursor > (watermark - lag)`. Timestamp cursors take a duration string (`lag: "1 hour"`, same grammar as `freshness.max_age`); numeric cursors take a positive int. Applies **only to storage-sourced watermarks** — `--cursor-value` overrides stay exact and `default_value` first runs already mark a user-chosen start — and the *persisted* watermark is never lagged (`new_cursor_value` seeds from the unlagged value), so the window can never regress on an empty run. The lag-adjusted cursor is what `SyncResult.cursor_value_used` reports, a new `watermark_lag` field lands in `--output json` entries, the post-run summary prints an overlap note, and the observer emits a `storage_lag` watermark-resolved event. Duration parsing moves to a shared `drt/config/duration.py` (mirrors the `freshness.max_age` grammar). Prior art: dlt's incremental `lag`/attribution window. Overlap rows are re-sent every run, so destinations must tolerate duplicates (e.g. `upsert_key`). Docs: `docs/llm/API_REFERENCE.md` + `CONTEXT.md`.
+
 ## [0.7.11] - 2026-07-10
 
 ### Added

--- a/docs/llm/API_REFERENCE.md
+++ b/docs/llm/API_REFERENCE.md
@@ -135,6 +135,7 @@ sync:                       # optional: all fields have defaults
     project: my-project     # BigQuery only
     dataset: my_dataset     # BigQuery only
     default_value: "2026-01-01 00:00:00"  # optional: fallback cursor for first run (v0.6.2)
+    lag: "1 hour"           # optional (#759): overlap window — re-read this far behind the stored watermark to catch late-arriving rows. Duration string for timestamp cursors ("1 hour", same grammar as freshness.max_age) or positive int for numeric cursors. Storage-sourced watermarks only (never --cursor-value / default_value); the persisted watermark is never lagged. Overlap rows are RE-SENT each run — destination must tolerate duplicates (upsert_key)
   batch_size: 100           # default: 100 — rows per destination call
   on_error: fail            # "fail" (default) | "skip"
   field_mappings:           # optional (#415): declarative column rename {source_column: destination_field}

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -218,6 +218,7 @@ Slash command versions also available in `.claude/commands/` for manual installa
 - Cursor comparison uses numeric ordering when possible (handles integer/float cursors correctly)
 - **Template variable**: Use `{{ cursor_value }}` (or `{{ watermark }}`) in model SQL for flexible WHERE placement. When present, auto-injection is skipped.
 - **Remote watermark storage**: For stateless environments (e.g., Cloud Run Jobs), set `sync.watermark.storage` to `gcs` or `bigquery` to persist cursor values externally instead of `.drt/state.json`.
+- **Overlap window** (#759): `sync.watermark.lag` re-reads a window behind the stored watermark (`"1 hour"` for timestamp cursors — same grammar as `freshness.max_age` — or a positive int for numeric cursors) so late-arriving rows are re-synced. Applies only to storage-sourced watermarks (never `--cursor-value` or `default_value`), and the persisted watermark itself is never lagged. Overlap rows are re-sent every run, so the destination must tolerate duplicates (e.g. `upsert_key`).
 
 **Upsert mode**: Semantic alias for `mode: full` when `upsert_key` is set. Makes YAML intent explicit.
 - Set `sync.mode: upsert` — behaves identically to `mode: full`

--- a/drt/cli/commands/run.py
+++ b/drt/cli/commands/run.py
@@ -230,6 +230,8 @@ def _run_one(
             entry["watermark_source"] = result.watermark_source
         if result.cursor_value_used is not None:
             entry["cursor_value_used"] = result.cursor_value_used
+        if result.watermark_lag is not None:
+            entry["watermark_lag"] = result.watermark_lag
         if ctx.log_json:
             logging.info(
                 "sync_complete",
@@ -286,6 +288,13 @@ def _print_watermark_summary(results: list[dict[str, object]]) -> None:
         console.print(
             f"\n[cyan]Note: {len(override_syncs)} sync(s) used --cursor-value "
             f"override: {names}[/cyan]"
+        )
+    lag_syncs = [e for e in results if e.get("watermark_lag")]
+    if lag_syncs:
+        names = ", ".join(f"{e['name']} ({e['watermark_lag']})" for e in lag_syncs)
+        console.print(
+            f"\n[cyan]Note: {len(lag_syncs)} sync(s) widened the read window via "
+            f"watermark.lag (overlap rows re-sent): {names}[/cyan]"
         )
 
 

--- a/drt/config/duration.py
+++ b/drt/config/duration.py
@@ -1,0 +1,52 @@
+"""Duration-string parsing for sync-level config knobs.
+
+Grammar: ``"<positive int> <unit>"`` where unit is day / hour / minute /
+second / week (singular or plural) — the same shape as
+``tests[].freshness.max_age`` so users learn one format.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+_UNIT_TO_KWARG: dict[str, str] = {
+    "day": "days",
+    "days": "days",
+    "hour": "hours",
+    "hours": "hours",
+    "minute": "minutes",
+    "minutes": "minutes",
+    "second": "seconds",
+    "seconds": "seconds",
+    "week": "weeks",
+    "weeks": "weeks",
+}
+
+
+def parse_duration(text: str, *, field_name: str = "duration") -> timedelta:
+    """Parse a duration string like ``"1 hour"`` or ``"7 days"``.
+
+    Raises ``ValueError`` with a config-facing message (prefixed with
+    ``field_name``) on any malformed input.
+    """
+    parts = text.strip().split()
+    if len(parts) != 2:
+        raise ValueError(
+            f"Invalid {field_name} format: {text!r}. Use format like '7 days' or '1 hour'."
+        )
+    value_str, unit = parts
+    try:
+        value = int(value_str)
+    except ValueError:
+        raise ValueError(
+            f"Invalid {field_name} value: {value_str!r}. Must be an integer."
+        ) from None
+    if value <= 0:
+        raise ValueError(f"Invalid {field_name} value: {value_str!r}. Must be a positive integer.")
+    kwarg = _UNIT_TO_KWARG.get(unit.lower())
+    if kwarg is None:
+        raise ValueError(
+            f"Invalid {field_name} unit: {unit!r}. "
+            "Use day(s), hour(s), minute(s), second(s), or week(s)."
+        )
+    return timedelta(**{kwarg: value})

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -6,6 +6,8 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
 
+from drt.config.duration import parse_duration
+
 # ---------------------------------------------------------------------------
 # Auth (shared across destination types)
 # ---------------------------------------------------------------------------
@@ -1095,6 +1097,31 @@ class WatermarkConfig(BaseModel):
     dataset: str | None = None
     # Fallback value used when no watermark exists yet (first run)
     default_value: str | None = None
+    # Overlap window (#759): widen the incremental *read* window by this much
+    # behind the stored watermark so late-arriving rows are re-synced.
+    # Timestamp cursors take a duration string ("1 hour" — grammar shared with
+    # freshness.max_age); numeric cursors take a positive int (cursor units).
+    # Applies only to storage-sourced watermarks — never to --cursor-value
+    # overrides or default_value first runs — and the persisted watermark is
+    # never lagged, so the window cannot regress. Rows inside the lag window
+    # are re-sent every run: the destination must tolerate duplicates
+    # (e.g. via upsert_key).
+    lag: str | int | None = None
+
+    @model_validator(mode="after")
+    def _check_lag(self) -> WatermarkConfig:
+        if isinstance(self.lag, bool):
+            raise ValueError("watermark.lag must be a duration string or a positive integer.")
+        if self.lag is None:
+            return self
+        if isinstance(self.lag, int):
+            if self.lag <= 0:
+                raise ValueError(
+                    "watermark.lag must be a positive integer (units of the numeric cursor)."
+                )
+        else:
+            parse_duration(self.lag, field_name="watermark.lag")
+        return self
 
     @model_validator(mode="after")
     def _check_backend_fields(self) -> WatermarkConfig:
@@ -1229,6 +1256,16 @@ class SyncOptions(BaseModel):
     def _check_incremental_cursor(self) -> SyncOptions:
         if self.mode == "incremental" and not self.cursor_field:
             raise ValueError("cursor_field is required when mode is 'incremental'.")
+        return self
+
+    @model_validator(mode="after")
+    def _check_watermark_lag_mode(self) -> SyncOptions:
+        if (
+            self.watermark is not None
+            and self.watermark.lag is not None
+            and self.mode != "incremental"
+        ):
+            raise ValueError("watermark.lag requires mode='incremental'.")
         return self
 
     @model_validator(mode="after")

--- a/drt/destinations/base.py
+++ b/drt/destinations/base.py
@@ -31,6 +31,9 @@ class SyncResult:
     # Watermark observability (#390 / #391)
     watermark_source: str | None = None  # "cli_override" | "storage" | "default_value"
     cursor_value_used: str | None = None
+    # Overlap window (#759) — the watermark.lag that widened this run's read
+    # window (e.g. "1 hour"), or None when no lag was applied.
+    watermark_lag: str | None = None
     # Graceful shutdown (#279) — True if the sync stopped early due to a
     # cooperative cancellation signal (SIGTERM/SIGINT) between batches.
     interrupted: bool = False

--- a/drt/engine/sync.py
+++ b/drt/engine/sync.py
@@ -7,6 +7,7 @@ CLI owns all console output; engine only returns SyncResult.
 
 from __future__ import annotations
 
+import re
 import threading
 import time
 from collections.abc import Iterator
@@ -15,6 +16,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from drt.config.credentials import ProfileConfig
+from drt.config.duration import parse_duration
 from drt.config.models import LookupConfig, SyncConfig
 from drt.destinations.base import Destination, StagedDestination, SyncResult
 from drt.destinations.lookup import (
@@ -60,6 +62,43 @@ def _stringify_cursor_value(val: Any) -> str:
     if isinstance(val, datetime) and val.tzinfo is not None:
         val = val.astimezone(timezone.utc).replace(tzinfo=None)
     return str(val)
+
+
+_INT_CURSOR_PATTERN = re.compile(r"-?\d+")
+
+
+def _apply_watermark_lag(value: str, lag: str | int) -> str:
+    """Return ``value`` shifted back by ``lag`` for the extraction predicate (#759).
+
+    Integer cursors take an integer ``lag`` (units of the cursor); timestamp
+    cursors take a duration string like ``"1 hour"`` (grammar shared with
+    ``freshness.max_age``). The lagged timestamp is re-stringified with the
+    same normalization as persisted watermarks (#475) so the rendered
+    predicate stays format-compatible with stored/default values.
+    """
+    text = value.strip()
+    if _INT_CURSOR_PATTERN.fullmatch(text):
+        if not isinstance(lag, int):
+            raise ValueError(
+                f"watermark.lag {lag!r} cannot apply to numeric cursor {value!r}: "
+                "numeric cursors take an integer lag (e.g. lag: 1000)."
+            )
+        return str(int(text) - lag)
+    if isinstance(lag, int):
+        raise ValueError(
+            f"watermark.lag {lag!r} cannot apply to timestamp cursor {value!r}: "
+            "timestamp cursors take a duration string (e.g. lag: '1 hour')."
+        )
+    iso = text[:-1] + "+00:00" if text.endswith(("Z", "z")) else text
+    try:
+        parsed = datetime.fromisoformat(iso)
+    except ValueError as e:
+        raise ValueError(
+            "watermark.lag requires a numeric or ISO-format timestamp cursor; "
+            f"could not parse stored watermark {value!r}."
+        ) from e
+    lagged = parsed - parse_duration(lag, field_name="watermark.lag")
+    return _stringify_cursor_value(lagged)
 
 
 def batch(iterable: Iterator[Any], size: int) -> Iterator[list[Any]]:
@@ -348,7 +387,29 @@ def _run_sync_body(
             watermark_source = "default_value"
             observer.on_watermark_resolved(sync.name, "default_value", last_cursor_value)
 
-    query = resolve_model_ref(sync.model, project_dir, profile, cursor_field, last_cursor_value)
+    # Overlap window (#759): widen the *read* window by watermark.lag so
+    # late-arriving rows are re-synced. Storage-sourced watermarks only —
+    # CLI overrides are exact by contract and default_value already marks a
+    # user-chosen start. Only the extraction predicate sees the lagged value;
+    # new_cursor_value below seeds from the unlagged watermark, so the
+    # persisted watermark can never regress (e.g. on an empty run).
+    effective_cursor_value = last_cursor_value
+    watermark_lag_applied: str | None = None
+    wm_cfg = sync.sync.watermark
+    if (
+        last_cursor_value is not None
+        and watermark_source == "storage"
+        and wm_cfg is not None
+        and wm_cfg.lag is not None
+    ):
+        effective_cursor_value = _apply_watermark_lag(last_cursor_value, wm_cfg.lag)
+        if effective_cursor_value != last_cursor_value:
+            watermark_lag_applied = str(wm_cfg.lag)
+            observer.on_watermark_resolved(sync.name, "storage_lag", effective_cursor_value)
+
+    query = resolve_model_ref(
+        sync.model, project_dir, profile, cursor_field, effective_cursor_value
+    )
 
     # Source extraction wrapped via generator helper so exceptions raised
     # during iteration (not just the initial call) carry stage="source" (#544).
@@ -537,7 +598,10 @@ def _run_sync_body(
 
     total_result.duration_seconds = round(time.perf_counter() - t0, 3)
     total_result.watermark_source = watermark_source
-    total_result.cursor_value_used = last_cursor_value
+    # The value the extraction predicate actually used — lag-adjusted when
+    # watermark.lag applied (#759). The persisted watermark is new_cursor_value.
+    total_result.cursor_value_used = effective_cursor_value
+    total_result.watermark_lag = watermark_lag_applied
 
     # State + watermark persistence is the observer's responsibility (#548).
     # The CLI composes ``LoggingObserver`` + ``StatePersistingObserver`` so

--- a/integrations/vscode-drt/schemas/sync.schema.json
+++ b/integrations/vscode-drt/schemas/sync.schema.json
@@ -4188,6 +4188,21 @@
           ],
           "default": null,
           "title": "Default Value"
+        },
+        "lag": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Lag"
         }
       },
       "title": "WatermarkConfig",

--- a/tests/unit/test_cli_diff.py
+++ b/tests/unit/test_cli_diff.py
@@ -70,6 +70,7 @@ def test_diff_with_dry_run_runs(
         errors: list[str] = []
         watermark_source: str | None = None
         cursor_value_used: str | None = None
+        watermark_lag: str | None = None
         duration_seconds = 0.01
         interrupted = False
         diff: Any = diff_mod.DiffResult(
@@ -127,6 +128,7 @@ def test_diff_json_mode_embeds_diff(
         errors: list[str] = []
         watermark_source: str | None = None
         cursor_value_used: str | None = None
+        watermark_lag: str | None = None
         duration_seconds = 0.01
         interrupted = False
         diff: Any = sample_diff

--- a/tests/unit/test_cli_graceful_shutdown.py
+++ b/tests/unit/test_cli_graceful_shutdown.py
@@ -59,6 +59,7 @@ class _FakeResult:
     errors: list[str] = []
     watermark_source: str | None = None
     cursor_value_used: str | None = None
+    watermark_lag: str | None = None
     duration_seconds: float | None = 0.01
     interrupted = False
 

--- a/tests/unit/test_cli_run_parallel.py
+++ b/tests/unit/test_cli_run_parallel.py
@@ -104,6 +104,7 @@ class _FakeResult:
         self.row_errors: list[Any] = []
         self.watermark_source: str | None = None
         self.cursor_value_used: str | None = None
+        self.watermark_lag: str | None = None
 
 
 @pytest.fixture

--- a/tests/unit/test_dry_run_summary.py
+++ b/tests/unit/test_dry_run_summary.py
@@ -59,6 +59,7 @@ def test_run_dry_run_summary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
             self.rows_extracted = self.success
             self.watermark_source = None
             self.cursor_value_used = None
+            self.watermark_lag = None
 
     def mock_run_sync(*args, **kwargs):
         return FakeResult()

--- a/tests/unit/test_print_watermark_summary.py
+++ b/tests/unit/test_print_watermark_summary.py
@@ -70,3 +70,18 @@ def test_print_watermark_summary_ignores_unknown_sources(capsys) -> None:  # typ
             ]
         )
     assert cap.get() == ""
+
+
+def test_print_watermark_summary_lag_branch(capsys) -> None:  # type: ignore[no-untyped-def]
+    """``watermark_lag`` entries trigger the overlap-window cyan note (#759)."""
+    with console.capture() as cap:
+        _print_watermark_summary(
+            [
+                {"name": "post_users", "watermark_source": "storage", "watermark_lag": "1 hour"},
+                {"name": "post_orders", "watermark_source": "storage"},
+            ]
+        )
+    out = cap.get()
+    assert "1 sync(s) widened the read window via" in out
+    assert "post_users (1 hour)" in out
+    assert "post_orders" not in out  # storage-source without lag stays silent

--- a/tests/unit/test_watermark_lag.py
+++ b/tests/unit/test_watermark_lag.py
@@ -1,0 +1,292 @@
+"""Tests for ``watermark.lag`` — overlap window for late-arriving rows (#759).
+
+Three layers:
+- ``parse_duration`` grammar (shared config duration parser)
+- ``_apply_watermark_lag`` value arithmetic (numeric + timestamp cursors,
+  #475-compatible re-stringification)
+- ``run_sync`` integration — lag widens only the extraction predicate for
+  storage-sourced watermarks, never the persisted watermark, and never
+  applies to ``--cursor-value`` overrides or ``default_value`` first runs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from drt.config.credentials import BigQueryProfile, ProfileConfig
+from drt.config.duration import parse_duration
+from drt.config.models import DestinationConfig, SyncConfig, SyncOptions, WatermarkConfig
+from drt.destinations.base import SyncResult
+from drt.engine.observer import StatePersistingObserver
+from drt.engine.sync import _apply_watermark_lag, run_sync
+
+# ---------------------------------------------------------------------------
+# parse_duration
+# ---------------------------------------------------------------------------
+
+
+def test_parse_duration_all_units() -> None:
+    assert parse_duration("1 hour") == timedelta(hours=1)
+    assert parse_duration("7 days") == timedelta(days=7)
+    assert parse_duration("30 minutes") == timedelta(minutes=30)
+    assert parse_duration("45 seconds") == timedelta(seconds=45)
+    assert parse_duration("2 weeks") == timedelta(weeks=2)
+    assert parse_duration("1 day") == timedelta(days=1)
+
+
+def test_parse_duration_rejects_single_token() -> None:
+    with pytest.raises(ValueError, match="Invalid watermark.lag format"):
+        parse_duration("1hour", field_name="watermark.lag")
+
+
+def test_parse_duration_rejects_non_integer_value() -> None:
+    with pytest.raises(ValueError, match="Must be an integer"):
+        parse_duration("1.5 hours")
+
+
+def test_parse_duration_rejects_non_positive_value() -> None:
+    with pytest.raises(ValueError, match="Must be a positive integer"):
+        parse_duration("0 hours")
+
+
+def test_parse_duration_rejects_unknown_unit() -> None:
+    with pytest.raises(ValueError, match="Invalid duration unit"):
+        parse_duration("1 fortnight")
+
+
+# ---------------------------------------------------------------------------
+# _apply_watermark_lag
+# ---------------------------------------------------------------------------
+
+
+def test_lag_naive_timestamp() -> None:
+    assert _apply_watermark_lag("2026-07-10 12:00:00", "1 hour") == "2026-07-10 11:00:00"
+
+
+def test_lag_t_separator_normalizes_to_space() -> None:
+    # Output uses the persisted-watermark convention (str(datetime) → space sep).
+    assert _apply_watermark_lag("2026-07-10T12:00:00", "1 hour") == "2026-07-10 11:00:00"
+
+
+def test_lag_z_suffix_normalizes_to_naive_utc() -> None:
+    # tz-aware inputs collapse to naive UTC, matching #475 stringification.
+    assert _apply_watermark_lag("2026-07-10T12:00:00Z", "2 hours") == "2026-07-10 10:00:00"
+
+
+def test_lag_utc_offset_normalizes_to_naive_utc() -> None:
+    assert _apply_watermark_lag("2026-07-10 12:00:00+09:00", "1 hour") == "2026-07-10 02:00:00"
+
+
+def test_lag_date_only_cursor() -> None:
+    assert _apply_watermark_lag("2026-07-10", "1 day") == "2026-07-09 00:00:00"
+
+
+def test_lag_numeric_cursor_with_int_lag() -> None:
+    assert _apply_watermark_lag("1000", 100) == "900"
+
+
+def test_lag_numeric_cursor_rejects_duration_lag() -> None:
+    with pytest.raises(ValueError, match="numeric cursors take an integer lag"):
+        _apply_watermark_lag("1000", "1 hour")
+
+
+def test_lag_timestamp_cursor_rejects_int_lag() -> None:
+    with pytest.raises(ValueError, match="duration string"):
+        _apply_watermark_lag("2026-07-10 12:00:00", 100)
+
+
+def test_lag_unparseable_cursor_raises() -> None:
+    with pytest.raises(ValueError, match="could not parse stored watermark"):
+        _apply_watermark_lag("not-a-date", "1 hour")
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+def test_watermark_config_accepts_duration_lag() -> None:
+    assert WatermarkConfig(lag="1 hour").lag == "1 hour"
+
+
+def test_watermark_config_accepts_int_lag() -> None:
+    assert WatermarkConfig(lag=3600).lag == 3600
+
+
+def test_watermark_config_rejects_malformed_duration() -> None:
+    with pytest.raises(ValueError, match="watermark.lag"):
+        WatermarkConfig(lag="1 fortnight")
+
+
+def test_watermark_config_rejects_non_positive_int() -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        WatermarkConfig(lag=0)
+
+
+def test_sync_options_lag_requires_incremental_mode() -> None:
+    with pytest.raises(ValueError, match="requires mode='incremental'"):
+        SyncOptions.model_validate({"mode": "full", "watermark": {"lag": "1 hour"}})
+
+
+def test_sync_options_lag_valid_with_incremental_mode() -> None:
+    opts = SyncOptions.model_validate(
+        {
+            "mode": "incremental",
+            "cursor_field": "updated_at",
+            "watermark": {"lag": "1 hour"},
+        }
+    )
+    assert opts.watermark is not None
+    assert opts.watermark.lag == "1 hour"
+
+
+# ---------------------------------------------------------------------------
+# run_sync integration
+# ---------------------------------------------------------------------------
+
+
+class QueryCapturingSource:
+    def __init__(self, rows: list[dict]) -> None:
+        self._rows = rows
+        self.queries: list[str] = []
+
+    def extract(self, query: str, config: ProfileConfig) -> Iterator[dict]:
+        self.queries.append(query)
+        yield from self._rows
+
+    def test_connection(self, config: ProfileConfig) -> bool:
+        return True
+
+
+class CollectDestination:
+    def load(
+        self,
+        records: list[dict],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        result = SyncResult()
+        result.success = len(records)
+        return result
+
+
+class FakeWatermarkStorage:
+    def __init__(self, value: str | None) -> None:
+        self._value = value
+        self.saved: list[tuple[str, str]] = []
+
+    def get(self, sync_name: str) -> str | None:
+        return self._value
+
+    def save(self, sync_name: str, value: str) -> None:
+        self.saved.append((sync_name, value))
+
+
+def _make_profile() -> BigQueryProfile:
+    return BigQueryProfile(type="bigquery", project="p", dataset="d")
+
+
+def _make_incremental_sync(lag: str | int | None = None) -> SyncConfig:
+    watermark: dict[str, object] = {"default_value": "2026-07-01 00:00:00"}
+    if lag is not None:
+        watermark["lag"] = lag
+    return SyncConfig.model_validate(
+        {
+            "name": "lag_sync",
+            "model": "SELECT * FROM t",
+            "destination": {"type": "rest_api", "url": "https://example.com"},
+            "sync": {
+                "mode": "incremental",
+                "cursor_field": "updated_at",
+                "watermark": watermark,
+            },
+        }
+    )
+
+
+def test_run_sync_lag_widens_extraction_predicate(tmp_path: Path) -> None:
+    source = QueryCapturingSource([{"id": 1, "updated_at": "2026-07-10 12:34:56"}])
+    storage = FakeWatermarkStorage("2026-07-10 12:00:00")
+    sync = _make_incremental_sync(lag="1 hour")
+
+    result = run_sync(
+        sync, source, CollectDestination(), _make_profile(), tmp_path, watermark_storage=storage
+    )
+
+    assert "2026-07-10 11:00:00" in source.queries[0]
+    assert "2026-07-10 12:00:00" not in source.queries[0]
+    assert result.watermark_source == "storage"
+    assert result.cursor_value_used == "2026-07-10 11:00:00"
+    assert result.watermark_lag == "1 hour"
+
+
+def test_run_sync_lag_never_regresses_persisted_watermark(tmp_path: Path) -> None:
+    """An empty run must persist the original watermark, not the lagged one."""
+    source = QueryCapturingSource([])
+    storage = FakeWatermarkStorage("2026-07-10 12:00:00")
+    sync = _make_incremental_sync(lag="1 hour")
+    observer = StatePersistingObserver(state_manager=None, watermark_storage=storage)
+
+    run_sync(
+        sync,
+        source,
+        CollectDestination(),
+        _make_profile(),
+        tmp_path,
+        watermark_storage=storage,
+        observer=observer,
+    )
+
+    assert storage.saved == [("lag_sync", "2026-07-10 12:00:00")]
+
+
+def test_run_sync_lag_skipped_for_cli_override(tmp_path: Path) -> None:
+    source = QueryCapturingSource([])
+    storage = FakeWatermarkStorage("2026-07-10 12:00:00")
+    sync = _make_incremental_sync(lag="1 hour")
+
+    result = run_sync(
+        sync,
+        source,
+        CollectDestination(),
+        _make_profile(),
+        tmp_path,
+        watermark_storage=storage,
+        cursor_value_override="2026-07-10 06:00:00",
+    )
+
+    assert "2026-07-10 06:00:00" in source.queries[0]
+    assert result.watermark_lag is None
+    assert result.watermark_source == "cli_override"
+
+
+def test_run_sync_lag_skipped_for_default_value_first_run(tmp_path: Path) -> None:
+    source = QueryCapturingSource([])
+    storage = FakeWatermarkStorage(None)  # nothing stored yet — first run
+    sync = _make_incremental_sync(lag="1 hour")
+
+    result = run_sync(
+        sync, source, CollectDestination(), _make_profile(), tmp_path, watermark_storage=storage
+    )
+
+    assert "2026-07-01 00:00:00" in source.queries[0]
+    assert result.watermark_lag is None
+    assert result.watermark_source == "default_value"
+
+
+def test_run_sync_without_lag_unchanged(tmp_path: Path) -> None:
+    source = QueryCapturingSource([])
+    storage = FakeWatermarkStorage("2026-07-10 12:00:00")
+    sync = _make_incremental_sync(lag=None)
+
+    result = run_sync(
+        sync, source, CollectDestination(), _make_profile(), tmp_path, watermark_storage=storage
+    )
+
+    assert "2026-07-10 12:00:00" in source.queries[0]
+    assert result.watermark_lag is None
+    assert result.cursor_value_used == "2026-07-10 12:00:00"


### PR DESCRIPTION
## Summary

Implements [#759](https://github.com/drt-hub/drt/issues/759): `sync.watermark.lag` widens the incremental **read** window behind the stored watermark so late-arriving rows are re-synced — `WHERE cursor > (watermark - lag)`. Prior art: dlt's incremental `lag`/attribution window.

```yaml
sync:
  mode: incremental
  cursor_field: updated_at
  watermark:
    default_value: "2026-01-01 00:00:00"
    lag: "1 hour"        # timestamp cursors; numeric cursors take a positive int
```

## Design decisions

- **Storage-sourced watermarks only** — `--cursor-value` is exact by contract; `default_value` first runs already mark a user-chosen start.
- **The persisted watermark is never lagged** — `new_cursor_value` seeds from the unlagged value, so an empty run cannot regress the window (regression-guard test included).
- **#475-compatible re-stringification** — lagged timestamps go back through `_stringify_cursor_value` (naive-UTC convention), so predicate and stored values stay format-compatible. `Z`/offset inputs are normalized.
- **Observer, not logger** — lag application emits a `storage_lag` `on_watermark_resolved` event (LoggingObserver prints it; plain `storage` stays silent as before). Engine purity boundary untouched.
- **`drt/config/duration.py`** — new config-layer leaf parser (same grammar as `freshness.max_age`) so pydantic validators can use it without importing engine modules. `test_runner._parse_max_age` left untouched to keep this PR's blast radius small — consolidating it onto the shared parser is a trivial follow-up if wanted.
- **Fakes updated in lockstep** — 4 test fakes mirroring `SyncResult` gained the new field (their comments invite exactly this).

## Surface

- `SyncResult.watermark_lag` + `--output json` `watermark_lag` field + post-run summary note
- `cursor_value_used` now reports the value the predicate actually used (lag-adjusted)
- Validation: bad duration / non-positive int rejected at config load; `watermark.lag` without `mode: incremental` is a validation error
- VS Code bundled schemas regenerated (#662 drift gate)
- Docs: `docs/llm/API_REFERENCE.md` + `CONTEXT.md`; CHANGELOG `[Unreleased]`

**Deferred (noted from the issue scope):** a `drt validate` advisory note when lag is combined with duplicate-visible destinations — the existing deprecation/warning plumbing is per-sync-file and this fits better as a small follow-up.

## Tests

24 new tests (`tests/unit/test_watermark_lag.py` + summary-note test): duration grammar, lag arithmetic (naive/T-sep/Z/offset/date-only/numeric + type-mismatch errors), config validation, and `run_sync` integration (predicate widened, no-regress on empty run, override/default-value skip, no-lag unchanged). Full suite: **1990 passed, 12 skipped**. `ruff check` + `mypy` clean.

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)