### PR TITLE
feat(docs): static SVG DAG emission from the layout engine (#701)

### DIFF
--- a/drt/docs/__init__.py
+++ b/drt/docs/__init__.py
@@ -1,6 +1,7 @@
 """Documentation graph helpers for drt projects."""
 
 from drt.docs.builder import build_manifest
+from drt.docs.dag import render_dag_svg
 from drt.docs.html import render_html
 from drt.docs.manifest import (
     SCHEMA_VERSION,
@@ -24,6 +25,7 @@ __all__ = [
     "Sync",
     "SyncStateSnapshot",
     "build_manifest",
+    "render_dag_svg",
     "render_html",
     "render_mermaid",
 ]

--- a/drt/docs/_html_assets.py
+++ b/drt/docs/_html_assets.py
@@ -27,6 +27,7 @@ STYLE_CSS = """\
   --success:#15803d; --warning:#b45309; --error:#b91c1c;
   /* lineage */
   --edge:#9aa0a8; --edge-lookup:var(--brand-500); --zone-drt-line:var(--brand-200);
+  --zone-drt-bg:var(--brand-50);
   /* shape & type */
   --radius:8px;
   --mono:ui-monospace,SFMono-Regular,Menlo,Monaco,monospace;
@@ -38,6 +39,7 @@ STYLE_CSS = """\
     --line:var(--ink-700); --surface:var(--ink-800); --chip:var(--ink-700);
     --success:#4ade80; --warning:#fbbf24; --error:#f87171;
     --edge:#6a707a; --zone-drt-line:rgba(139,92,246,0.35);
+    --zone-drt-bg:rgba(124,58,237,0.10);
   }
 }
 * { box-sizing:border-box; }
@@ -151,6 +153,12 @@ td.right, th.right { text-align:right; }
   padding:10px; overflow-x:auto; }
 .ego svg text { font-family:var(--sans); }
 .ego svg .mono { font-family:var(--mono); }
