### PR TITLE
docs(readme): hero redesign — lead with value, drop competitor comparison (closes #281)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 dlt loads data in, dbt transforms it, and **drt** activates it back out — reverse ETL from your warehouse to the tools your team works in. Declarative YAML, one `drt run`.
 
+<p align="center">
+  <code>dlt</code> <sub>load</sub> &nbsp;→&nbsp; <code>dbt</code> <sub>transform</sub> &nbsp;→&nbsp; <b><code>drt</code></b> <sub>activate</sub>
+</p>
+
 [![CI](https://img.shields.io/github/actions/workflow/status/drt-hub/drt/ci.yml?branch=main&style=flat-square&logo=githubactions&logoColor=white&label=CI)](https://github.com/drt-hub/drt/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/drt-hub/drt?style=flat-square&logo=codecov&logoColor=white&label=coverage)](https://codecov.io/gh/drt-hub/drt)
 [![PyPI](https://img.shields.io/pypi/v/drt-core?style=flat-square&logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/drt-core/)
@@ -46,10 +50,32 @@ drt init && drt run
 
 ## Why drt?
 
-- **Same DX as dbt.** If you know `dbt run`, you already know `drt run` — declarative YAML, versioned in Git, reviewed in PRs.
-- **CI-native.** Exit codes and `--output json` drop straight into GitHub Actions, cron, or Dagster / Airflow / Prefect — no GUI, no clickops.
-- **LLM-native.** A built-in MCP server and Claude Code skills let AI tools author and run your syncs.
-- **Free and open source.** Every connector, the CLI, the MCP server, and the sync engine — Apache 2.0, self-hosted, no lock-in.
+<table>
+<tr>
+<td width="50%">
+
+**Same DX as dbt.** If you know `dbt run`, you already know `drt run` — declarative YAML, versioned in Git, reviewed in PRs.
+
+</td>
+<td width="50%">
+
+**CI-native.** Exit codes and `--output json` drop straight into GitHub Actions, cron, or Dagster / Airflow / Prefect — no GUI, no clickops.
+
+</td>
+</tr>
+<tr>
+<td width="50%">
+
+**LLM-native.** A built-in MCP server and Claude Code skills let AI tools author and run your syncs.
+
+</td>
+<td width="50%">
+
+**Free and open source.** Every connector, the CLI, the MCP server, and the sync engine — Apache 2.0, self-hosted, no lock-in.
+
+</td>
+</tr>
+</table>
 
 > **What's always free?** All connectors, CLI, MCP server, and sync engine. See [OPEN_CORE.md](./OPEN_CORE.md) for the open core boundary.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 # drt — data reverse tool
 
-**Reverse ETL for the code-first data stack.**
+### The reverse leg of your data stack.
+
+dlt loads data in, dbt transforms it, and **drt** activates it back out — reverse ETL from your warehouse to the tools your team works in. Declarative YAML, one `drt run`.
 
 [![CI](https://img.shields.io/github/actions/workflow/status/drt-hub/drt/ci.yml?branch=main&style=flat-square&logo=githubactions&logoColor=white&label=CI)](https://github.com/drt-hub/drt/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/drt-hub/drt?style=flat-square&logo=codecov&logoColor=white&label=coverage)](https://codecov.io/gh/drt-hub/drt)
@@ -27,9 +29,6 @@
 
 </div>
 
-**drt** syncs data from your data warehouse to external services — declaratively, via YAML and CLI.
-Think `dbt run` → `drt run`. Same developer experience, opposite data direction.
-
 <p align="center">
   <img src="docs/assets/quickstart.gif" alt="drt quickstart demo" width="700">
 </p>
@@ -47,12 +46,10 @@ drt init && drt run
 
 ## Why drt?
 
-| Problem                              | drt's answer             |
-| ------------------------------------ | ------------------------ |
-| Census/Hightouch are expensive SaaS  | Free, self-hosted OSS    |
-| GUI-first tools don't fit CI/CD      | CLI + YAML, Git-native   |
-| dbt/dlt ecosystem has no reverse leg | Same philosophy, same DX |
-| LLM/MCP era makes GUI SaaS overkill  | LLM-native by design     |
+- **Same DX as dbt.** If you know `dbt run`, you already know `drt run` — declarative YAML, versioned in Git, reviewed in PRs.
+- **CI-native.** Exit codes and `--output json` drop straight into GitHub Actions, cron, or Dagster / Airflow / Prefect — no GUI, no clickops.
+- **LLM-native.** A built-in MCP server and Claude Code skills let AI tools author and run your syncs.
+- **Free and open source.** Every connector, the CLI, the MCP server, and the sync engine — Apache 2.0, self-hosted, no lock-in.
 
 > **What's always free?** All connectors, CLI, MCP server, and sync engine. See [OPEN_CORE.md](./OPEN_CORE.md) for the open core boundary.
 


### PR DESCRIPTION
## Summary

Redesigns the README hero so a visitor gets **what / why / how-to-try** in ~10 seconds (#281: 339 views → 12 stars = the hero wasn't converting). Direction A of three mockups masukai compared — **stack-complement framing**, full name kept.

Reworks the **top ~50 lines only**; everything from Quickstart down is untouched.

### What changed
- **Headline.** Keep `# drt — data reverse tool` (full name), add a value line **"The reverse leg of your data stack."** + a one-sentence `dlt → dbt → drt` framing so a dbt/dlt user places it instantly.
- **Dropped the competitor-comparison table.** The old "Why drt?" led with *"Census/Hightouch are expensive SaaS"* — exactly what #281 says to avoid. Replaced with **four of drt's own strengths**: same DX as dbt · CI-native · LLM-native · free & open source. No other tool is named or criticised.
- **Folded** the redundant "drt syncs data…" intro into the hero sub. Badges, quickstart GIF, install snippet, Codespaces, and the "What's always free?" note all stay.

### Preview
Rendered via GitHub's own markdown API (real badges): the hero leads with the value headline, the ecosystem framing, then install + strengths — no comparison table. (Screenshot shared with masukai; the GIF resolves on GitHub, only the local preview shows it as a broken link.)

Three hero directions were mocked up for comparison before landing on A; happy to swap the headline or bullet copy if you'd prefer B ("Reverse ETL, as code") or C ("free & self-hosted") framing.

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)