+
+/* Project DAG — static SVG from the layout engine (#701) */
+.dag { border:1px solid var(--line); border-radius:var(--radius); background:var(--surface);
+  padding:10px; overflow-x:auto; }
+.dag svg text { font-family:var(--sans); }
+.dag svg .mono { font-family:var(--mono); }
 .group a .count { float:right; }
 
 @media (max-width:860px) {

--- a/drt/docs/_svg.py
+++ b/drt/docs/_svg.py
@@ -1,0 +1,175 @@
+"""Shared SVG/emission helpers for the docs site.
+
+Extracted from ``drt.docs.html`` (#704) so the full-DAG emission (#701) and the
+per-sync ego-graphs render nodes, badges, and arrow markers through one code
+path. Everything here is pure string emission — deterministic for a given
+input, all manifest-derived text HTML-escaped at the point of use.
+"""
+
+from __future__ import annotations
+
+import re
+from html import escape
+
+_SLUG_RE = re.compile(r"[^A-Za-z0-9]+")
+
+
+def _slug(value: str) -> str:
+    return _SLUG_RE.sub("-", value).strip("-").lower() or "x"
+
+
+def _slug_map(names: list[str], kind: str) -> dict[str, str]:
+    """Map each name to a stable slug, failing fast on a collision.
+
+    ``_slug`` collapses runs of non-alphanumerics, so punctuation-only-distinct
+    names (``a_b`` vs ``a__b``) can slugify to the same file — which would
+    silently overwrite a page and break cross-links. Detect that and raise.
+    """
+    out: dict[str, str] = {}
+    seen: dict[str, str] = {}
+    for name in names:
+        slug = _slug(name)
+        if slug in seen and seen[slug] != name:
+            raise ValueError(
+                f"Two {kind} names slugify to the same page {slug!r}: "
+                f"{seen[slug]!r} and {name!r}. Rename one so their pages don't collide."
+            )
+        seen[slug] = name
+        out[name] = slug
+    return out
+
+
+# Connector badges — brand-color initials (decision: docs design pass 1).
+# Curated map for known types; anything else falls back to a neutral brand
+# badge with the first two letters, so new plugins render without changes.
+_BADGES: dict[str, tuple[str, str, str]] = {
+    "bigquery": ("BQ", "#4285f4", "#ffffff"),
+    "postgres": ("PG", "#336791", "#ffffff"),
+    "duckdb": ("DK", "#fff100", "#3a3a00"),
+    "snowflake": ("SF", "#29b5e8", "#062d3d"),
+    "databricks": ("DX", "#ff3621", "#ffffff"),
+    "clickhouse": ("CH", "#faff69", "#3a3d00"),
+    "sqlite": ("SQ", "#0f80cc", "#ffffff"),
+    "mysql": ("MY", "#00758f", "#ffffff"),
+    "elasticsearch": ("ES", "#00bfb3", "#00312e"),
+    "s3": ("S3", "#ff9900", "#3e2500"),
+    "gcs": ("GC", "#4285f4", "#ffffff"),
+    "azure_blob": ("AZ", "#0078d4", "#ffffff"),
+    "slack": ("SL", "#4a154b", "#ffffff"),
+    "discord": ("DC", "#5865f2", "#ffffff"),
+    "hubspot": ("HS", "#ff7a59", "#3e1c00"),
+    "salesforce": ("SF", "#00a1e0", "#ffffff"),
+    "airtable": ("AT", "#fcb400", "#3d2c00"),
+    "klaviyo": ("KL", "#232426", "#ffffff"),
+    "rest_api": ("API", "#5a6068", "#ffffff"),
+    "webhook": ("WH", "#5a6068", "#ffffff"),
+}
+
+# Status dot/word pairs (never color-alone) — token names from STYLE_CSS.
+_STATUS_VARS: dict[str, str] = {
+    "success": "--success",
+    "partial": "--warning",
+    "failed": "--error",
+}
+
+
+def _badge(conn_type: str) -> tuple[str, str, str]:
+    known = _BADGES.get(conn_type)
+    if known:
+        return known
+    initials = (conn_type[:2] or "??").upper()
+    return (initials, "#7c3aed", "#ffffff")
+
+
+def _badge_svg(conn_type: str, x: int, y: int) -> str:
+    """A 26x26 brand-initial badge at (x, y). All text escaped."""
+    initials, bg, fg = _badge(conn_type)
+    fs = 9 if len(initials) > 2 else 10
+    return (
+        f'<rect x="{x}" y="{y}" width="26" height="26" rx="7" fill="{bg}"/>'
+        f'<text x="{x + 13}" y="{y + 17}" font-size="{fs}" font-weight="700" '
+        f'class="mono" fill="{fg}" text-anchor="middle">{escape(initials)}</text>'
+    )
+
+
+def _clip(value: str, limit: int = 24) -> str:
+    return value if len(value) <= limit else value[: limit - 1] + "…"
+
+
+def _marker_defs(prefix: str, size: int = 6) -> str:
+    """Arrowhead ``<defs>`` for forward (``{prefix}-arr``) and lookup
+    (``{prefix}-arr-lk``) edges, colored by the ``--edge`` / ``--edge-lookup``
+    tokens. ``prefix`` keeps marker ids unique per SVG."""
+    return (
+        "<defs>"
+        f'<marker id="{prefix}-arr" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="{size}" '
+        f'markerHeight="{size}" orient="auto-start-reverse">'
+        '<path d="M0,0.6 L7.4,4 L0,7.4 Z" fill="var(--edge)"/></marker>'
+        f'<marker id="{prefix}-arr-lk" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="{size}" '
+        f'markerHeight="{size}" orient="auto-start-reverse">'
+        '<path d="M0,0.6 L7.4,4 L0,7.4 Z" fill="var(--edge-lookup)"/></marker>'
+        "</defs>"
+    )
+
+
+def _node_card(
+    x: int,
+    y: int,
+    w: int,
+    conn_type: str,
+    name: str,
+    sub: str,
+    href: str | None,
+    *,
+    code: bool = False,
+    status: str | None = None,
+) -> str:
+    """One 54px-high node card. ``code=True`` renders the drt-managed sync style
+    (violet accent + doc icon); otherwise a connector card with a brand badge.
+    ``status`` adds a right-aligned dot + word pair colored by the status tokens.
+    """
+    accent = (
+        f'<rect x="{x}" y="{y}" width="3" height="54" rx="1.5" fill="var(--brand-600)"/>'
+        if code
+        else ""
+    )
+    stroke = "var(--zone-drt-line)" if code else "var(--line)"
+    if code:
+        icon = (
+            f'<g transform="translate({x + 13},{y + 14})">'
+            '<path d="M0,1.5 a1.5,1.5 0 0 1 1.5,-1.5 h6 l4,4 v11 a1.5,1.5 0 0 1 -1.5,1.5 '
+            'h-8.5 a1.5,1.5 0 0 1 -1.5,-1.5 z" fill="none" stroke="var(--brand-600)" '
+            'stroke-width="1.4" stroke-linejoin="round"/>'
+            '<path d="M7.5,0 v4 h4" fill="none" stroke="var(--brand-600)" '
+            'stroke-width="1.4" stroke-linejoin="round"/>'
+            '<path d="M3,9 h6 M3,12 h4" stroke="#a78bfa" stroke-width="1.2" '
+            'stroke-linecap="round"/></g>'
+        )
+        tx = x + 34
+    else:
+        icon = _badge_svg(conn_type, x + 12, y + 14)
+        tx = x + 48
+    name = _clip(name)
+    sub = _clip(sub, 16 if status else 30)
+    status_svg = ""
+    if status:
+        var = _STATUS_VARS.get(status, "--muted")
+        sx = x + w - 62
+        status_svg = (
+            f'<circle cx="{sx}" cy="{y + 36.5}" r="3.5" fill="var({var})"/>'
+            f'<text x="{sx + 8}" y="{y + 40}" font-size="10" font-weight="500" '
+            f'fill="var({var})">{escape(_clip(status, 8))}</text>'
+        )
+    body = (
+        f'<rect x="{x}" y="{y}" width="{w}" height="54" rx="8" '
+        f'fill="var(--surface)" stroke="{stroke}"/>'
+        f"{accent}{icon}"
+        f'<text x="{tx}" y="{y + 23}" font-size="12.5" font-weight="600" '
+        f'class="mono" fill="var(--fg)">{escape(name)}</text>'
+        f'<text x="{tx}" y="{y + 40}" font-size="10" letter-spacing="0.6" '
+        f'fill="var(--muted)">{escape(sub.upper())}</text>'
+        f"{status_svg}"
+    )
+    if href:
+        return f'<a href="{escape(href, quote=True)}">{body}</a>'
+    return body

--- a/drt/docs/_svg.py
+++ b/drt/docs/_svg.py
@@ -42,27 +42,58 @@ def _slug_map(names: list[str], kind: str) -> dict[str, str]:
 # Connector badges — brand-color initials (decision: docs design pass 1).
 # Curated map for known types; anything else falls back to a neutral brand
 # badge with the first two letters, so new plugins render without changes.
+# Keys must match the registered connector ``type`` (see
+# ``drt/connectors/registry.py``) — a guard test pins this so a typo'd key
+# (e.g. the old ``salesforce`` vs the registered ``salesforce_bulk``) can't
+# silently fall through to the neutral badge.
 _BADGES: dict[str, tuple[str, str, str]] = {
+    # Warehouses / databases
     "bigquery": ("BQ", "#4285f4", "#ffffff"),
     "postgres": ("PG", "#336791", "#ffffff"),
+    "redshift": ("RS", "#8c4fff", "#ffffff"),
     "duckdb": ("DK", "#fff100", "#3a3a00"),
-    "snowflake": ("SF", "#29b5e8", "#062d3d"),
+    # NB: snowflake moved SF -> SN so the now-active salesforce_bulk keeps the
+    # canonical "SF". Revert if design prefers SF for Snowflake instead.
+    "snowflake": ("SN", "#29b5e8", "#062d3d"),
     "databricks": ("DX", "#ff3621", "#ffffff"),
     "clickhouse": ("CH", "#faff69", "#3a3d00"),
     "sqlite": ("SQ", "#0f80cc", "#ffffff"),
     "mysql": ("MY", "#00758f", "#ffffff"),
-    "elasticsearch": ("ES", "#00bfb3", "#00312e"),
+    "sqlserver": ("MS", "#a91d22", "#ffffff"),
+    # Lakehouse / files / object stores
+    "deltalake": ("DL", "#00add4", "#00303d"),
+    "iceberg": ("IB", "#2c88d9", "#ffffff"),
+    "parquet": ("PQ", "#50abf1", "#0a2740"),
+    "file": ("FL", "#5a6068", "#ffffff"),
     "s3": ("S3", "#ff9900", "#3e2500"),
     "gcs": ("GC", "#4285f4", "#ffffff"),
     "azure_blob": ("AZ", "#0078d4", "#ffffff"),
+    "elasticsearch": ("ES", "#00bfb3", "#00312e"),
+    # Messaging / collaboration
     "slack": ("SL", "#4a154b", "#ffffff"),
     "discord": ("DC", "#5865f2", "#ffffff"),
+    "teams": ("TM", "#6264a7", "#ffffff"),
+    "email_smtp": ("EM", "#5a6068", "#ffffff"),
+    "twilio": ("TW", "#f22f46", "#ffffff"),
+    "sendgrid": ("SG", "#1a82e2", "#ffffff"),
+    # CRM / marketing / product analytics
     "hubspot": ("HS", "#ff7a59", "#3e1c00"),
-    "salesforce": ("SF", "#00a1e0", "#ffffff"),
-    "airtable": ("AT", "#fcb400", "#3d2c00"),
+    "salesforce_bulk": ("SF", "#00a1e0", "#ffffff"),
+    "intercom": ("IC", "#1f8ded", "#ffffff"),
     "klaviyo": ("KL", "#232426", "#ffffff"),
+    "airtable": ("AT", "#fcb400", "#3d2c00"),
+    "notion": ("NO", "#191919", "#ffffff"),
+    "amplitude": ("AM", "#1f6fff", "#ffffff"),
+    "mixpanel": ("MX", "#7856ff", "#ffffff"),
+    "google_ads": ("GA", "#4285f4", "#ffffff"),
+    "google_sheets": ("GS", "#0f9d58", "#ffffff"),
+    # Issue trackers / other
+    "jira": ("JR", "#0052cc", "#ffffff"),
+    "linear": ("LN", "#5e6ad2", "#ffffff"),
+    "github_actions": ("GH", "#2088ff", "#ffffff"),
+    "zendesk": ("ZD", "#03363d", "#ffffff"),
+    "staged_upload": ("SU", "#5a6068", "#ffffff"),
     "rest_api": ("API", "#5a6068", "#ffffff"),
-    "webhook": ("WH", "#5a6068", "#ffffff"),
 }
 
 # Status dot/word pairs (never color-alone) — token names from STYLE_CSS.

--- a/drt/docs/dag.py
+++ b/drt/docs/dag.py
@@ -1,0 +1,193 @@
+"""Static SVG emission for the project DAG page (#701, phase 2).
+
+Consumes the deterministic geometry from :mod:`drt.docs.layout` and emits one
+inline, themeable SVG — the visual language of
+``docs/design/drt-docs-lineage-mock.html``: ownership zone bands (sources ·
+external read | syncs · managed by drt | destinations · external write),
+forward edges as bezier curves, lookup back-edges as dashed "subway" lanes over
+the top, and the #704 node cards / connector badges for every node, each linked
+to its detail page.
+
+No runtime layout JS, no CDN — the output works opened via ``file://``. Same
+manifest in, same bytes out (#697): the layout engine rounds all coordinates,
+node/edge iteration follows the layout's stable ordering, and nothing here
+reads clocks, randomness, or unordered sets.
+"""
+
+from __future__ import annotations
+
+from drt.docs._svg import _marker_defs, _node_card, _slug_map
+from drt.docs.layout import LayoutConfig, LayoutEdge, compute_layout
+from drt.docs.manifest import Manifest
+
+_HEADER_H = 48.0  # band above the layout content, holding the zone titles
+_ZONE_PAD_X = 12  # horizontal breathing room between a column and its zone edge
+_ZONE_PAD_Y = 10  # gap between the SVG edge and the zone bands
+
+# (title, title fill, secondary right-aligned label) per rank. The sync zone
+# carries the "managed by drt" pill instead of a secondary label — the band is
+# too narrow for both (the mock's "version-controlled YAML" tag is dropped).
+_ZONES: tuple[tuple[str, str, str | None], ...] = (
+    ("SOURCES", "var(--muted)", "external · read"),
+    ("SYNCS", "var(--brand-700)", None),
+    ("DESTINATIONS", "var(--muted)", "external · write"),
+)
+
+
+def _dag_config() -> LayoutConfig:
+    """Layout geometry tuned to the mock's proportions. ``node_h`` matches the
+    fixed 54px card height so edge ports land on card borders."""
+    return LayoutConfig(
+        col_w=380.0,  # rank pitch — leaves a 160px gutter for lookup risers
+        row_h=96.0,
+        node_w=220.0,
+        node_h=54.0,
+        margin=32.0,
+        lane_gap=20.0,
+    )
+
+
+def _f(value: float) -> str:
+    """Compact deterministic coordinate formatting (``84.0`` -> ``84``)."""
+    return format(value, "g")
+
+
+def _zone_bands(cfg: LayoutConfig, total_h: float) -> str:
+    """The three ownership bands, drawn behind everything else."""
+    parts: list[str] = []
+    band_w = cfg.node_w + 2 * _ZONE_PAD_X
+    band_h = total_h - 2 * _ZONE_PAD_Y
+    for rank, (title, title_fill, secondary) in enumerate(_ZONES):
+        left = cfg.margin + rank * cfg.col_w - _ZONE_PAD_X
+        is_sync = rank == 1
+        fill = "var(--zone-drt-bg)" if is_sync else "none"
+        stroke = "var(--zone-drt-line)" if is_sync else "var(--line)"
+        parts.append(
+            f'<rect x="{_f(left)}" y="{_ZONE_PAD_Y}" width="{_f(band_w)}" '
+            f'height="{_f(band_h)}" rx="10" fill="{fill}" stroke="{stroke}"/>'
+            f'<text x="{_f(left + 14)}" y="32" font-size="11" letter-spacing="1.2" '
+            f'fill="{title_fill}" font-weight="600">{title}</text>'
+        )
+        if is_sync:
+            parts.append(
+                f'<rect x="{_f(left + 66)}" y="19" width="92" height="18" rx="9" '
+                'fill="var(--brand-600)"/>'
+                f'<text x="{_f(left + 112)}" y="32" font-size="10.5" fill="#fff" '
+                'text-anchor="middle" font-weight="600">managed by drt</text>'
+            )
+        elif secondary:
+            parts.append(
+                f'<text x="{_f(left + band_w - 14)}" y="32" font-size="11" '
+                f'fill="var(--muted)" text-anchor="end">{secondary}</text>'
+            )
+    return "".join(parts)
+
+
+def _edge_svg(edge: LayoutEdge) -> str:
+    pts = edge.points
+    if edge.kind == "forward":
+        # 4 bezier control points from the layout: start, c1, c2, end.
+        d = (
+            f"M{_f(pts[0][0])},{_f(pts[0][1])} "
+            f"C{_f(pts[1][0])},{_f(pts[1][1])} "
+            f"{_f(pts[2][0])},{_f(pts[2][1])} "
+            f"{_f(pts[3][0])},{_f(pts[3][1])}"
+        )
+        return (
+            f'<path d="{d}" fill="none" stroke="var(--edge)" stroke-width="1.5" '
+            'marker-end="url(#dag-arr)"/>'
+        )
+    # Lookup back-edge: orthogonal lane polyline over the top of the graph,
+    # dashed, with a port dot where it enters the consumer's top edge.
+    d = f"M{_f(pts[0][0])},{_f(pts[0][1])}" + "".join(
+        f" L{_f(x)},{_f(y)}" for x, y in pts[1:]
+    )
+    end_x, end_y = pts[-1]
+    return (
+        f'<path d="{d}" fill="none" stroke="var(--edge-lookup)" stroke-width="1.5" '
+        'stroke-dasharray="5 4" marker-end="url(#dag-arr-lk)"/>'
+        f'<circle cx="{_f(end_x)}" cy="{_f(end_y)}" r="3" fill="var(--edge-lookup)"/>'
+    )
+
+
+def render_dag_svg(manifest: Manifest, *, strategy: str = "median") -> str:
+    """Render *manifest* as one static, themeable DAG SVG.
+
+    Deterministic: the same manifest (and strategy) always yields byte-identical
+    markup. Every node is an ``<a>`` to its detail page, using the same slug
+    scheme as the rest of the site; hrefs are relative to the site root (the
+    DAG page lives at ``dag.html``).
+    """
+    cfg = _dag_config()
+    layout = compute_layout(manifest, strategy=strategy, config=cfg)
+
+    sync_slugs = _slug_map([s.name for s in manifest.syncs], "sync")
+    source_slugs = _slug_map([s.name for s in manifest.sources], "source")
+    dest_slugs = _slug_map([d.name for d in manifest.destinations], "destination")
+    src_type = {s.name: s.type for s in manifest.sources}
+    sync_by_name = {s.name: s for s in manifest.syncs}
+    dest_by_id = {d.name: d for d in manifest.destinations}
+
+    width = layout.width
+    height = layout.height + _HEADER_H
+    card_w = round(cfg.node_w)
+
+    parts: list[str] = [
+        f'<svg viewBox="0 0 {_f(width)} {_f(height)}" width="{_f(width)}" '
+        f'height="{_f(height)}" role="img" aria-label="Lineage graph: sources feed '
+        'drt-managed syncs which write to destinations">',
+        _marker_defs("dag", size=7),
+        # back to front: zones, then edges, then node cards
+        _zone_bands(cfg, height),
+        f'<g transform="translate(0,{_f(_HEADER_H)})">',
+    ]
+    parts.extend(_edge_svg(e) for e in layout.edges)
+
+    for node in layout.nodes:
+        x = round(node.x - cfg.node_w / 2)
+        y = round(node.y - cfg.node_h / 2)
+        if node.kind == "sync":
+            sync = sync_by_name[node.id]
+            parts.append(
+                _node_card(
+                    x,
+                    y,
+                    card_w,
+                    "",
+                    sync.name,
+                    sync.mode,
+                    f"sync/{sync_slugs[sync.name]}.html",
+                    code=True,
+                    status=sync.state.last_status if sync.state else None,
+                )
+            )
+        elif node.kind == "source":
+            conn_type = src_type.get(node.id, "source")
+            parts.append(
+                _node_card(
+                    x,
+                    y,
+                    card_w,
+                    conn_type,
+                    node.id,
+                    conn_type,
+                    f"source/{source_slugs[node.id]}.html",
+                )
+            )
+        else:
+            dest = dest_by_id.get(node.id)
+            conn_type = dest.type if dest else "destination"
+            parts.append(
+                _node_card(
+                    x,
+                    y,
+                    card_w,
+                    conn_type,
+                    dest.label if dest else node.id,
+                    conn_type,
+                    f"destination/{dest_slugs[node.id]}.html",
+                )
+            )
+
+    parts.append("</g></svg>")
+    return "".join(parts)

--- a/drt/docs/dag.py
+++ b/drt/docs/dag.py
@@ -48,8 +48,16 @@ def _dag_config() -> LayoutConfig:
 
 
 def _f(value: float) -> str:
-    """Compact deterministic coordinate formatting (``84.0`` -> ``84``)."""
-    return format(value, "g")
+    """Compact deterministic coordinate formatting (``84.0`` -> ``84``).
+
+    Fixed-point, never scientific: ``format(value, "g")`` switches to ``1e+06``
+    at ``>= 1e6`` — invalid as an SVG coordinate — which an absurdly large DAG
+    could hit. All coordinates arrive rounded to <= 2 decimals (the layout
+    engine's ``_COORD_PRECISION``; dag.py only adds integer offsets), so
+    ``.2f`` is exact and byte-identical to the old ``"g"`` output for every
+    real coordinate — only the >999,999px scientific case changes.
+    """
+    return f"{value:.2f}".rstrip("0").rstrip(".")
 
 
 def _zone_bands(cfg: LayoutConfig, total_h: float) -> str:
@@ -69,11 +77,17 @@ def _zone_bands(cfg: LayoutConfig, total_h: float) -> str:
             f'fill="{title_fill}" font-weight="600">{title}</text>'
         )
         if is_sync:
+            # "managed by drt" pill on the title row, then the mock's second
+            # descriptor as a muted line beneath it (the band is too narrow to
+            # carry both on one row — see the sources/destinations secondary,
+            # which is right-aligned on the title row instead).
             parts.append(
                 f'<rect x="{_f(left + 66)}" y="19" width="92" height="18" rx="9" '
                 'fill="var(--brand-600)"/>'
                 f'<text x="{_f(left + 112)}" y="32" font-size="10.5" fill="#fff" '
                 'text-anchor="middle" font-weight="600">managed by drt</text>'
+                f'<text x="{_f(left + 14)}" y="44" font-size="9.5" letter-spacing="0.3" '
+                'fill="var(--muted)">version-controlled YAML</text>'
             )
         elif secondary:
             parts.append(
@@ -133,8 +147,14 @@ def render_dag_svg(manifest: Manifest, *, strategy: str = "median") -> str:
     card_w = round(cfg.node_w)
 
     parts: list[str] = [
-        f'<svg viewBox="0 0 {_f(width)} {_f(height)}" width="{_f(width)}" '
-        f'height="{_f(height)}" role="img" aria-label="Lineage graph: sources feed '
+        # Responsive: viewBox carries the intrinsic geometry; the style scales
+        # the SVG down to its column and never upscales past natural size, so
+        # the destination rank stays on-screen instead of overflowing a
+        # narrower content column (the `.dag` overflow-x:auto only engages on
+        # genuinely tiny viewports). No fixed width/height px attributes.
+        f'<svg viewBox="0 0 {_f(width)} {_f(height)}" '
+        f'style="width:100%;height:auto;max-width:{_f(width)}px" '
+        'role="img" aria-label="Lineage graph: sources feed '
         'drt-managed syncs which write to destinations">',
         _marker_defs("dag", size=7),
         # back to front: zones, then edges, then node cards

--- a/drt/docs/html.py
+++ b/drt/docs/html.py
@@ -4,14 +4,15 @@
 per view (overview, DAG, and each sync/source/destination) plus vendored
 ``assets/``. Per the ADR (#500): no runtime fetch, each page inlines its data
 subset in a ``<script type="application/json" id="drt-data">`` block, so the
-site works opened directly via ``file://`` with no CORS issues. Mermaid renders
-the DAG via CDN; YAML is syntax-highlighted at build time with Pygments.
+site works opened directly via ``file://`` with no CORS issues. The DAG page is
+a static SVG emitted from the layout engine (:mod:`drt.docs.dag`, #701) — no
+CDN, no runtime layout JS; YAML is syntax-highlighted at build time with
+Pygments.
 """
 
 from __future__ import annotations
 
 import json
-import re
 import shutil
 from collections import Counter
 from html import escape
@@ -24,132 +25,9 @@ from pygments.formatters import HtmlFormatter
 from pygments.lexers import YamlLexer
 
 from drt.docs._html_assets import APP_JS, STYLE_CSS
+from drt.docs._svg import _badge, _marker_defs, _node_card, _slug, _slug_map
+from drt.docs.dag import render_dag_svg
 from drt.docs.manifest import Manifest, Sync
-from drt.docs.mermaid import render_mermaid
-
-_SLUG_RE = re.compile(r"[^A-Za-z0-9]+")
-
-
-def _slug(value: str) -> str:
-    return _SLUG_RE.sub("-", value).strip("-").lower() or "x"
-
-
-def _slug_map(names: list[str], kind: str) -> dict[str, str]:
-    """Map each name to a stable slug, failing fast on a collision.
-
-    ``_slug`` collapses runs of non-alphanumerics, so punctuation-only-distinct
-    names (``a_b`` vs ``a__b``) can slugify to the same file — which would
-    silently overwrite a page and break cross-links. Detect that and raise.
-    """
-    out: dict[str, str] = {}
-    seen: dict[str, str] = {}
-    for name in names:
-        slug = _slug(name)
-        if slug in seen and seen[slug] != name:
-            raise ValueError(
-                f"Two {kind} names slugify to the same page {slug!r}: "
-                f"{seen[slug]!r} and {name!r}. Rename one so their pages don't collide."
-            )
-        seen[slug] = name
-        out[name] = slug
-    return out
-# Connector badges — brand-color initials (decision: docs design pass 1).
-# Curated map for known types; anything else falls back to a neutral brand
-# badge with the first two letters, so new plugins render without changes.
-_BADGES: dict[str, tuple[str, str, str]] = {
-    "bigquery": ("BQ", "#4285f4", "#ffffff"),
-    "postgres": ("PG", "#336791", "#ffffff"),
-    "duckdb": ("DK", "#fff100", "#3a3a00"),
-    "snowflake": ("SF", "#29b5e8", "#062d3d"),
-    "databricks": ("DX", "#ff3621", "#ffffff"),
-    "clickhouse": ("CH", "#faff69", "#3a3d00"),
-    "sqlite": ("SQ", "#0f80cc", "#ffffff"),
-    "mysql": ("MY", "#00758f", "#ffffff"),
-    "elasticsearch": ("ES", "#00bfb3", "#00312e"),
-    "s3": ("S3", "#ff9900", "#3e2500"),
-    "gcs": ("GC", "#4285f4", "#ffffff"),
-    "azure_blob": ("AZ", "#0078d4", "#ffffff"),
-    "slack": ("SL", "#4a154b", "#ffffff"),
-    "discord": ("DC", "#5865f2", "#ffffff"),
-    "hubspot": ("HS", "#ff7a59", "#3e1c00"),
-    "salesforce": ("SF", "#00a1e0", "#ffffff"),
-    "airtable": ("AT", "#fcb400", "#3d2c00"),
-    "klaviyo": ("KL", "#232426", "#ffffff"),
-    "rest_api": ("API", "#5a6068", "#ffffff"),
-    "webhook": ("WH", "#5a6068", "#ffffff"),
-}
-
-
-def _badge(conn_type: str) -> tuple[str, str, str]:
-    known = _BADGES.get(conn_type)
-    if known:
-        return known
-    initials = (conn_type[:2] or "??").upper()
-    return (initials, "#7c3aed", "#ffffff")
-
-
-def _badge_svg(conn_type: str, x: int, y: int) -> str:
-    """A 26x26 brand-initial badge at (x, y). All text escaped."""
-    initials, bg, fg = _badge(conn_type)
-    fs = 9 if len(initials) > 2 else 10
-    return (
-        f'<rect x="{x}" y="{y}" width="26" height="26" rx="7" fill="{bg}"/>'
-        f'<text x="{x + 13}" y="{y + 17}" font-size="{fs}" font-weight="700" '
-        f'class="mono" fill="{fg}" text-anchor="middle">{escape(initials)}</text>'
-    )
-
-
-def _clip(value: str, limit: int = 24) -> str:
-    return value if len(value) <= limit else value[: limit - 1] + "…"
-
-
-def _node_card(
-    x: int,
-    y: int,
-    w: int,
-    conn_type: str,
-    name: str,
-    sub: str,
-    href: str | None,
-    *,
-    code: bool = False,
-) -> str:
-    """One ego-graph node card. `code=True` renders the drt-managed sync style."""
-    accent = (
-        f'<rect x="{x}" y="{y}" width="3" height="54" rx="1.5" fill="var(--brand-600)"/>'
-        if code
-        else ""
-    )
-    stroke = "var(--zone-drt-line)" if code else "var(--line)"
-    if code:
-        icon = (
-            f'<g transform="translate({x + 13},{y + 14})">'
-            '<path d="M0,1.5 a1.5,1.5 0 0 1 1.5,-1.5 h6 l4,4 v11 a1.5,1.5 0 0 1 -1.5,1.5 '
-            'h-8.5 a1.5,1.5 0 0 1 -1.5,-1.5 z" fill="none" stroke="var(--brand-600)" '
-            'stroke-width="1.4" stroke-linejoin="round"/>'
-            '<path d="M7.5,0 v4 h4" fill="none" stroke="var(--brand-600)" '
-            'stroke-width="1.4" stroke-linejoin="round"/>'
-            '<path d="M3,9 h6 M3,12 h4" stroke="#a78bfa" stroke-width="1.2" '
-            'stroke-linecap="round"/></g>'
-        )
-        tx = x + 34
-    else:
-        icon = _badge_svg(conn_type, x + 12, y + 14)
-        tx = x + 48
-    name = _clip(name)
-    sub = _clip(sub, 30)
-    body = (
-        f'<rect x="{x}" y="{y}" width="{w}" height="54" rx="8" '
-        f'fill="var(--surface)" stroke="{stroke}"/>'
-        f"{accent}{icon}"
-        f'<text x="{tx}" y="{y + 23}" font-size="12.5" font-weight="600" '
-        f'class="mono" fill="var(--fg)">{escape(name)}</text>'
-        f'<text x="{tx}" y="{y + 40}" font-size="10" letter-spacing="0.6" '
-        f'fill="var(--muted)">{escape(sub.upper())}</text>'
-    )
-    if href:
-        return f'<a href="{escape(href, quote=True)}">{body}</a>'
-    return body
 
 
 def _ego_svg(
@@ -177,14 +55,7 @@ def _ego_svg(
     parts: list[str] = [
         f'<svg viewBox="0 0 890 {height}" width="890" height="{height}" role="img" '
         f'aria-label="Lineage for {escape(sync.name, quote=True)}">',
-        "<defs>"
-        '<marker id="ego-arr" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" '
-        'markerHeight="6" orient="auto-start-reverse">'
-        '<path d="M0,0.6 L7.4,4 L0,7.4 Z" fill="var(--edge)"/></marker>'
-        '<marker id="ego-arr-lk" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" '
-        'markerHeight="6" orient="auto-start-reverse">'
-        '<path d="M0,0.6 L7.4,4 L0,7.4 Z" fill="var(--edge-lookup)"/></marker>'
-        "</defs>",
+        _marker_defs("ego"),
     ]
 
     # main row: source → sync → destination
@@ -416,15 +287,14 @@ _DAG = """\
 {% block main %}
 <div class="eyebrow">Lineage</div>
 <h1>DAG</h1>
-<p class="lede">Source → sync → destination lineage. Dashed edges are destination lookups.</p>
-<pre class="mermaid">{{ mermaid }}</pre>
-{% endblock %}
-{% block scripts %}
-<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
-<script>
-  var dark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-  mermaid.initialize({ startOnLoad: true, theme: dark ? "dark" : "default" });
-</script>
+<p class="lede">Ownership at a glance: what drt manages, what it reads, what it writes.
+Dashed edges are destination lookups.</p>
+{% if dag_svg %}
+<div class="dag">{{ dag_svg|safe }}</div>
+{% else %}
+<div class="empty">No syncs found &mdash; add <code>.yml</code> files to <code>syncs/</code>
+and re-run <code>drt docs generate</code>.</div>
+{% endif %}
 {% endblock %}
 """
 
@@ -722,7 +592,7 @@ def render_html(manifest: Manifest, output_dir: Path) -> list[Path]:
         ),
     )
 
-    # dag.html
+    # dag.html — static SVG from the layout engine (#701); no runtime layout JS.
     write(
         "dag.html",
         env.get_template("dag").render(
@@ -730,7 +600,7 @@ def render_html(manifest: Manifest, output_dir: Path) -> list[Path]:
             active="dag",
             root="",
             current_slug="",
-            mermaid=render_mermaid(manifest),
+            dag_svg=render_dag_svg(manifest) if manifest.syncs else None,
             data_json=dumps({"nav": nav}),
             **common,
         ),

--- a/tests/unit/test_docs_dag.py
+++ b/tests/unit/test_docs_dag.py
@@ -198,3 +198,47 @@ def test_manifest_text_is_escaped() -> None:
     )
     svg = render_dag_svg(manifest)
     assert "<script>" not in svg
+
+
+def test_badge_keys_match_registered_connectors() -> None:
+    """Every curated badge key must be a registered connector ``type``.
+
+    Guards the drift that had ``salesforce`` (never registered — the type is
+    ``salesforce_bulk``) silently falling through to the neutral badge.
+    """
+    from drt.connectors import registry
+    from drt.docs._svg import _BADGES
+
+    registered = set(registry._source_registry) | set(registry._destination_registry)
+    stray = set(_BADGES) - registered
+    assert not stray, f"_BADGES keys not registered as connector types: {sorted(stray)}"
+
+
+def test_svg_is_responsive_not_fixed_width() -> None:
+    """The DAG SVG scales to its column (#701 follow-up): viewBox + a
+    max-width style, no fixed width/height px attributes that would overflow a
+    narrower content column and push the destination rank off-screen."""
+    svg = render_dag_svg(_manifest())
+    opening = svg[: svg.index(">") + 1]
+    assert "viewBox=" in opening
+    assert "width:100%" in opening and "max-width:" in opening
+    assert ' width="' not in opening and ' height="' not in opening
+
+
+def test_coordinate_formatter_never_scientific() -> None:
+    """``_f`` must stay fixed-point: ``format(v, "g")`` emits ``1e+06`` at
+    ``>= 1e6`` — invalid as an SVG coordinate — reachable on an absurdly large
+    DAG. It also stays byte-identical to the old ``"g"`` form for the normal
+    <= 2-decimal coordinates the layout engine produces."""
+    from drt.docs.dag import _f
+
+    # never scientific, even past the 1e6 threshold that broke "g"
+    for big in (1_000_000.0, 1_234_567.89, 9_999_999.5):
+        out = _f(big)
+        assert "e" not in out and "E" not in out, f"{big!r} -> {out!r} went scientific"
+    # exact + trailing-zero-stripped for the values that actually occur
+    assert _f(12.0) == "12"
+    assert _f(12.5) == "12.5"
+    assert _f(12.34) == "12.34"
+    assert _f(1_000_000.0) == "1000000"
+    assert _f(0.0) == "0"

--- a/tests/unit/test_docs_dag.py
+++ b/tests/unit/test_docs_dag.py
@@ -1,0 +1,200 @@
+"""Tests for the static DAG SVG emission (#701, phase 2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from drt.docs.dag import render_dag_svg
+from drt.docs.html import render_html
+from drt.docs.manifest import (
+    SCHEMA_VERSION,
+    Destination,
+    Edge,
+    Manifest,
+    Project,
+    Source,
+    Sync,
+    SyncStateSnapshot,
+)
+
+
+def _state(status: str) -> SyncStateSnapshot:
+    return SyncStateSnapshot(
+        last_sync_at="2026-07-01T00:00:00Z",
+        last_cursor_value=None,
+        rows_synced=10,
+        last_status=status,
+        last_error=None,
+    )
+
+
+def _manifest() -> Manifest:
+    """Two sources, three syncs, three destinations, one lookup back-edge —
+    built fresh on every call so byte-identity is tested across object graphs,
+    not on a cached instance."""
+    return Manifest(
+        schema_version=SCHEMA_VERSION,
+        drt_version="9.9.9",
+        generated_at="2026-07-01T00:00:00Z",
+        project=Project(name="acme", profile="default"),
+        sources=[
+            Source(name="bq_prod", type="bigquery"),
+            Source(name="pg_replica", type="postgres"),
+        ],
+        destinations=[
+            Destination(name="dest_pg_users", type="postgres", label="public.users"),
+            Destination(name="dest_pg_orders", type="postgres", label="public.orders"),
+            Destination(name="dest_slack_alerts", type="slack", label="#alerts"),
+        ],
+        syncs=[
+            Sync(
+                name="users_to_pg",
+                source="bq_prod",
+                destination="dest_pg_users",
+                mode="incremental",
+                state=_state("success"),
+            ),
+            Sync(
+                name="orders_to_pg",
+                source="bq_prod",
+                destination="dest_pg_orders",
+                mode="upsert",
+                state=_state("partial"),
+            ),
+            Sync(
+                name="alerts_to_slack",
+                source="pg_replica",
+                destination="dest_slack_alerts",
+                mode="append",
+                state=_state("failed"),
+            ),
+        ],
+        edges=[
+            Edge(kind="source_to_sync", from_="bq_prod", to="users_to_pg"),
+            Edge(kind="source_to_sync", from_="bq_prod", to="orders_to_pg"),
+            Edge(kind="source_to_sync", from_="pg_replica", to="alerts_to_slack"),
+            Edge(kind="sync_to_destination", from_="users_to_pg", to="dest_pg_users"),
+            Edge(kind="sync_to_destination", from_="orders_to_pg", to="dest_pg_orders"),
+            Edge(kind="sync_to_destination", from_="alerts_to_slack", to="dest_slack_alerts"),
+            # orders_to_pg looks up users_to_pg's destination table
+            Edge(kind="lookup", from_="users_to_pg", to="orders_to_pg"),
+        ],
+    )
+
+
+# --- determinism (#697 acceptance bar) --------------------------------------
+
+
+def test_byte_identical_across_renders() -> None:
+    """Same manifest -> same SVG bytes, across freshly built object graphs."""
+    assert render_dag_svg(_manifest()) == render_dag_svg(_manifest())
+
+
+def test_dag_page_byte_identical_across_site_builds(tmp_path: Path) -> None:
+    render_html(_manifest(), tmp_path / "a")
+    render_html(_manifest(), tmp_path / "b")
+    assert (tmp_path / "a/dag.html").read_bytes() == (tmp_path / "b/dag.html").read_bytes()
+
+
+# --- structure ---------------------------------------------------------------
+
+
+def test_ownership_zones_present() -> None:
+    svg = render_dag_svg(_manifest())
+    assert "SOURCES" in svg
+    assert "SYNCS" in svg
+    assert "DESTINATIONS" in svg
+    assert "managed by drt" in svg
+    assert "external · read" in svg
+    assert "external · write" in svg
+    assert "var(--zone-drt-bg)" in svg
+    assert "var(--zone-drt-line)" in svg
+
+
+def test_forward_and_lookup_edges_present() -> None:
+    svg = render_dag_svg(_manifest())
+    # 6 forward edges as beziers with the forward marker
+    assert svg.count('marker-end="url(#dag-arr)"') == 6
+    assert 'stroke="var(--edge)"' in svg
+
+
+def test_lookup_edge_has_lookup_styling_and_marker() -> None:
+    svg = render_dag_svg(_manifest())
+    assert svg.count('marker-end="url(#dag-arr-lk)"') == 1
+    assert 'stroke="var(--edge-lookup)"' in svg
+    assert 'stroke-dasharray="5 4"' in svg
+
+
+def test_every_node_is_a_link() -> None:
+    svg = render_dag_svg(_manifest())
+    assert svg.count('<a href="sync/') == 3
+    assert svg.count('<a href="source/') == 2
+    assert svg.count('<a href="destination/') == 3
+    assert '<a href="sync/users-to-pg.html">' in svg
+    assert '<a href="source/bq-prod.html">' in svg
+    assert '<a href="destination/dest-pg-users.html">' in svg
+
+
+def test_sync_cards_show_status_dot_and_word() -> None:
+    svg = render_dag_svg(_manifest())
+    for word, var in [("success", "--success"), ("partial", "--warning"), ("failed", "--error")]:
+        assert word in svg
+        assert f"var({var})" in svg
+
+
+def test_connector_cards_use_brand_badges() -> None:
+    svg = render_dag_svg(_manifest())
+    assert ">BQ</text>" in svg  # bigquery badge initials
+    assert ">PG</text>" in svg  # postgres
+    assert ">SL</text>" in svg  # slack
+
+
+# --- file:// safety ----------------------------------------------------------
+
+
+def test_no_runtime_layout_js_or_cdn(tmp_path: Path) -> None:
+    out = tmp_path / "docs"
+    render_html(_manifest(), out)
+    html = (out / "dag.html").read_text(encoding="utf-8")
+    assert "fetch(" not in html
+    assert "mermaid" not in html
+    assert "cdn." not in html
+    assert "<svg" in html  # the SVG really is inline
+
+
+# --- edge cases --------------------------------------------------------------
+
+
+def test_empty_project_renders_without_crashing(tmp_path: Path) -> None:
+    empty = Manifest(
+        schema_version=SCHEMA_VERSION,
+        drt_version="9.9.9",
+        generated_at="2026-07-01T00:00:00Z",
+        project=Project(name="empty", profile="default"),
+        sources=[Source(name="default", type="duckdb")],
+    )
+    # the module itself must not crash on 0 syncs
+    assert "<svg" in render_dag_svg(empty)
+    # and the site falls back to the empty state on the DAG page
+    out = tmp_path / "docs"
+    render_html(empty, out)
+    assert "No syncs found" in (out / "dag.html").read_text(encoding="utf-8")
+
+
+def test_manifest_text_is_escaped() -> None:
+    bad = 'x<script>alert(1)</script>&"'
+    manifest = Manifest(
+        schema_version=SCHEMA_VERSION,
+        drt_version="9.9.9",
+        generated_at="2026-07-01T00:00:00Z",
+        project=Project(name="p", profile="default"),
+        sources=[Source(name="default", type="duckdb")],
+        destinations=[Destination(name="dest_x", type="discord", label=bad)],
+        syncs=[Sync(name=bad, source="default", destination="dest_x", mode=bad)],
+        edges=[
+            Edge(kind="source_to_sync", from_="default", to=bad),
+            Edge(kind="sync_to_destination", from_=bad, to="dest_x"),
+        ],
+    )
+    svg = render_dag_svg(manifest)
+    assert "<script>" not in svg

--- a/tests/unit/test_docs_html.py
+++ b/tests/unit/test_docs_html.py
@@ -110,10 +110,12 @@ def test_sync_page_has_highlighted_yaml_and_state(site: Path) -> None:
     assert "../destination/dest-discord-x.html" in html
 
 
-def test_dag_uses_mermaid(site: Path) -> None:
+def test_dag_is_static_svg(site: Path) -> None:
+    """The DAG page inlines the layout-engine SVG (#701) — no Mermaid, no CDN."""
     html = (site / "dag.html").read_text(encoding="utf-8")
-    assert "mermaid" in html
-    assert "graph LR" in html
+    assert "<svg" in html
+    assert "mermaid" not in html
+    assert "cdn.jsdelivr.net" not in html
 
 
 def test_assets_referenced_with_correct_relative_paths(site: Path) -> None:


### PR DESCRIPTION
Phase 2 of #701. Consumes the merged layout engine (`drt/docs/layout.py`) and renders its output as one inline, themeable SVG, replacing the runtime-Mermaid DAG page. Draft for pairing on the visual pass (@masukai leads design).

## What it does
- **`drt/docs/dag.py`** — `render_dag_svg(manifest)` calls `compute_layout` (median default) and draws back-to-front:
  - **Ownership zone bands** — sources (external · read) | syncs (violet "managed by drt" band, `--zone-drt-bg`/`--zone-drt-line`) | destinations (external · write).
  - **Edges** from `LayoutEdge.points` — forward beziers styled `--edge`; lookup back-edges as dashed `--edge-lookup` lanes over the top with port dots, both using the marker defs.
  - **Nodes** via `_node_card` — syncs as code cards (doc icon, mono name, mode, status dot+word), sources/destinations as connector cards with `_badge` brand-initial badges. Every node wrapped in `<a>` to its detail page.
- Replaces the Mermaid/CDN DAG page with the static SVG; empty projects fall back to an empty-state card. Works via `file://` — no fetch, no CDN, no runtime layout JS.

## Reusing #704's helpers
Extracted `_node_card`, `_badge`/`_badge_svg`, `_slug`/`_slug_map`, `_clip`, and the marker defs into **`drt/docs/_svg.py`**; `html.py` now imports them from there, so the per-sync ego-graphs and the full DAG share one code path (no duplicated card/badge/escaping logic). `_node_card` gained an optional `status` arg; `_marker_defs(prefix)` takes an id prefix so ego/DAG markers don't collide. `--zone-drt-bg` promoted from the mock into the real token file.

## Determinism (#697)
Same manifest → byte-identical SVG. A test asserts two renders match and that two site builds produce identical `dag.html` bytes. Coordinates come pre-rounded from the engine; iteration follows the layout's stable ordering; no clocks/random/set-ordering.

## Tests
`tests/unit/test_docs_dag.py` (new): byte-identity, zones present, forward+lookup edges, every node `<a>`-wrapped, `file://` safety (no `fetch(`/Mermaid/CDN), empty project, lookup edge uses `--edge-lookup` + marker, escaping. Updated `test_docs_html.py` (Mermaid → static-SVG assertion).

`ruff check` + `mypy drt` clean; full suite green (one pre-existing Windows-only sqlite teardown flake, unrelated).

## For the pairing session
- Dropped the mock's secondary "version-controlled YAML" label under SYNCS — the band can't carry it plus the "managed by drt" pill without overlap. Easy to restore.
- DLQ/drift badges are out of scope (need manifest schema v2, per the mock's footnote).
- Layout engine untouched — consumed, not modified.

Closes #701 (pending design review).
