### PR TITLE
refactor(config): split models.py into destination/sync-option modules (#721)

### DIFF
--- a/drt/config/base.py
+++ b/drt/config/base.py
@@ -1,0 +1,193 @@
+"""Shared config primitives for drt (auth, pagination, retry, lookups, project).
+
+Phase 1 of #721 lifted these out of the former monolithic ``models.py`` so the
+destination and sync-option modules can share them without a circular import
+(destinations need :class:`RetryConfig`; ``sync_options`` needs the destination
+union). ``models.py`` re-exports everything here — import sites are unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class DescribableConfig(BaseModel):
+    """Mixin base for destination configs whose ``describe()`` is the canonical
+    ``f"{type} (detail)"`` shape (#721). Trivial subclasses supply
+    ``_describe_detail``; connectors with a non-standard label (a hardcoded name
+    or no parens) override ``describe()`` and inherit :class:`BaseModel` directly.
+    """
+
+    def describe(self) -> str:
+        return f"{self.type} ({self._describe_detail()})"  # type: ignore[attr-defined]
+
+    def _describe_detail(self) -> str:  # pragma: no cover - always overridden
+        raise NotImplementedError
+
+
+class BearerAuth(BaseModel):
+    type: Literal["bearer"]
+    token: str | None = None
+    token_env: str | None = None
+
+
+class ApiKeyAuth(BaseModel):
+    type: Literal["api_key"]
+    header: str = "X-API-Key"
+    value: str | None = None
+    value_env: str | None = None
+
+
+class BasicAuth(BaseModel):
+    type: Literal["basic"]
+    username_env: str
+    password_env: str
+
+
+class OAuth2ClientCredentialsAuth(BaseModel):
+    type: Literal["oauth2_client_credentials"]
+    token_url: str
+    client_id_env: str
+    client_secret_env: str
+    scope: str | None = None
+
+
+AuthConfig = Annotated[
+    BearerAuth | ApiKeyAuth | BasicAuth | OAuth2ClientCredentialsAuth,
+    Field(discriminator="type"),
+]
+
+
+class OffsetPaginationConfig(BaseModel):
+    type: Literal["offset"]
+    limit: int = 100
+    offset_param: str = "offset"
+    limit_param: str = "limit"
+    max_pages: int = 100
+
+
+class CursorPaginationConfig(BaseModel):
+    type: Literal["cursor"]
+    limit: int = 100
+    cursor_param: str = "cursor"
+    limit_param: str = "limit"
+    cursor_field: str
+    max_pages: int = 100
+
+
+class LinkHeaderPaginationConfig(BaseModel):
+    type: Literal["link_header"]
+    max_pages: int = 100
+
+
+PaginationConfig = Annotated[
+    OffsetPaginationConfig | CursorPaginationConfig | LinkHeaderPaginationConfig,
+    Field(discriminator="type"),
+]
+
+
+class RestIncrementalConfig(BaseModel):
+    """Incremental extraction for the REST API source (#767).
+
+    ``start_param`` names the request query parameter that receives the last
+    watermark value (e.g. ``updated_since``). Cursor *tracking* stays
+    engine-side: ``sync.cursor_field`` names the record field whose max value
+    is persisted after each run — this config only tells the source where to
+    put that value on the request.
+    """
+
+    start_param: str
+
+
+class SourceConfig(BaseModel):
+    type: Literal["bigquery", "snowflake", "postgres", "duckdb", "clickhouse"]
+    project: str | None = None
+    dataset: str | None = None
+    credentials: str | None = None
+
+
+class HistoryConfig(BaseModel):
+    """Sync execution history retention (#276)."""
+
+    enabled: bool = True
+    retention_days: int = 30
+
+
+class ProjectConfig(BaseModel):
+    name: str
+    version: str = "0.1"
+    profile: str = "default"
+    source: SourceConfig | None = None  # optional; profile is authoritative
+    history: HistoryConfig = Field(default_factory=HistoryConfig)
+
+
+class LookupConfig(BaseModel):
+    """Resolve a column value by querying the destination DB.
+
+    Used to resolve foreign key values when syncing related tables.
+    The destination DB is queried once per lookup to build an in-memory
+    mapping, then each source row is enriched with the resolved value.
+
+    Example YAML::
+
+        lookups:
+          interviewer_profile_id:
+            table: interviewer_profiles
+            match: { user_id: user_id }
+            select: id
+            on_miss: skip
+    """
+
+    table: str  # destination DB table to query
+    match: dict[str, str]  # { destination_column: source_column }
+    select: str | None = None  # column to fetch; omitted when check_only=True
+    on_miss: Literal["skip", "fail", "null"] = "skip"
+    drop_match_columns: bool = True  # remove match source columns from INSERT
+    check_only: bool = False  # filter-only mode: existence check, no value resolution
+
+    @model_validator(mode="after")
+    def _check_match_not_empty(self) -> LookupConfig:
+        if not self.match:
+            raise ValueError("lookups.match must contain at least one mapping.")
+        return self
+
+    @model_validator(mode="after")
+    def _check_select_consistency(self) -> LookupConfig:
+        if self.check_only and self.select is not None:
+            raise ValueError(
+                "lookups.select must be omitted when check_only=True "
+                "(check_only is filter-only — no value is resolved)."
+            )
+        if not self.check_only and self.select is None:
+            raise ValueError(
+                "lookups.select is required (or set check_only=true for existence-only filtering)."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _check_on_miss_consistency(self) -> LookupConfig:
+        if self.check_only and self.on_miss == "null":
+            raise ValueError(
+                "lookups.on_miss='null' is invalid with check_only=True "
+                "(no target column to set NULL on; use 'skip' or 'fail')."
+            )
+        return self
+
+
+class SslConfig(BaseModel):
+    """SSL/TLS connection options for DB destinations."""
+
+    enabled: bool = False
+    ca_env: str | None = None  # env var for CA cert path
+    cert_env: str | None = None  # env var for client cert path
+    key_env: str | None = None
+
+
+class RetryConfig(BaseModel):
+    max_attempts: int = 3
+    initial_backoff: float = 1.0
+    backoff_multiplier: float = 2.0
+    max_backoff: float = 60.0
+    retryable_status_codes: tuple[int, ...] = (429, 500, 502, 503, 504)

--- a/drt/config/destinations_saas.py
+++ b/drt/config/destinations_saas.py
@@ -1,0 +1,479 @@
+"""SaaS / API / messaging destination configs (#721 split from models.py).
+
+Webhook, CRM, marketing, issue-tracker, email and staged-upload destinations.
+All ``*DestinationConfig`` here are members of the
+:data:`~drt.config.sync_options.DestinationConfig` union.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from drt.config.base import AuthConfig, BearerAuth, DescribableConfig, PaginationConfig, RetryConfig
+
+
+class RestApiDestinationConfig(DescribableConfig):
+    type: Literal["rest_api"]
+    url: str
+    method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"] = "POST"
+    headers: dict[str, str] = Field(default_factory=dict)
+    body_template: str | None = None
+    auth: AuthConfig | None = None
+    pagination: PaginationConfig | None = None
+    retry: RetryConfig | None = None  # destination-level override of sync.retry
+
+    def _describe_detail(self) -> str:
+        return f"{self.url}"
+
+
+class SlackDestinationConfig(DescribableConfig):
+    type: Literal["slack"]
+    webhook_url: str | None = None
+    webhook_url_env: str | None = None
+    # Jinja2 template for Slack message. Supports plain text or Block Kit JSON.
+    # Plain text example: "New user: {{ row.name }} ({{ row.email }})"
+    # Block Kit: full JSON payload as template string
+    message_template: str = "{{ row }}"
+    # If True, treat message_template as a Block Kit JSON payload
+    block_kit: bool = False
+    retry: RetryConfig | None = None  # destination-level override of sync.retry
+
+    def _describe_detail(self) -> str:
+        return "webhook"
+
+
+class TwilioDestinationConfig(DescribableConfig):
+    type: Literal["twilio"]
+
+    account_sid: str | None = None
+    account_sid_env: str | None = None
+
+    auth_token: str | None = None
+    auth_token_env: str | None = None
+
+    from_number: str  # Twilio phone number (E.164 format)
+
+    # Jinja2 template → destination phone number
+    to_template: str  # e.g. "{{ row.phone }}"
+
+    # Jinja2 template → SMS body
+    message_template: str
+    retry: RetryConfig | None = None  # destination-level override of sync.retry
+
+    def _describe_detail(self) -> str:
+        return f"{self.from_number}"
+
+    @model_validator(mode="after")
+    def _check_auth(self) -> TwilioDestinationConfig:
+        if not (self.account_sid or self.account_sid_env):
+            raise ValueError("account_sid or account_sid_env is required.")
+        if not (self.auth_token or self.auth_token_env):
+            raise ValueError("auth_token or auth_token_env is required.")
+        return self
+
+
+class DiscordDestinationConfig(DescribableConfig):
+    type: Literal["discord"]
+    webhook_url: str | None = None
+    webhook_url_env: str | None = None
+    # Jinja2 template for Discord message. Supports plain text or embeds JSON.
+    # Plain text example: "New user: {{ row.name }} ({{ row.email }})"
+    # Embeds: full JSON payload with "embeds" array
+    message_template: str = "{{ row }}"
+    # If True, treat message_template as a JSON payload with embeds
+    embeds: bool = False
+    retry: RetryConfig | None = None  # destination-level override of sync.retry
+
+    def _describe_detail(self) -> str:
+        return "webhook"
+
+
+class GitHubActionsDestinationConfig(DescribableConfig):
+    type: Literal["github_actions"]
+    owner: str
+    repo: str
+    workflow_id: str  # filename (e.g. "deploy.yml") or workflow ID
+    ref: str = "main"  # branch/tag to run on
+    # Jinja2 template → JSON object for workflow inputs
+    # Example: '{"environment": "{{ row.env }}", "version": "{{ row.version }}"}'
+    inputs_template: str | None = None
+    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
+    retry: RetryConfig | None = None  # destination-level override of sync.retry
+
+    def _describe_detail(self) -> str:
+        return f"{self.owner}/{self.repo}"
+
+
+class GoogleSheetsDestinationConfig(DescribableConfig):
+    type: Literal["google_sheets"]
+    spreadsheet_id: str
+    sheet: str = "Sheet1"
+    mode: Literal["overwrite", "append"] = "overwrite"
+    credentials_path: str | None = None
+    credentials_env: str | None = None
+
+    def _describe_detail(self) -> str:
+        return f"{self.sheet}"
+
+
+class HubSpotDestinationConfig(DescribableConfig):
+    type: Literal["hubspot"]
+    object_type: Literal["contacts", "deals", "companies"] = "contacts"
+    # Property used as upsert key (contacts → email, deals → dealname, etc.)
+    id_property: str = "email"
+    # Jinja2 template → JSON object of HubSpot properties
+    # Example: '{"email": "{{ row.email }}", "firstname": "{{ row.name }}"}'
+    properties_template: str | None = None
+    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
+    retry: RetryConfig | None = None  # destination-level override of sync.retry
+
+    def _describe_detail(self) -> str:
+        return f"{self.object_type}"
+
+
+class ZendeskDestinationConfig(DescribableConfig):
+    type: Literal["zendesk"]
+    subdomain: str | None = None
+    subdomain_env: str | None = None
+    email: str | None = None
+    email_env: str | None = None
+    api_token: str | None = None
+    api_token_env: str | None = None
+    object: Literal["user", "organization"] = "user"
+    id_field: str | None = None
+    custom_fields_template: str | None = None
+    retry: RetryConfig | None = None  # destination-level override of sync.retry
+
+    def _describe_detail(self) -> str:
+        return f"{self.object}"
+
+
+class AmplitudeDestinationConfig(DescribableConfig):
+    type: Literal["amplitude"]
+    api_key: str | None = None
+    api_key_env: str | None = "AMPLITUDE_API_KEY"
+    region: Literal["default", "eu"] = "default"
+    endpoint: Literal["identify", "event"] = "identify"
+    user_id_field: str = "user_id"
+    device_id_field: str | None = None
+    event_type_field: str | None = None
+    event_type: str | None = None
+    time_field: str | None = None
+    insert_id_field: str | None = None
+    properties_template: str | None = None
+    batch_size: int = 1000
+    min_id_length: int | None = None
+    retry: RetryConfig | None = None
+
+    def _describe_detail(self) -> str:
+        return f"{self.endpoint}, {self.region}"
+
+    @model_validator(mode="after")
+    def _check_api_key(self) -> AmplitudeDestinationConfig:
+        if not self.api_key and not self.api_key_env:
+            raise ValueError("api_key or api_key_env is required.")
+        return self
+
+    @model_validator(mode="after")
+    def _check_event_endpoint(self) -> AmplitudeDestinationConfig:
+        if self.endpoint == "event" and not self.event_type and not self.event_type_field:
+            raise ValueError("event_type or event_type_field is required when endpoint is 'event'.")
+        return self
+
+    @field_validator("batch_size", mode="after")
+    @classmethod
+    def _clamp_batch_size(cls, value: int) -> int:
+        return max(1, min(value, 1000))
+
+
+class AirtableDestinationConfig(BaseModel):
+    type: Literal["airtable"]
+    access_token: str | None = None
+    access_token_env: str | None = "AIRTABLE_TOKEN"
+    base_id: str
+    table_name: str
+    # When set, records are upserted by matching this field (Airtable
+    # performUpsert / fieldsToMergeOn). Omit for append-only.
+    primary_key: str | None = None
+    retry: RetryConfig | None = None
+
+    def describe(self) -> str:
+        return f"airtable ({self.base_id}/{self.table_name})"
+
+    @model_validator(mode="after")
+    def _check_token(self) -> AirtableDestinationConfig:
+        if not self.access_token and not self.access_token_env:
+            raise ValueError("access_token or access_token_env is required.")
+        return self
+
+
+class KlaviyoDestinationConfig(BaseModel):
+    type: Literal["klaviyo"]
+    api_key: str | None = None
+    api_key_env: str | None = "KLAVIYO_API_KEY"
+    # Row field used as the profile identifier (email).
+    email_field: str = "email"
+    # Jinja2 JSON template → custom profile properties. When omitted, all
+    # row fields except email_field are sent as custom properties.
+    properties_template: str | None = None
+    # Optional: add each upserted profile to this Klaviyo list.
+    list_id: str | None = None
+    list_id_env: str | None = None
+    # Klaviyo API revision (sent as the `revision` header).
+    revision: str = "2024-10-15"
+    retry: RetryConfig | None = None
+
+    def describe(self) -> str:
+        return "klaviyo (profiles)"
+
+    @model_validator(mode="after")
+    def _check_api_key(self) -> KlaviyoDestinationConfig:
+        if not self.api_key and not self.api_key_env:
+            raise ValueError("api_key or api_key_env is required.")
+        return self
+
+
+class MixpanelDestinationConfig(DescribableConfig):
+    type: Literal["mixpanel"]
+    # endpoint selects which Mixpanel API to target:
+    #   people_set    -> /engage#profile-set (auth: project token, per-record)
+    #   import_events -> /import             (auth: service account + project_id)
+    endpoint: Literal["people_set", "import_events"] = "people_set"
+    region: Literal["default", "eu"] = "default"
+
+    # people_set auth — project token
+    project_token: str | None = None
+    project_token_env: str | None = "MIXPANEL_TOKEN"
+
+    # import_events auth — service account + numeric project id
+    project_id: str | None = None
+    service_account_username: str | None = None
+    service_account_username_env: str | None = "MIXPANEL_SA_USERNAME"
+    service_account_secret: str | None = None
+    service_account_secret_env: str | None = "MIXPANEL_SA_SECRET"
+
+    # field mapping
+    distinct_id_field: str = "distinct_id"
+    event_name_field: str | None = None  # import_events: per-row event name
+    event_name: str | None = None  # import_events: constant event name
+    time_field: str | None = None  # import_events: row field for event time
+    insert_id_field: str | None = None  # import_events: dedup id (else derived)
+    properties_template: str | None = None
+
+    batch_size: int = 2000
+    retry: RetryConfig | None = None
+
+    def _describe_detail(self) -> str:
+        return f"{self.endpoint}, {self.region}"
+
+    @model_validator(mode="after")
+    def _check_auth(self) -> MixpanelDestinationConfig:
+        if self.endpoint == "people_set":
+            if not self.project_token and not self.project_token_env:
+                raise ValueError(
+                    "project_token or project_token_env is required for endpoint 'people_set'."
+                )
+        else:  # import_events
+            if not self.project_id:
+                raise ValueError("project_id is required for endpoint 'import_events'.")
+            has_user = self.service_account_username or self.service_account_username_env
+            has_secret = self.service_account_secret or self.service_account_secret_env
+            if not has_user or not has_secret:
+                raise ValueError(
+                    "service account credentials (username + secret, or their *_env "
+                    "vars) are required for endpoint 'import_events'."
+                )
+        return self
+
+    @model_validator(mode="after")
+    def _check_event_name(self) -> MixpanelDestinationConfig:
+        if self.endpoint == "import_events" and not self.event_name and not self.event_name_field:
+            raise ValueError(
+                "event_name or event_name_field is required when endpoint is 'import_events'."
+            )
+        return self
+
+    @field_validator("batch_size", mode="after")
+    @classmethod
+    def _clamp_batch_size(cls, value: int) -> int:
+        # Mixpanel caps both /engage and /import at 2000 records per request.
+        return max(1, min(value, 2000))
+
+
+class IntercomDestinationConfig(DescribableConfig):
+    type: Literal["intercom"]
+
+    auth: AuthConfig
+
+    # Jinja2 JSON template for contact payload
+    properties_template: str
+
+    retry: RetryConfig | None = None  # destination-level override of sync.retry
+
+    def _describe_detail(self) -> str:
+        return "contacts"
+
+
+class SendGridDestinationConfig(BaseModel):
+    type: Literal["sendgrid"]
+    from_email: str
+    from_name: str | None = None
+    subject_template: str
+    body_template: str
+    to_email_field: str = "email"
+    list_ids: list[str] | None = None
+    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
+    retry: RetryConfig | None = None  # destination-level override of sync.retry
+
+    def describe(self) -> str:
+        return f"sendgrid ({self.from_email})"
+
+
+class LinearDestinationConfig(BaseModel):
+    type: Literal["linear"]
+    team_id: str | None = None
+    team_id_env: str | None = None
+    title_template: str
+    description_template: str
+    label_ids: list[str] = []
+    assignee_id: str | None = None
+    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
+    retry: RetryConfig | None = None  # destination-level override of sync.retry
+
+    def describe(self) -> str:
+        return "linear (issue)"
+
+
+class TeamsDestinationConfig(DescribableConfig):
+    type: Literal["teams"]
+    webhook_url: str | None = None
+    webhook_url_env: str | None = None
+    # Jinja2 template for the message card. Supports plain text or Adaptive Card JSON.
+    message_template: str = "{{ row }}"
+    # If True, treat message_template as an Adaptive Card JSON payload
+    adaptive_card: bool = False
+    retry: RetryConfig | None = None  # destination-level override of sync.retry
+
+    def _describe_detail(self) -> str:
+        return "webhook"
+
+
+class JiraDestinationConfig(BaseModel):
+    type: Literal["jira"]
+    base_url_env: str  # e.g. JIRA_BASE_URL -> https://myorg.atlassian.net
+    email_env: str  # Jira account email env var
+    token_env: str  # Jira API token env var
+    project_key: str  # can include Jinja2 template syntax
+    issue_type: str = "Task"  # can include Jinja2 template syntax
+    summary_template: str
+    description_template: str
+    issue_id_field: str = "issue_id"  # row key that indicates update mode
+    retry: RetryConfig | None = None  # destination-level override of sync.retry
+
+    def describe(self) -> str:
+        return f"jira ({self.project_key})"
+
+
+class EmailSmtpDestinationConfig(DescribableConfig):
+    type: Literal["email_smtp"] = "email_smtp"
+    host: str
+    port: int = 587
+    sender: str
+    recipients: list[str]
+    subject_template: str
+    body_template: str
+    use_tls: bool = True
+    username: str | None = None
+    username_env: str | None = None
+    password: str | None = None
+    password_env: str | None = None
+
+    def _describe_detail(self) -> str:
+        return f"{self.host}"
+
+
+class NotionDestinationConfig(DescribableConfig):
+    type: Literal["notion"]
+    database_id: str
+    # Jinja2 template → JSON object of Notion page properties
+    # Example: see https://developers.notion.com/reference/post-page for template format
+    properties_template: str | None = None
+    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
+    retry: RetryConfig | None = None  # destination-level override of sync.retry
+
+    def _describe_detail(self) -> str:
+        return f"database {self.database_id}"
+
+
+class GoogleAdsDestinationConfig(BaseModel):
+    type: Literal["google_ads"]
+    customer_id: str  # Google Ads customer ID (without hyphens)
+    conversion_action: str  # e.g. "customers/123/conversionActions/456"
+    gclid_field: str = "gclid"  # row field containing the click ID
+    conversion_time_field: str = "conversion_time"  # row field for timestamp
+    conversion_value_field: str | None = None  # optional: row field for value
+    currency_code: str = "USD"
+    developer_token_env: str = "GOOGLE_ADS_DEVELOPER_TOKEN"
+    auth: AuthConfig | None = None  # typically oauth2_client_credentials
+    retry: RetryConfig | None = None  # destination-level override of sync.retry
+
+    def describe(self) -> str:
+        return f"google_ads ({self.customer_id})"
+
+
+class StagedUploadPhaseConfig(BaseModel):
+    url: str
+    method: str = "POST"
+    headers: dict[str, str] | None = None
+    auth: AuthConfig | None = None
+    body_template: str | None = None
+    response_extract: dict[str, str] | None = None
+
+
+class StagedUploadPollConfig(BaseModel):
+    url: str
+    method: str = "GET"
+    headers: dict[str, str] | None = None
+    auth: AuthConfig | None = None
+    status_field: str = "status"
+    success_values: list[str] = ["SUCCEEDED", "COMPLETED"]
+    failure_values: list[str] = ["FAILED", "ERROR"]
+    interval_seconds: int = 30
+    timeout_seconds: int = 3600
+
+
+class StagedUploadDestinationConfig(BaseModel):
+    type: Literal["staged_upload"]
+    stage: StagedUploadPhaseConfig
+    trigger: StagedUploadPhaseConfig
+    poll: StagedUploadPollConfig | None = None
+    format: Literal["csv", "json", "jsonl"] = "csv"
+
+    def describe(self) -> str:
+        return "staged_upload"
+
+
+class SalesforceBulkDestinationConfig(BaseModel):
+    type: Literal["salesforce_bulk"]
+    instance_url: str | None = None
+    instance_url_env: str | None = None
+    object_name: str  # e.g. "Contact", "Account"
+    operation: Literal["insert", "update", "upsert", "delete"] = "upsert"
+    external_id_field: str = "Id"
+    poll_timeout_seconds: int = 3600
+    poll_interval_seconds: int = 30
+    client_id_env: str
+    client_secret_env: str
+    username_env: str
+    password_env: str
+
+    def describe(self) -> str:
+        return f"salesforce_bulk ({self.object_name})"
+
+    @model_validator(mode="after")
+    def _check_instance_url(self) -> SalesforceBulkDestinationConfig:
+        if not self.instance_url and not self.instance_url_env:
+            raise ValueError("Either instance_url or instance_url_env is required.")
+        return self

--- a/drt/config/destinations_sql.py
+++ b/drt/config/destinations_sql.py
@@ -1,0 +1,275 @@
+"""SQL / warehouse destination configs (#721 split from models.py).
+
+Postgres / MySQL / ClickHouse share :class:`BaseSqlDestinationConfig`;
+Snowflake / Databricks / BigQuery / Elasticsearch stand alone. All are members
+of the :data:`~drt.config.sync_options.DestinationConfig` union.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field, model_validator
+
+from drt.config.base import DescribableConfig, LookupConfig, RetryConfig, SslConfig
+
+
+class SnowflakeDestinationConfig(DescribableConfig):
+    type: Literal["snowflake"]
+
+    account_env: str
+    user_env: str
+    # Auth: either a password or an RSA private key (#737). Key-pair is the
+    # path for ``TYPE = SERVICE`` users — new Snowflake accounts enforce MFA
+    # on password sign-ins, so programmatic identities should migrate to a
+    # SERVICE user + key pair. ``private_key_env`` names an env var holding
+    # the PEM (PKCS#8) private key *contents*; it takes precedence over
+    # ``password_env`` when both are set.
+    password_env: str | None = None
+    private_key_env: str | None = None
+    private_key_passphrase_env: str | None = None
+
+    database: str
+    # Use alias because BaseModel.schema() shadows a plain `schema` attribute
+    # under mypy strict mode; YAML key stays `schema:`.
+    schema_: str = Field(alias="schema")
+    table: str
+
+    warehouse: str
+
+    mode: Literal["insert", "merge"] = "insert"
+
+    upsert_key: list[str] | None = None
+
+    # FK resolution against the destination (#316/#354 lookup pattern,
+    # extended to Snowflake in #468). Also makes Snowflake queryable, so
+    # `drt run --dry-run --diff` produces a true diff and `drt test`
+    # validation queries run against the target table.
+    lookups: dict[str, LookupConfig] | None = None
+
+    # Layer 3 (#317): introspect INFORMATION_SCHEMA once per sync to wrap
+    # VARIANT/OBJECT/ARRAY columns with PARSE_JSON (so dict/list values land as
+    # proper semi-structured data, not a stringified repr). On by default; set
+    # false for roles without read access to information_schema.
+    introspect_schema: bool = True
+
+    @model_validator(mode="after")
+    def _check_auth(self) -> SnowflakeDestinationConfig:
+        if not self.password_env and not self.private_key_env:
+            raise ValueError(
+                "snowflake destination needs private_key_env (key-pair auth, "
+                "preferred) or password_env."
+            )
+        return self
+
+    def _describe_detail(self) -> str:
+        return f"{self.database}.{self.schema_}.{self.table}"
+
+
+class BigQueryDestinationConfig(DescribableConfig):
+    """BigQuery destination — write data back to BigQuery tables.
+
+    Auth mirrors the BigQuery source: Application Default Credentials by
+    default, or a service-account ``keyfile``. The principal needs
+    ``bigquery.tables.updateData`` on the target (plus ``bigquery.tables.create``
+    / ``bigquery.jobs.create`` for the merge-path temp table).
+    """
+
+    type: Literal["bigquery"]
+
+    project: str
+    dataset: str
+    table: str
+    location: str | None = None
+
+    mode: Literal["insert", "merge"] = "insert"
+    upsert_key: list[str] | None = None
+
+    # Auth — same convention as the BigQuery source (sources/bigquery.py).
+    method: Literal["application_default", "keyfile"] = "application_default"
+    keyfile: str | None = None
+
+    def _describe_detail(self) -> str:
+        return f"{self.project}.{self.dataset}.{self.table}"
+
+
+class DatabricksDestinationConfig(DescribableConfig):
+    """Databricks Delta Lake destination — write data back to Databricks tables.
+
+    Auth via the Databricks SQL Connector: a SQL warehouse HTTP path
+    plus a personal access token (PAT). The token-bearing user needs
+    USAGE on the catalog + schema and INSERT/MODIFY on the target
+    table.
+    """
+
+    type: Literal["databricks"]
+
+    # Workspace hostname (env-var resolved), e.g.
+    # ``dbc-abc12345-1234.cloud.databricks.com``.
+    host_env: str
+    # SQL warehouse HTTP path (env-var resolved), e.g.
+    # ``/sql/1.0/warehouses/abc123def456``.
+    http_path_env: str
+    # Databricks personal access token (env-var resolved). Starts with ``dapi``.
+    token_env: str
+
+    # Three-part name (Unity Catalog). For Hive Metastore deployments
+    # use catalog="hive_metastore".
+    catalog: str
+    # Field alias because BaseModel.schema() shadows a plain `schema`
+    # attribute under mypy strict mode; YAML key stays `schema:`.
+    schema_: str = Field(alias="schema")
+    table: str
+
+    mode: Literal["insert", "merge"] = "insert"
+
+    # Required for merge mode and for ``sync.mode: mirror``. Composite
+    # keys supported (`upsert_key: [tenant_id, user_id]`).
+    upsert_key: list[str] | None = None
+
+    # Layer 3 (#317): introspect information_schema once per sync to wrap
+    # STRUCT/MAP/ARRAY columns with from_json (and VARIANT with parse_json), so
+    # dict/list values land as proper complex types, not a stringified repr. On
+    # by default; set false for roles without read access to information_schema.
+    introspect_schema: bool = True
+
+    def _describe_detail(self) -> str:
+        return f"{self.catalog}.{self.schema_}.{self.table}"
+
+
+class ElasticsearchDestinationConfig(DescribableConfig):
+    """Elasticsearch / OpenSearch destination — bulk-index records via the ``_bulk`` API."""
+
+    type: Literal["elasticsearch"]
+    url: str  # cluster base URL, e.g. https://localhost:9200
+    index: str  # target index name
+    # Row field whose value becomes the document _id. None → the cluster
+    # auto-generates ids (only valid with op_type="index"/"create" where
+    # create without an id always inserts).
+    id_field: str | None = None
+    # "index" upserts (replace-if-exists); "create" fails the row if the
+    # _id already exists (409). OpenSearch shares the same API surface.
+    op_type: Literal["index", "create"] = "index"
+    # Auth — provide an API key (direct or env) OR HTTP Basic creds (env):
+    api_key: str | None = None
+    api_key_env: str | None = None
+    username_env: str | None = None
+    password_env: str | None = None
+    # TLS verification. Set False for self-signed dev clusters (local
+    # OpenSearch / Elasticsearch with the bundled cert).
+    verify_tls: bool = True
+    retry: RetryConfig | None = None  # destination-level override of sync.retry
+
+    def _describe_detail(self) -> str:
+        return f"{self.index}"
+
+
+class BaseSqlDestinationConfig(DescribableConfig):
+    """Shared connection fields for host-based SQL destinations.
+
+    Postgres, MySQL, and ClickHouse all expose the same connection
+    surface (``host`` / ``host_env`` + credentials + a connection-string
+    escape hatch) plus a lookups field for FK resolution. The
+    destination-specific bits (``dbname`` vs ``database`` field name,
+    ``ssl`` vs ``secure``, port defaults, ``json_columns`` applicability,
+    ``upsert_key`` typing) stay on the concrete subclasses where they
+    differ in name or semantics.
+
+    Subclasses keep their own ``_check_connection`` model_validator
+    because the database field name differs across dialects; sharing the
+    validator would require a ClassVar lookup that obscures the simple
+    "host + dbname required unless connection_string_env" rule.
+
+    New host-based SQL destinations (Redshift, future Vertica/CockroachDB)
+    should inherit from this class and override ``port`` for the default
+    wire port; see ``MySQLDestinationConfig`` / ``ClickHouseDestinationConfig``
+    for examples.
+    """
+
+    connection_string_env: str | None = None
+    host: str | None = None
+    host_env: str | None = None
+    port: int = 5432  # Postgres default; subclasses override
+    user: str | None = None
+    user_env: str | None = None
+    password: str | None = None
+    password_env: str | None = None
+    lookups: dict[str, LookupConfig] | None = None
+    # Layer 3 (#317): introspect INFORMATION_SCHEMA once per sync to route
+    # dict/list values by the column's real type (no json_columns needed).
+    # On by default; set false for locked-down environments without read
+    # access to information_schema. Explicit json_columns always takes priority.
+    introspect_schema: bool = True
+
+
+class PostgresDestinationConfig(BaseSqlDestinationConfig):
+    type: Literal["postgres"]
+    dbname: str | None = None
+    dbname_env: str | None = None
+    table: str  # e.g. "public.analytics_scores"
+    upsert_key: list[str]  # columns for ON CONFLICT
+    ssl: SslConfig | None = None
+    json_columns: list[str] | None = None  # columns that hold JSON/JSONB data
+
+    def _describe_detail(self) -> str:
+        return f"{self.table}"
+
+    @model_validator(mode="after")
+    def _check_connection(self) -> PostgresDestinationConfig:
+        if self.connection_string_env:
+            return self  # connection string takes precedence
+        if not self.host and not self.host_env:
+            raise ValueError("Either host, host_env, or connection_string_env is required.")
+        if not self.dbname and not self.dbname_env:
+            raise ValueError("Either dbname, dbname_env, or connection_string_env is required.")
+        return self
+
+
+class MySQLDestinationConfig(BaseSqlDestinationConfig):
+    type: Literal["mysql"]
+    port: int = 3306  # MySQL default
+    dbname: str | None = None
+    dbname_env: str | None = None
+    table: str  # e.g. "interviewer_learning_profiles"
+    upsert_key: list[str]  # columns for ON DUPLICATE KEY
+    ssl: SslConfig | None = None
+    json_columns: list[str] | None = None  # columns that hold JSON data
+
+    def _describe_detail(self) -> str:
+        return f"{self.table}"
+
+    @model_validator(mode="after")
+    def _check_connection(self) -> MySQLDestinationConfig:
+        if self.connection_string_env:
+            return self  # connection string takes precedence
+        if not self.host and not self.host_env:
+            raise ValueError("Either host, host_env, or connection_string_env is required.")
+        if not self.dbname and not self.dbname_env:
+            raise ValueError("Either dbname, dbname_env, or connection_string_env is required.")
+        return self
+
+
+class ClickHouseDestinationConfig(BaseSqlDestinationConfig):
+    type: Literal["clickhouse"]
+    port: int = 8123  # ClickHouse HTTP interface; use 8443 for HTTPS
+    database: str | None = None
+    database_env: str | None = None
+    table: str  # unqualified table name (database set via database/database_env)
+
+    # Informational only for ClickHouse. drt does not enforce/create
+    # ReplacingMergeTree tables or apply upsert semantics from this field.
+    upsert_key: list[str] | None = None
+    secure: bool = False  # use HTTPS/TLS; set port explicitly for your deployment (commonly 8443)
+
+    def _describe_detail(self) -> str:
+        return f"{self.table}"
+
+    @model_validator(mode="after")
+    def _check_connection(self) -> ClickHouseDestinationConfig:
+        if self.connection_string_env:
+            return self  # connection string takes precedence
+        if not self.host and not self.host_env:
+            raise ValueError("Either host, host_env, or connection_string_env is required.")
+        if not self.database and not self.database_env:
+            raise ValueError("Either database, database_env, or connection_string_env is required.")
+        return self

--- a/drt/config/destinations_storage.py
+++ b/drt/config/destinations_storage.py
@@ -1,0 +1,134 @@
+"""Object-store / file destination configs (#721 split from models.py).
+
+S3 / GCS / Azure Blob object stores plus local Parquet / File writers. All are
+members of the :data:`~drt.config.sync_options.DestinationConfig` union.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from drt.config.base import DescribableConfig
+
+
+class ParquetDestinationConfig(DescribableConfig):
+    type: Literal["parquet"]
+    path: str  # output file or directory path, e.g. "output/data.parquet"
+    partition_by: list[str] | None = None  # optional partition columns
+    compression: Literal["snappy", "gzip", "zstd", "none"] = "snappy"
+
+    def _describe_detail(self) -> str:
+        return f"{self.path}"
+
+
+class FileDestinationConfig(DescribableConfig):
+    type: Literal["file"]
+    path: str  # output file path, e.g. "output/data.csv"
+    format: Literal["csv", "json", "jsonl"] = "csv"
+
+    def _describe_detail(self) -> str:
+        return f"{self.path}"
+
+
+class S3DestinationConfig(DescribableConfig):
+    """S3 destination — upload records as CSV / JSON / JSONL / Parquet to S3."""
+
+    type: Literal["s3"]
+    bucket: str
+    # Optional key prefix. The generated file name is appended to this prefix:
+    # e.g. prefix="drt/users/" → "drt/users/20260605T123000Z.csv". For
+    # per-sync routing, give each sync its own prefix.
+    prefix: str = ""
+    format: Literal["csv", "json", "jsonl", "parquet"] = "csv"
+    # gzip-compress csv / json / jsonl uploads ("none" disables). Parquet
+    # uses its native compression below; "gzip" here is ignored for parquet.
+    compression: Literal["none", "gzip"] = "none"
+    # Optional Parquet-specific compression (matches ParquetDestinationConfig).
+    parquet_compression: Literal["snappy", "gzip", "zstd", "none"] = "snappy"
+    region: str | None = None  # AWS region; defers to boto3 default if unset
+    # AWS auth: by default, falls back to boto3's standard credential chain
+    # (env vars, ~/.aws/credentials, instance profile, IAM role). Provide one
+    # of the following for explicit overrides:
+    aws_profile: str | None = None  # named profile in ~/.aws/credentials
+    aws_access_key_id_env: str | None = None
+    aws_secret_access_key_env: str | None = None
+    aws_session_token_env: str | None = None
+    # Optional endpoint URL — set when targeting an S3-compatible service
+    # (MinIO, LocalStack, R2, etc.). None → real AWS S3.
+    endpoint_url: str | None = None
+    # Optional file-name template (Jinja2-free, supports one placeholder:
+    # {timestamp} — UTC ISO 8601 basic format, e.g. "20260605T123000Z").
+    # Default produces "<prefix><timestamp>.<ext>". For per-sync naming,
+    # set ``prefix`` per sync (e.g. ``prefix: drt/active_users/``).
+    key_template: str | None = None
+
+    def _describe_detail(self) -> str:
+        return f"s3://{self.bucket}/{self.prefix}"
+
+
+class GCSDestinationConfig(DescribableConfig):
+    """GCS destination — upload records as CSV / JSON / JSONL / Parquet to Google Cloud Storage."""
+
+    type: Literal["gcs"]
+    bucket: str
+    # Optional object-name prefix. The generated file name is appended:
+    # e.g. prefix="drt/users/" → "drt/users/20260605T123000Z.csv". For
+    # per-sync routing, give each sync its own prefix.
+    prefix: str = ""
+    format: Literal["csv", "json", "jsonl", "parquet"] = "csv"
+    # gzip-compress csv / json / jsonl uploads ("none" disables). Parquet
+    # uses its native compression below; "gzip" here is ignored for parquet.
+    compression: Literal["none", "gzip"] = "none"
+    # Optional Parquet-specific compression (matches ParquetDestinationConfig).
+    parquet_compression: Literal["snappy", "gzip", "zstd", "none"] = "snappy"
+    # GCP project to bill / scope the client to. Optional — the credentials
+    # file usually carries one, and ADC will use the project from
+    # ``gcloud config get-value project`` if neither is set.
+    project_id: str | None = None
+    # GCS auth: by default, falls back to Application Default Credentials
+    # (GOOGLE_APPLICATION_CREDENTIALS env → gcloud
+    # application-default → GCE/GKE/Cloud Run service account). For
+    # explicit overrides, point at a service-account JSON keyfile:
+    credentials_path: str | None = None
+    # Optional file-name template (Jinja2-free, supports one placeholder:
+    # {timestamp} — UTC ISO 8601 basic format, e.g. "20260605T123000Z").
+    # Default produces "<prefix><timestamp>.<ext>". For per-sync naming,
+    # set ``prefix`` per sync (e.g. ``prefix: drt/active_users/``).
+    key_template: str | None = None
+
+    def _describe_detail(self) -> str:
+        return f"gs://{self.bucket}/{self.prefix}"
+
+
+class AzureBlobDestinationConfig(DescribableConfig):
+    """Azure Blob destination — upload records as CSV / JSON / JSONL / Parquet."""
+
+    type: Literal["azure_blob"]
+    container: str
+    # Optional blob-name prefix. The generated file name is appended:
+    # e.g. prefix="drt/users/" → "drt/users/20260605T123000Z.csv". For
+    # per-sync routing, give each sync its own prefix.
+    prefix: str = ""
+    format: Literal["csv", "json", "jsonl", "parquet"] = "csv"
+    # gzip-compress csv / json / jsonl uploads ("none" disables). Parquet
+    # uses its native compression below; "gzip" here is ignored for parquet.
+    compression: Literal["none", "gzip"] = "none"
+    # Optional Parquet-specific compression (matches ParquetDestinationConfig).
+    parquet_compression: Literal["snappy", "gzip", "zstd", "none"] = "snappy"
+    # Auth path 1: env-var name holding a storage-account connection
+    # string (DefaultEndpointsProtocol=...). Most common shape for
+    # non-Azure CI / cron deployments.
+    connection_string_env: str | None = None
+    # Auth path 2: storage account blob endpoint
+    # (https://<account>.blob.core.windows.net) — when set without
+    # connection_string_env, DefaultAzureCredential is used (env vars,
+    # managed identity, Azure CLI, ...).
+    account_url: str | None = None
+    # Optional file-name template (Jinja2-free, supports one placeholder:
+    # {timestamp} — UTC ISO 8601 basic format, e.g. "20260605T123000Z").
+    # Default produces "<prefix><timestamp>.<ext>". For per-sync naming,
+    # set ``prefix`` per sync (e.g. ``prefix: drt/active_users/``).
+    key_template: str | None = None
+
+    def _describe_detail(self) -> str:
+        return f"{self.container}/{self.prefix}"

--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -1,1397 +1,173 @@
-"""Pydantic models for drt project and sync configuration."""
+"""Pydantic models for drt project and sync configuration.
+
+Phase 1 of #721 split this formerly ~1300-line module into cohesive submodules
+(:mod:`~drt.config.base`, :mod:`~drt.config.destinations_sql`,
+:mod:`~drt.config.destinations_saas`, :mod:`~drt.config.destinations_storage`,
+:mod:`~drt.config.sync_options`). This module re-exports the full public surface
+so every ``from drt.config.models import X`` keeps working unchanged.
+
+``__all__`` below IS that public surface and is **required**: under mypy strict
+``no_implicit_reexport`` a merely re-imported name is not considered exported,
+so single-file type-checking would pass while the 135 import sites fail. Keep
+``__all__`` in sync when adding or removing a config name.
+"""
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from drt.config.base import (
+    ApiKeyAuth,
+    AuthConfig,
+    BasicAuth,
+    BearerAuth,
+    CursorPaginationConfig,
+    HistoryConfig,
+    LinkHeaderPaginationConfig,
+    LookupConfig,
+    OAuth2ClientCredentialsAuth,
+    OffsetPaginationConfig,
+    PaginationConfig,
+    ProjectConfig,
+    RestIncrementalConfig,
+    RetryConfig,
+    SourceConfig,
+    SslConfig,
+)
+from drt.config.destinations_saas import (
+    AirtableDestinationConfig,
+    AmplitudeDestinationConfig,
+    DiscordDestinationConfig,
+    EmailSmtpDestinationConfig,
+    GitHubActionsDestinationConfig,
+    GoogleAdsDestinationConfig,
+    GoogleSheetsDestinationConfig,
+    HubSpotDestinationConfig,
+    IntercomDestinationConfig,
+    JiraDestinationConfig,
+    KlaviyoDestinationConfig,
+    LinearDestinationConfig,
+    MixpanelDestinationConfig,
+    NotionDestinationConfig,
+    RestApiDestinationConfig,
+    SalesforceBulkDestinationConfig,
+    SendGridDestinationConfig,
+    SlackDestinationConfig,
+    StagedUploadDestinationConfig,
+    StagedUploadPhaseConfig,
+    StagedUploadPollConfig,
+    TeamsDestinationConfig,
+    TwilioDestinationConfig,
+    ZendeskDestinationConfig,
+)
+from drt.config.destinations_sql import (
+    BaseSqlDestinationConfig,
+    BigQueryDestinationConfig,
+    ClickHouseDestinationConfig,
+    DatabricksDestinationConfig,
+    ElasticsearchDestinationConfig,
+    MySQLDestinationConfig,
+    PostgresDestinationConfig,
+    SnowflakeDestinationConfig,
+)
+from drt.config.destinations_storage import (
+    AzureBlobDestinationConfig,
+    FileDestinationConfig,
+    GCSDestinationConfig,
+    ParquetDestinationConfig,
+    S3DestinationConfig,
+)
+from drt.config.sync_options import (
+    AcceptedValuesTest,
+    AlertItem,
+    AlertsConfig,
+    DestinationConfig,
+    DLQConfig,
+    FreshnessTest,
+    MaskRule,
+    MaskSpec,
+    MirrorConfig,
+    NotNullTest,
+    RateLimitConfig,
+    RowCountTest,
+    SlackAlertConfig,
+    SyncConfig,
+    SyncOptions,
+    SyncTest,
+    UniqueTest,
+    WatermarkConfig,
+    WebhookAlertConfig,
+)
 
-from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
-
-from drt.config.duration import parse_duration
-
-# ---------------------------------------------------------------------------
-# Auth (shared across destination types)
-# ---------------------------------------------------------------------------
-
-
-class BearerAuth(BaseModel):
-    type: Literal["bearer"]
-    token: str | None = None
-    token_env: str | None = None
-
-
-class ApiKeyAuth(BaseModel):
-    type: Literal["api_key"]
-    header: str = "X-API-Key"
-    value: str | None = None
-    value_env: str | None = None
-
-
-class BasicAuth(BaseModel):
-    type: Literal["basic"]
-    username_env: str
-    password_env: str
-
-
-class OAuth2ClientCredentialsAuth(BaseModel):
-    type: Literal["oauth2_client_credentials"]
-    token_url: str
-    client_id_env: str
-    client_secret_env: str
-    scope: str | None = None
-
-
-AuthConfig = Annotated[
-    BearerAuth | ApiKeyAuth | BasicAuth | OAuth2ClientCredentialsAuth,
-    Field(discriminator="type"),
+__all__ = [
+    "AcceptedValuesTest",
+    "AirtableDestinationConfig",
+    "AlertItem",
+    "AlertsConfig",
+    "AmplitudeDestinationConfig",
+    "ApiKeyAuth",
+    "AuthConfig",
+    "AzureBlobDestinationConfig",
+    "BaseSqlDestinationConfig",
+    "BasicAuth",
+    "BearerAuth",
+    "BigQueryDestinationConfig",
+    "ClickHouseDestinationConfig",
+    "CursorPaginationConfig",
+    "DLQConfig",
+    "DatabricksDestinationConfig",
+    "DestinationConfig",
+    "DiscordDestinationConfig",
+    "ElasticsearchDestinationConfig",
+    "EmailSmtpDestinationConfig",
+    "FileDestinationConfig",
+    "FreshnessTest",
+    "GCSDestinationConfig",
+    "GitHubActionsDestinationConfig",
+    "GoogleAdsDestinationConfig",
+    "GoogleSheetsDestinationConfig",
+    "HistoryConfig",
+    "HubSpotDestinationConfig",
+    "IntercomDestinationConfig",
+    "JiraDestinationConfig",
+    "KlaviyoDestinationConfig",
+    "LinearDestinationConfig",
+    "LinkHeaderPaginationConfig",
+    "LookupConfig",
+    "MaskRule",
+    "MaskSpec",
+    "MirrorConfig",
+    "MixpanelDestinationConfig",
+    "MySQLDestinationConfig",
+    "NotNullTest",
+    "NotionDestinationConfig",
+    "OAuth2ClientCredentialsAuth",
+    "OffsetPaginationConfig",
+    "PaginationConfig",
+    "ParquetDestinationConfig",
+    "PostgresDestinationConfig",
+    "ProjectConfig",
+    "RateLimitConfig",
+    "RestApiDestinationConfig",
+    "RestIncrementalConfig",
+    "RetryConfig",
+    "RowCountTest",
+    "S3DestinationConfig",
+    "SalesforceBulkDestinationConfig",
+    "SendGridDestinationConfig",
+    "SlackAlertConfig",
+    "SlackDestinationConfig",
+    "SnowflakeDestinationConfig",
+    "SourceConfig",
+    "SslConfig",
+    "StagedUploadDestinationConfig",
+    "StagedUploadPhaseConfig",
+    "StagedUploadPollConfig",
+    "SyncConfig",
+    "SyncOptions",
+    "SyncTest",
+    "TeamsDestinationConfig",
+    "TwilioDestinationConfig",
+    "UniqueTest",
+    "WatermarkConfig",
+    "WebhookAlertConfig",
+    "ZendeskDestinationConfig",
 ]
-
-
-# ---------------------------------------------------------------------------
-# Pagination (REST API destination)
-# ---------------------------------------------------------------------------
-
-
-class OffsetPaginationConfig(BaseModel):
-    type: Literal["offset"]
-    limit: int = 100
-    offset_param: str = "offset"
-    limit_param: str = "limit"
-    max_pages: int = 100
-
-
-class CursorPaginationConfig(BaseModel):
-    type: Literal["cursor"]
-    limit: int = 100
-    cursor_param: str = "cursor"
-    limit_param: str = "limit"
-    cursor_field: str
-    max_pages: int = 100
-
-
-class LinkHeaderPaginationConfig(BaseModel):
-    type: Literal["link_header"]
-    max_pages: int = 100
-
-
-PaginationConfig = Annotated[
-    OffsetPaginationConfig | CursorPaginationConfig | LinkHeaderPaginationConfig,
-    Field(discriminator="type"),
-]
-
-
-class RestIncrementalConfig(BaseModel):
-    """Incremental extraction for the REST API source (#767).
-
-    ``start_param`` names the request query parameter that receives the last
-    watermark value (e.g. ``updated_since``). Cursor *tracking* stays
-    engine-side: ``sync.cursor_field`` names the record field whose max value
-    is persisted after each run — this config only tells the source where to
-    put that value on the request.
-    """
-
-    start_param: str
-
-
-# ---------------------------------------------------------------------------
-# Source config (inline — kept for backward compat; prefer profiles.yml)
-# ---------------------------------------------------------------------------
-
-
-class SourceConfig(BaseModel):
-    type: Literal["bigquery", "snowflake", "postgres", "duckdb", "clickhouse"]
-    project: str | None = None
-    dataset: str | None = None
-    credentials: str | None = None
-
-
-# ---------------------------------------------------------------------------
-# Project
-# ---------------------------------------------------------------------------
-
-
-class HistoryConfig(BaseModel):
-    """Sync execution history retention (#276)."""
-
-    enabled: bool = True
-    retention_days: int = 30
-    # Future: max_entries, storage backend (sqlite), s3 upload, etc.
-
-
-class ProjectConfig(BaseModel):
-    name: str
-    version: str = "0.1"
-    profile: str = "default"
-    source: SourceConfig | None = None  # optional; profile is authoritative
-    history: HistoryConfig = Field(default_factory=HistoryConfig)
-
-
-# ---------------------------------------------------------------------------
-# Destination configs — discriminated union
-# ---------------------------------------------------------------------------
-
-
-class RestApiDestinationConfig(BaseModel):
-    type: Literal["rest_api"]
-    url: str
-    method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"] = "POST"
-    headers: dict[str, str] = Field(default_factory=dict)
-    body_template: str | None = None
-    auth: AuthConfig | None = None
-    pagination: PaginationConfig | None = None
-    retry: RetryConfig | None = None  # destination-level override of sync.retry
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.url})"
-
-
-class SlackDestinationConfig(BaseModel):
-    type: Literal["slack"]
-    webhook_url: str | None = None
-    webhook_url_env: str | None = None
-    # Jinja2 template for Slack message. Supports plain text or Block Kit JSON.
-    # Plain text example: "New user: {{ row.name }} ({{ row.email }})"
-    # Block Kit: full JSON payload as template string
-    message_template: str = "{{ row }}"
-    # If True, treat message_template as a Block Kit JSON payload
-    block_kit: bool = False
-    retry: RetryConfig | None = None  # destination-level override of sync.retry
-
-    def describe(self) -> str:
-        return f"{self.type} (webhook)"
-
-
-class TwilioDestinationConfig(BaseModel):
-    type: Literal["twilio"]
-
-    account_sid: str | None = None
-    account_sid_env: str | None = None
-
-    auth_token: str | None = None
-    auth_token_env: str | None = None
-
-    from_number: str  # Twilio phone number (E.164 format)
-
-    # Jinja2 template → destination phone number
-    to_template: str  # e.g. "{{ row.phone }}"
-
-    # Jinja2 template → SMS body
-    message_template: str
-    retry: RetryConfig | None = None  # destination-level override of sync.retry
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.from_number})"
-
-    @model_validator(mode="after")
-    def _check_auth(self) -> TwilioDestinationConfig:
-        if not (self.account_sid or self.account_sid_env):
-            raise ValueError("account_sid or account_sid_env is required.")
-        if not (self.auth_token or self.auth_token_env):
-            raise ValueError("auth_token or auth_token_env is required.")
-        return self
-
-
-class DiscordDestinationConfig(BaseModel):
-    type: Literal["discord"]
-    webhook_url: str | None = None
-    webhook_url_env: str | None = None
-    # Jinja2 template for Discord message. Supports plain text or embeds JSON.
-    # Plain text example: "New user: {{ row.name }} ({{ row.email }})"
-    # Embeds: full JSON payload with "embeds" array
-    message_template: str = "{{ row }}"
-    # If True, treat message_template as a JSON payload with embeds
-    embeds: bool = False
-    retry: RetryConfig | None = None  # destination-level override of sync.retry
-
-    def describe(self) -> str:
-        return f"{self.type} (webhook)"
-
-
-class GitHubActionsDestinationConfig(BaseModel):
-    type: Literal["github_actions"]
-    owner: str
-    repo: str
-    workflow_id: str  # filename (e.g. "deploy.yml") or workflow ID
-    ref: str = "main"  # branch/tag to run on
-    # Jinja2 template → JSON object for workflow inputs
-    # Example: '{"environment": "{{ row.env }}", "version": "{{ row.version }}"}'
-    inputs_template: str | None = None
-    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
-    retry: RetryConfig | None = None  # destination-level override of sync.retry
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.owner}/{self.repo})"
-
-
-class GoogleSheetsDestinationConfig(BaseModel):
-    type: Literal["google_sheets"]
-    spreadsheet_id: str
-    sheet: str = "Sheet1"
-    mode: Literal["overwrite", "append"] = "overwrite"
-    credentials_path: str | None = None
-    credentials_env: str | None = None
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.sheet})"
-
-
-class HubSpotDestinationConfig(BaseModel):
-    type: Literal["hubspot"]
-    object_type: Literal["contacts", "deals", "companies"] = "contacts"
-    # Property used as upsert key (contacts → email, deals → dealname, etc.)
-    id_property: str = "email"
-    # Jinja2 template → JSON object of HubSpot properties
-    # Example: '{"email": "{{ row.email }}", "firstname": "{{ row.name }}"}'
-    properties_template: str | None = None
-    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
-    retry: RetryConfig | None = None  # destination-level override of sync.retry
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.object_type})"
-
-
-class ZendeskDestinationConfig(BaseModel):
-    type: Literal["zendesk"]
-    subdomain: str | None = None
-    subdomain_env: str | None = None
-    email: str | None = None
-    email_env: str | None = None
-    api_token: str | None = None
-    api_token_env: str | None = None
-    object: Literal["user", "organization"] = "user"
-    id_field: str | None = None
-    custom_fields_template: str | None = None
-    retry: RetryConfig | None = None  # destination-level override of sync.retry
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.object})"
-
-
-class AmplitudeDestinationConfig(BaseModel):
-    type: Literal["amplitude"]
-    api_key: str | None = None
-    api_key_env: str | None = "AMPLITUDE_API_KEY"
-    region: Literal["default", "eu"] = "default"
-    endpoint: Literal["identify", "event"] = "identify"
-    user_id_field: str = "user_id"
-    device_id_field: str | None = None
-    event_type_field: str | None = None
-    event_type: str | None = None
-    time_field: str | None = None
-    insert_id_field: str | None = None
-    properties_template: str | None = None
-    batch_size: int = 1000
-    min_id_length: int | None = None
-    retry: RetryConfig | None = None
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.endpoint}, {self.region})"
-
-    @model_validator(mode="after")
-    def _check_api_key(self) -> AmplitudeDestinationConfig:
-        if not self.api_key and not self.api_key_env:
-            raise ValueError("api_key or api_key_env is required.")
-        return self
-
-    @model_validator(mode="after")
-    def _check_event_endpoint(self) -> AmplitudeDestinationConfig:
-        if self.endpoint == "event" and not self.event_type and not self.event_type_field:
-            raise ValueError("event_type or event_type_field is required when endpoint is 'event'.")
-        return self
-
-    @field_validator("batch_size", mode="after")
-    @classmethod
-    def _clamp_batch_size(cls, value: int) -> int:
-        return max(1, min(value, 1000))
-
-
-class AirtableDestinationConfig(BaseModel):
-    type: Literal["airtable"]
-    access_token: str | None = None
-    access_token_env: str | None = "AIRTABLE_TOKEN"
-    base_id: str
-    table_name: str
-    # When set, records are upserted by matching this field (Airtable
-    # performUpsert / fieldsToMergeOn). Omit for append-only.
-    primary_key: str | None = None
-    retry: RetryConfig | None = None
-
-    def describe(self) -> str:
-        return f"airtable ({self.base_id}/{self.table_name})"
-
-    @model_validator(mode="after")
-    def _check_token(self) -> AirtableDestinationConfig:
-        if not self.access_token and not self.access_token_env:
-            raise ValueError("access_token or access_token_env is required.")
-        return self
-
-
-class KlaviyoDestinationConfig(BaseModel):
-    type: Literal["klaviyo"]
-    api_key: str | None = None
-    api_key_env: str | None = "KLAVIYO_API_KEY"
-    # Row field used as the profile identifier (email).
-    email_field: str = "email"
-    # Jinja2 JSON template → custom profile properties. When omitted, all
-    # row fields except email_field are sent as custom properties.
-    properties_template: str | None = None
-    # Optional: add each upserted profile to this Klaviyo list.
-    list_id: str | None = None
-    list_id_env: str | None = None
-    # Klaviyo API revision (sent as the `revision` header).
-    revision: str = "2024-10-15"
-    retry: RetryConfig | None = None
-
-    def describe(self) -> str:
-        return "klaviyo (profiles)"
-
-    @model_validator(mode="after")
-    def _check_api_key(self) -> KlaviyoDestinationConfig:
-        if not self.api_key and not self.api_key_env:
-            raise ValueError("api_key or api_key_env is required.")
-        return self
-
-
-class MixpanelDestinationConfig(BaseModel):
-    type: Literal["mixpanel"]
-    # endpoint selects which Mixpanel API to target:
-    #   people_set    -> /engage#profile-set (auth: project token, per-record)
-    #   import_events -> /import             (auth: service account + project_id)
-    endpoint: Literal["people_set", "import_events"] = "people_set"
-    region: Literal["default", "eu"] = "default"
-
-    # people_set auth — project token
-    project_token: str | None = None
-    project_token_env: str | None = "MIXPANEL_TOKEN"
-
-    # import_events auth — service account + numeric project id
-    project_id: str | None = None
-    service_account_username: str | None = None
-    service_account_username_env: str | None = "MIXPANEL_SA_USERNAME"
-    service_account_secret: str | None = None
-    service_account_secret_env: str | None = "MIXPANEL_SA_SECRET"
-
-    # field mapping
-    distinct_id_field: str = "distinct_id"
-    event_name_field: str | None = None  # import_events: per-row event name
-    event_name: str | None = None  # import_events: constant event name
-    time_field: str | None = None  # import_events: row field for event time
-    insert_id_field: str | None = None  # import_events: dedup id (else derived)
-    properties_template: str | None = None
-
-    batch_size: int = 2000
-    retry: RetryConfig | None = None
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.endpoint}, {self.region})"
-
-    @model_validator(mode="after")
-    def _check_auth(self) -> MixpanelDestinationConfig:
-        if self.endpoint == "people_set":
-            if not self.project_token and not self.project_token_env:
-                raise ValueError(
-                    "project_token or project_token_env is required for endpoint 'people_set'."
-                )
-        else:  # import_events
-            if not self.project_id:
-                raise ValueError("project_id is required for endpoint 'import_events'.")
-            has_user = self.service_account_username or self.service_account_username_env
-            has_secret = self.service_account_secret or self.service_account_secret_env
-            if not has_user or not has_secret:
-                raise ValueError(
-                    "service account credentials (username + secret, or their *_env "
-                    "vars) are required for endpoint 'import_events'."
-                )
-        return self
-
-    @model_validator(mode="after")
-    def _check_event_name(self) -> MixpanelDestinationConfig:
-        if self.endpoint == "import_events" and not self.event_name and not self.event_name_field:
-            raise ValueError(
-                "event_name or event_name_field is required when endpoint is 'import_events'."
-            )
-        return self
-
-    @field_validator("batch_size", mode="after")
-    @classmethod
-    def _clamp_batch_size(cls, value: int) -> int:
-        # Mixpanel caps both /engage and /import at 2000 records per request.
-        return max(1, min(value, 2000))
-
-
-class IntercomDestinationConfig(BaseModel):
-    type: Literal["intercom"]
-
-    auth: AuthConfig
-
-    # Jinja2 JSON template for contact payload
-    properties_template: str
-
-    retry: RetryConfig | None = None  # destination-level override of sync.retry
-
-    def describe(self) -> str:
-        return f"{self.type} (contacts)"
-
-
-class SendGridDestinationConfig(BaseModel):
-    type: Literal["sendgrid"]
-    from_email: str
-    from_name: str | None = None
-    subject_template: str
-    body_template: str
-    to_email_field: str = "email"
-    list_ids: list[str] | None = None
-    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
-    retry: RetryConfig | None = None  # destination-level override of sync.retry
-
-    def describe(self) -> str:
-        return f"sendgrid ({self.from_email})"
-
-
-class SnowflakeDestinationConfig(BaseModel):
-    type: Literal["snowflake"]
-
-    account_env: str
-    user_env: str
-    # Auth: either a password or an RSA private key (#737). Key-pair is the
-    # path for ``TYPE = SERVICE`` users — new Snowflake accounts enforce MFA
-    # on password sign-ins, so programmatic identities should migrate to a
-    # SERVICE user + key pair. ``private_key_env`` names an env var holding
-    # the PEM (PKCS#8) private key *contents*; it takes precedence over
-    # ``password_env`` when both are set.
-    password_env: str | None = None
-    private_key_env: str | None = None
-    private_key_passphrase_env: str | None = None
-
-    database: str
-    # Use alias because BaseModel.schema() shadows a plain `schema` attribute
-    # under mypy strict mode; YAML key stays `schema:`.
-    schema_: str = Field(alias="schema")
-    table: str
-
-    warehouse: str
-
-    mode: Literal["insert", "merge"] = "insert"
-
-    upsert_key: list[str] | None = None
-
-    # FK resolution against the destination (#316/#354 lookup pattern,
-    # extended to Snowflake in #468). Also makes Snowflake queryable, so
-    # `drt run --dry-run --diff` produces a true diff and `drt test`
-    # validation queries run against the target table.
-    lookups: dict[str, LookupConfig] | None = None
-
-    # Layer 3 (#317): introspect INFORMATION_SCHEMA once per sync to wrap
-    # VARIANT/OBJECT/ARRAY columns with PARSE_JSON (so dict/list values land as
-    # proper semi-structured data, not a stringified repr). On by default; set
-    # false for roles without read access to information_schema.
-    introspect_schema: bool = True
-
-    @model_validator(mode="after")
-    def _check_auth(self) -> SnowflakeDestinationConfig:
-        if not self.password_env and not self.private_key_env:
-            raise ValueError(
-                "snowflake destination needs private_key_env (key-pair auth, "
-                "preferred) or password_env."
-            )
-        return self
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.database}.{self.schema_}.{self.table})"
-
-
-class BigQueryDestinationConfig(BaseModel):
-    """BigQuery destination — write data back to BigQuery tables.
-
-    Auth mirrors the BigQuery source: Application Default Credentials by
-    default, or a service-account ``keyfile``. The principal needs
-    ``bigquery.tables.updateData`` on the target (plus ``bigquery.tables.create``
-    / ``bigquery.jobs.create`` for the merge-path temp table).
-    """
-
-    type: Literal["bigquery"]
-
-    project: str
-    dataset: str
-    table: str
-    location: str | None = None
-
-    mode: Literal["insert", "merge"] = "insert"
-    upsert_key: list[str] | None = None
-
-    # Auth — same convention as the BigQuery source (sources/bigquery.py).
-    method: Literal["application_default", "keyfile"] = "application_default"
-    keyfile: str | None = None
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.project}.{self.dataset}.{self.table})"
-
-
-class DatabricksDestinationConfig(BaseModel):
-    """Databricks Delta Lake destination — write data back to Databricks tables.
-
-    Auth via the Databricks SQL Connector: a SQL warehouse HTTP path
-    plus a personal access token (PAT). The token-bearing user needs
-    USAGE on the catalog + schema and INSERT/MODIFY on the target
-    table.
-    """
-
-    type: Literal["databricks"]
-
-    # Workspace hostname (env-var resolved), e.g.
-    # ``dbc-abc12345-1234.cloud.databricks.com``.
-    host_env: str
-    # SQL warehouse HTTP path (env-var resolved), e.g.
-    # ``/sql/1.0/warehouses/abc123def456``.
-    http_path_env: str
-    # Databricks personal access token (env-var resolved). Starts with ``dapi``.
-    token_env: str
-
-    # Three-part name (Unity Catalog). For Hive Metastore deployments
-    # use catalog="hive_metastore".
-    catalog: str
-    # Field alias because BaseModel.schema() shadows a plain `schema`
-    # attribute under mypy strict mode; YAML key stays `schema:`.
-    schema_: str = Field(alias="schema")
-    table: str
-
-    mode: Literal["insert", "merge"] = "insert"
-
-    # Required for merge mode and for ``sync.mode: mirror``. Composite
-    # keys supported (`upsert_key: [tenant_id, user_id]`).
-    upsert_key: list[str] | None = None
-
-    # Layer 3 (#317): introspect information_schema once per sync to wrap
-    # STRUCT/MAP/ARRAY columns with from_json (and VARIANT with parse_json), so
-    # dict/list values land as proper complex types, not a stringified repr. On
-    # by default; set false for roles without read access to information_schema.
-    introspect_schema: bool = True
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.catalog}.{self.schema_}.{self.table})"
-
-
-class ElasticsearchDestinationConfig(BaseModel):
-    """Elasticsearch / OpenSearch destination — bulk-index records via the ``_bulk`` API."""
-
-    type: Literal["elasticsearch"]
-    url: str  # cluster base URL, e.g. https://localhost:9200
-    index: str  # target index name
-    # Row field whose value becomes the document _id. None → the cluster
-    # auto-generates ids (only valid with op_type="index"/"create" where
-    # create without an id always inserts).
-    id_field: str | None = None
-    # "index" upserts (replace-if-exists); "create" fails the row if the
-    # _id already exists (409). OpenSearch shares the same API surface.
-    op_type: Literal["index", "create"] = "index"
-    # Auth — provide an API key (direct or env) OR HTTP Basic creds (env):
-    api_key: str | None = None
-    api_key_env: str | None = None
-    username_env: str | None = None
-    password_env: str | None = None
-    # TLS verification. Set False for self-signed dev clusters (local
-    # OpenSearch / Elasticsearch with the bundled cert).
-    verify_tls: bool = True
-    retry: RetryConfig | None = None  # destination-level override of sync.retry
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.index})"
-
-
-class LinearDestinationConfig(BaseModel):
-    type: Literal["linear"]
-    team_id: str | None = None
-    team_id_env: str | None = None
-    title_template: str
-    description_template: str
-    label_ids: list[str] = []
-    assignee_id: str | None = None
-    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
-    retry: RetryConfig | None = None  # destination-level override of sync.retry
-
-    def describe(self) -> str:
-        return "linear (issue)"
-
-
-class LookupConfig(BaseModel):
-    """Resolve a column value by querying the destination DB.
-
-    Used to resolve foreign key values when syncing related tables.
-    The destination DB is queried once per lookup to build an in-memory
-    mapping, then each source row is enriched with the resolved value.
-
-    Example YAML::
-
-        lookups:
-          interviewer_profile_id:
-            table: interviewer_profiles
-            match: { user_id: user_id }
-            select: id
-            on_miss: skip
-    """
-
-    table: str  # destination DB table to query
-    match: dict[str, str]  # { destination_column: source_column }
-    select: str | None = None  # column to fetch; omitted when check_only=True
-    on_miss: Literal["skip", "fail", "null"] = "skip"
-    drop_match_columns: bool = True  # remove match source columns from INSERT
-    check_only: bool = False  # filter-only mode: existence check, no value resolution
-
-    @model_validator(mode="after")
-    def _check_match_not_empty(self) -> LookupConfig:
-        if not self.match:
-            raise ValueError("lookups.match must contain at least one mapping.")
-        return self
-
-    @model_validator(mode="after")
-    def _check_select_consistency(self) -> LookupConfig:
-        if self.check_only and self.select is not None:
-            raise ValueError(
-                "lookups.select must be omitted when check_only=True "
-                "(check_only is filter-only — no value is resolved)."
-            )
-        if not self.check_only and self.select is None:
-            raise ValueError(
-                "lookups.select is required (or set check_only=true for existence-only filtering)."
-            )
-        return self
-
-    @model_validator(mode="after")
-    def _check_on_miss_consistency(self) -> LookupConfig:
-        if self.check_only and self.on_miss == "null":
-            raise ValueError(
-                "lookups.on_miss='null' is invalid with check_only=True "
-                "(no target column to set NULL on; use 'skip' or 'fail')."
-            )
-        return self
-
-
-class SslConfig(BaseModel):
-    """SSL/TLS connection options for DB destinations."""
-
-    enabled: bool = False
-    ca_env: str | None = None  # env var for CA cert path
-    cert_env: str | None = None  # env var for client cert path
-    key_env: str | None = None  # env var for client key path
-
-
-class BaseSqlDestinationConfig(BaseModel):
-    """Shared connection fields for host-based SQL destinations.
-
-    Postgres, MySQL, and ClickHouse all expose the same connection
-    surface (``host`` / ``host_env`` + credentials + a connection-string
-    escape hatch) plus a lookups field for FK resolution. The
-    destination-specific bits (``dbname`` vs ``database`` field name,
-    ``ssl`` vs ``secure``, port defaults, ``json_columns`` applicability,
-    ``upsert_key`` typing) stay on the concrete subclasses where they
-    differ in name or semantics.
-
-    Subclasses keep their own ``_check_connection`` model_validator
-    because the database field name differs across dialects; sharing the
-    validator would require a ClassVar lookup that obscures the simple
-    "host + dbname required unless connection_string_env" rule.
-
-    New host-based SQL destinations (Redshift, future Vertica/CockroachDB)
-    should inherit from this class and override ``port`` for the default
-    wire port; see ``MySQLDestinationConfig`` / ``ClickHouseDestinationConfig``
-    for examples.
-    """
-
-    connection_string_env: str | None = None
-    host: str | None = None
-    host_env: str | None = None
-    port: int = 5432  # Postgres default; subclasses override
-    user: str | None = None
-    user_env: str | None = None
-    password: str | None = None
-    password_env: str | None = None
-    lookups: dict[str, LookupConfig] | None = None
-    # Layer 3 (#317): introspect INFORMATION_SCHEMA once per sync to route
-    # dict/list values by the column's real type (no json_columns needed).
-    # On by default; set false for locked-down environments without read
-    # access to information_schema. Explicit json_columns always takes priority.
-    introspect_schema: bool = True
-
-
-class PostgresDestinationConfig(BaseSqlDestinationConfig):
-    type: Literal["postgres"]
-    dbname: str | None = None
-    dbname_env: str | None = None
-    table: str  # e.g. "public.analytics_scores"
-    upsert_key: list[str]  # columns for ON CONFLICT
-    ssl: SslConfig | None = None
-    json_columns: list[str] | None = None  # columns that hold JSON/JSONB data
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.table})"
-
-    @model_validator(mode="after")
-    def _check_connection(self) -> PostgresDestinationConfig:
-        if self.connection_string_env:
-            return self  # connection string takes precedence
-        if not self.host and not self.host_env:
-            raise ValueError("Either host, host_env, or connection_string_env is required.")
-        if not self.dbname and not self.dbname_env:
-            raise ValueError("Either dbname, dbname_env, or connection_string_env is required.")
-        return self
-
-
-class MySQLDestinationConfig(BaseSqlDestinationConfig):
-    type: Literal["mysql"]
-    port: int = 3306  # MySQL default
-    dbname: str | None = None
-    dbname_env: str | None = None
-    table: str  # e.g. "interviewer_learning_profiles"
-    upsert_key: list[str]  # columns for ON DUPLICATE KEY
-    ssl: SslConfig | None = None
-    json_columns: list[str] | None = None  # columns that hold JSON data
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.table})"
-
-    @model_validator(mode="after")
-    def _check_connection(self) -> MySQLDestinationConfig:
-        if self.connection_string_env:
-            return self  # connection string takes precedence
-        if not self.host and not self.host_env:
-            raise ValueError("Either host, host_env, or connection_string_env is required.")
-        if not self.dbname and not self.dbname_env:
-            raise ValueError("Either dbname, dbname_env, or connection_string_env is required.")
-        return self
-
-
-class TeamsDestinationConfig(BaseModel):
-    type: Literal["teams"]
-    webhook_url: str | None = None
-    webhook_url_env: str | None = None
-    # Jinja2 template for the message card. Supports plain text or Adaptive Card JSON.
-    message_template: str = "{{ row }}"
-    # If True, treat message_template as an Adaptive Card JSON payload
-    adaptive_card: bool = False
-    retry: RetryConfig | None = None  # destination-level override of sync.retry
-
-    def describe(self) -> str:
-        return f"{self.type} (webhook)"
-
-
-class JiraDestinationConfig(BaseModel):
-    type: Literal["jira"]
-    base_url_env: str  # e.g. JIRA_BASE_URL -> https://myorg.atlassian.net
-    email_env: str  # Jira account email env var
-    token_env: str  # Jira API token env var
-    project_key: str  # can include Jinja2 template syntax
-    issue_type: str = "Task"  # can include Jinja2 template syntax
-    summary_template: str
-    description_template: str
-    issue_id_field: str = "issue_id"  # row key that indicates update mode
-    retry: RetryConfig | None = None  # destination-level override of sync.retry
-
-    def describe(self) -> str:
-        return f"jira ({self.project_key})"
-
-
-class ClickHouseDestinationConfig(BaseSqlDestinationConfig):
-    type: Literal["clickhouse"]
-    port: int = 8123  # ClickHouse HTTP interface; use 8443 for HTTPS
-    database: str | None = None
-    database_env: str | None = None
-    table: str  # unqualified table name (database set via database/database_env)
-
-    # Informational only for ClickHouse. drt does not enforce/create
-    # ReplacingMergeTree tables or apply upsert semantics from this field.
-    upsert_key: list[str] | None = None
-    secure: bool = False  # use HTTPS/TLS; set port explicitly for your deployment (commonly 8443)
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.table})"
-
-    @model_validator(mode="after")
-    def _check_connection(self) -> ClickHouseDestinationConfig:
-        if self.connection_string_env:
-            return self  # connection string takes precedence
-        if not self.host and not self.host_env:
-            raise ValueError("Either host, host_env, or connection_string_env is required.")
-        if not self.database and not self.database_env:
-            raise ValueError("Either database, database_env, or connection_string_env is required.")
-        return self
-
-
-class ParquetDestinationConfig(BaseModel):
-    type: Literal["parquet"]
-    path: str  # output file or directory path, e.g. "output/data.parquet"
-    partition_by: list[str] | None = None  # optional partition columns
-    compression: Literal["snappy", "gzip", "zstd", "none"] = "snappy"
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.path})"
-
-
-class FileDestinationConfig(BaseModel):
-    type: Literal["file"]
-    path: str  # output file path, e.g. "output/data.csv"
-    format: Literal["csv", "json", "jsonl"] = "csv"
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.path})"
-
-
-class S3DestinationConfig(BaseModel):
-    """S3 destination — upload records as CSV / JSON / JSONL / Parquet to S3."""
-
-    type: Literal["s3"]
-    bucket: str
-    # Optional key prefix. The generated file name is appended to this prefix:
-    # e.g. prefix="drt/users/" → "drt/users/20260605T123000Z.csv". For
-    # per-sync routing, give each sync its own prefix.
-    prefix: str = ""
-    format: Literal["csv", "json", "jsonl", "parquet"] = "csv"
-    # gzip-compress csv / json / jsonl uploads ("none" disables). Parquet
-    # uses its native compression below; "gzip" here is ignored for parquet.
-    compression: Literal["none", "gzip"] = "none"
-    # Optional Parquet-specific compression (matches ParquetDestinationConfig).
-    parquet_compression: Literal["snappy", "gzip", "zstd", "none"] = "snappy"
-    region: str | None = None  # AWS region; defers to boto3 default if unset
-    # AWS auth: by default, falls back to boto3's standard credential chain
-    # (env vars, ~/.aws/credentials, instance profile, IAM role). Provide one
-    # of the following for explicit overrides:
-    aws_profile: str | None = None  # named profile in ~/.aws/credentials
-    aws_access_key_id_env: str | None = None
-    aws_secret_access_key_env: str | None = None
-    aws_session_token_env: str | None = None
-    # Optional endpoint URL — set when targeting an S3-compatible service
-    # (MinIO, LocalStack, R2, etc.). None → real AWS S3.
-    endpoint_url: str | None = None
-    # Optional file-name template (Jinja2-free, supports one placeholder:
-    # {timestamp} — UTC ISO 8601 basic format, e.g. "20260605T123000Z").
-    # Default produces "<prefix><timestamp>.<ext>". For per-sync naming,
-    # set ``prefix`` per sync (e.g. ``prefix: drt/active_users/``).
-    key_template: str | None = None
-
-    def describe(self) -> str:
-        return f"{self.type} (s3://{self.bucket}/{self.prefix})"
-
-
-class GCSDestinationConfig(BaseModel):
-    """GCS destination — upload records as CSV / JSON / JSONL / Parquet to Google Cloud Storage."""
-
-    type: Literal["gcs"]
-    bucket: str
-    # Optional object-name prefix. The generated file name is appended:
-    # e.g. prefix="drt/users/" → "drt/users/20260605T123000Z.csv". For
-    # per-sync routing, give each sync its own prefix.
-    prefix: str = ""
-    format: Literal["csv", "json", "jsonl", "parquet"] = "csv"
-    # gzip-compress csv / json / jsonl uploads ("none" disables). Parquet
-    # uses its native compression below; "gzip" here is ignored for parquet.
-    compression: Literal["none", "gzip"] = "none"
-    # Optional Parquet-specific compression (matches ParquetDestinationConfig).
-    parquet_compression: Literal["snappy", "gzip", "zstd", "none"] = "snappy"
-    # GCP project to bill / scope the client to. Optional — the credentials
-    # file usually carries one, and ADC will use the project from
-    # ``gcloud config get-value project`` if neither is set.
-    project_id: str | None = None
-    # GCS auth: by default, falls back to Application Default Credentials
-    # (GOOGLE_APPLICATION_CREDENTIALS env → gcloud
-    # application-default → GCE/GKE/Cloud Run service account). For
-    # explicit overrides, point at a service-account JSON keyfile:
-    credentials_path: str | None = None
-    # Optional file-name template (Jinja2-free, supports one placeholder:
-    # {timestamp} — UTC ISO 8601 basic format, e.g. "20260605T123000Z").
-    # Default produces "<prefix><timestamp>.<ext>". For per-sync naming,
-    # set ``prefix`` per sync (e.g. ``prefix: drt/active_users/``).
-    key_template: str | None = None
-
-    def describe(self) -> str:
-        return f"{self.type} (gs://{self.bucket}/{self.prefix})"
-
-
-class AzureBlobDestinationConfig(BaseModel):
-    """Azure Blob destination — upload records as CSV / JSON / JSONL / Parquet."""
-
-    type: Literal["azure_blob"]
-    container: str
-    # Optional blob-name prefix. The generated file name is appended:
-    # e.g. prefix="drt/users/" → "drt/users/20260605T123000Z.csv". For
-    # per-sync routing, give each sync its own prefix.
-    prefix: str = ""
-    format: Literal["csv", "json", "jsonl", "parquet"] = "csv"
-    # gzip-compress csv / json / jsonl uploads ("none" disables). Parquet
-    # uses its native compression below; "gzip" here is ignored for parquet.
-    compression: Literal["none", "gzip"] = "none"
-    # Optional Parquet-specific compression (matches ParquetDestinationConfig).
-    parquet_compression: Literal["snappy", "gzip", "zstd", "none"] = "snappy"
-    # Auth path 1: env-var name holding a storage-account connection
-    # string (DefaultEndpointsProtocol=...). Most common shape for
-    # non-Azure CI / cron deployments.
-    connection_string_env: str | None = None
-    # Auth path 2: storage account blob endpoint
-    # (https://<account>.blob.core.windows.net) — when set without
-    # connection_string_env, DefaultAzureCredential is used (env vars,
-    # managed identity, Azure CLI, ...).
-    account_url: str | None = None
-    # Optional file-name template (Jinja2-free, supports one placeholder:
-    # {timestamp} — UTC ISO 8601 basic format, e.g. "20260605T123000Z").
-    # Default produces "<prefix><timestamp>.<ext>". For per-sync naming,
-    # set ``prefix`` per sync (e.g. ``prefix: drt/active_users/``).
-    key_template: str | None = None
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.container}/{self.prefix})"
-
-
-class EmailSmtpDestinationConfig(BaseModel):
-    type: Literal["email_smtp"] = "email_smtp"
-    host: str
-    port: int = 587
-    sender: str
-    recipients: list[str]
-    subject_template: str
-    body_template: str
-    use_tls: bool = True
-    username: str | None = None
-    username_env: str | None = None
-    password: str | None = None
-    password_env: str | None = None
-
-    def describe(self) -> str:
-        return f"{self.type} ({self.host})"
-
-
-class NotionDestinationConfig(BaseModel):
-    type: Literal["notion"]
-    database_id: str
-    # Jinja2 template → JSON object of Notion page properties
-    # Example: see https://developers.notion.com/reference/post-page for template format
-    properties_template: str | None = None
-    auth: BearerAuth = Field(default_factory=lambda: BearerAuth(type="bearer"))
-    retry: RetryConfig | None = None  # destination-level override of sync.retry
-
-    def describe(self) -> str:
-        return f"{self.type} (database {self.database_id})"
-
-
-class GoogleAdsDestinationConfig(BaseModel):
-    type: Literal["google_ads"]
-    customer_id: str  # Google Ads customer ID (without hyphens)
-    conversion_action: str  # e.g. "customers/123/conversionActions/456"
-    gclid_field: str = "gclid"  # row field containing the click ID
-    conversion_time_field: str = "conversion_time"  # row field for timestamp
-    conversion_value_field: str | None = None  # optional: row field for value
-    currency_code: str = "USD"
-    developer_token_env: str = "GOOGLE_ADS_DEVELOPER_TOKEN"
-    auth: AuthConfig | None = None  # typically oauth2_client_credentials
-    retry: RetryConfig | None = None  # destination-level override of sync.retry
-
-    def describe(self) -> str:
-        return f"google_ads ({self.customer_id})"
-
-
-class StagedUploadPhaseConfig(BaseModel):
-    url: str
-    method: str = "POST"
-    headers: dict[str, str] | None = None
-    auth: AuthConfig | None = None
-    body_template: str | None = None
-    response_extract: dict[str, str] | None = None
-
-
-class StagedUploadPollConfig(BaseModel):
-    url: str
-    method: str = "GET"
-    headers: dict[str, str] | None = None
-    auth: AuthConfig | None = None
-    status_field: str = "status"
-    success_values: list[str] = ["SUCCEEDED", "COMPLETED"]
-    failure_values: list[str] = ["FAILED", "ERROR"]
-    interval_seconds: int = 30
-    timeout_seconds: int = 3600
-
-
-class StagedUploadDestinationConfig(BaseModel):
-    type: Literal["staged_upload"]
-    stage: StagedUploadPhaseConfig
-    trigger: StagedUploadPhaseConfig
-    poll: StagedUploadPollConfig | None = None
-    format: Literal["csv", "json", "jsonl"] = "csv"
-
-    def describe(self) -> str:
-        return "staged_upload"
-
-
-class SalesforceBulkDestinationConfig(BaseModel):
-    type: Literal["salesforce_bulk"]
-    instance_url: str | None = None
-    instance_url_env: str | None = None
-    object_name: str  # e.g. "Contact", "Account"
-    operation: Literal["insert", "update", "upsert", "delete"] = "upsert"
-    external_id_field: str = "Id"
-    poll_timeout_seconds: int = 3600
-    poll_interval_seconds: int = 30
-    client_id_env: str
-    client_secret_env: str
-    username_env: str
-    password_env: str
-
-    def describe(self) -> str:
-        return f"salesforce_bulk ({self.object_name})"
-
-    @model_validator(mode="after")
-    def _check_instance_url(self) -> SalesforceBulkDestinationConfig:
-        if not self.instance_url and not self.instance_url_env:
-            raise ValueError("Either instance_url or instance_url_env is required.")
-        return self
-
-
-# Discriminated union — add new destination types here
-DestinationConfig = Annotated[
-    RestApiDestinationConfig
-    | SlackDestinationConfig
-    | DiscordDestinationConfig
-    | GitHubActionsDestinationConfig
-    | HubSpotDestinationConfig
-    | ZendeskDestinationConfig
-    | AmplitudeDestinationConfig
-    | MixpanelDestinationConfig
-    | SendGridDestinationConfig
-    | LinearDestinationConfig
-    | GoogleSheetsDestinationConfig
-    | PostgresDestinationConfig
-    | MySQLDestinationConfig
-    | TeamsDestinationConfig
-    | JiraDestinationConfig
-    | ClickHouseDestinationConfig
-    | ParquetDestinationConfig
-    | GoogleAdsDestinationConfig
-    | FileDestinationConfig
-    | S3DestinationConfig
-    | GCSDestinationConfig
-    | AzureBlobDestinationConfig
-    | EmailSmtpDestinationConfig
-    | NotionDestinationConfig
-    | IntercomDestinationConfig
-    | StagedUploadDestinationConfig
-    | SalesforceBulkDestinationConfig
-    | TwilioDestinationConfig
-    | SnowflakeDestinationConfig
-    | DatabricksDestinationConfig
-    | ElasticsearchDestinationConfig
-    | BigQueryDestinationConfig
-    | AirtableDestinationConfig
-    | KlaviyoDestinationConfig,
-    Field(discriminator="type"),
-]
-
-
-# ---------------------------------------------------------------------------
-# Sync options
-# ---------------------------------------------------------------------------
-
-
-class RateLimitConfig(BaseModel):
-    requests_per_second: int = 10
-
-
-class RetryConfig(BaseModel):
-    max_attempts: int = 3
-    initial_backoff: float = 1.0
-    backoff_multiplier: float = 2.0
-    max_backoff: float = 60.0
-    retryable_status_codes: tuple[int, ...] = (429, 500, 502, 503, 504)
-
-
-class WatermarkConfig(BaseModel):
-    """Configuration for remote watermark storage."""
-
-    storage: Literal["local", "gcs", "bigquery"] = "local"
-    # GCS
-    bucket: str | None = None
-    key: str | None = None
-    # BigQuery
-    project: str | None = None
-    dataset: str | None = None
-    # Fallback value used when no watermark exists yet (first run)
-    default_value: str | None = None
-    # Overlap window (#759): widen the incremental *read* window by this much
-    # behind the stored watermark so late-arriving rows are re-synced.
-    # Timestamp cursors take a duration string ("1 hour" — grammar shared with
-    # freshness.max_age); numeric cursors take a positive int (cursor units).
-    # Applies only to storage-sourced watermarks — never to --cursor-value
-    # overrides or default_value first runs — and the persisted watermark is
-    # never lagged, so the window cannot regress. Rows inside the lag window
-    # are re-sent every run: the destination must tolerate duplicates
-    # (e.g. via upsert_key).
-    lag: str | int | None = None
-
-    @model_validator(mode="after")
-    def _check_lag(self) -> WatermarkConfig:
-        if isinstance(self.lag, bool):
-            raise ValueError("watermark.lag must be a duration string or a positive integer.")
-        if self.lag is None:
-            return self
-        if isinstance(self.lag, int):
-            if self.lag <= 0:
-                raise ValueError(
-                    "watermark.lag must be a positive integer (units of the numeric cursor)."
-                )
-        else:
-            parse_duration(self.lag, field_name="watermark.lag")
-        return self
-
-    @model_validator(mode="after")
-    def _check_backend_fields(self) -> WatermarkConfig:
-        if self.storage == "gcs" and not self.bucket:
-            raise ValueError("watermark.bucket is required when storage is 'gcs'.")
-        if self.storage == "gcs" and not self.key:
-            raise ValueError("watermark.key is required when storage is 'gcs'.")
-        if self.storage == "bigquery" and not self.project:
-            raise ValueError("watermark.project is required when storage is 'bigquery'.")
-        if self.storage == "bigquery" and not self.dataset:
-            raise ValueError("watermark.dataset is required when storage is 'bigquery'.")
-        return self
-
-
-class DLQConfig(BaseModel):
-    """Dead Letter Queue — persist per-record load failures for replay (#278).
-
-    Opt-in: when ``enabled``, each record that fails during ``destination.load()``
-    is written verbatim to ``.drt/dlq/<sync_name>.jsonl`` so ``drt retry <sync>``
-    can re-send just the failures. Off by default because it writes full record
-    payloads to disk (a PII decision the operator makes explicitly).
-    """
-
-    enabled: bool = False
-    # Cap queue growth — oldest entries are dropped past this (0 = unbounded).
-    max_records: int = 10_000
-
-    @model_validator(mode="after")
-    def _check_max_records(self) -> DLQConfig:
-        if self.max_records < 0:
-            raise ValueError("dlq.max_records must be >= 0 (0 disables the cap).")
-        return self
-
-
-class MaskRule(BaseModel):
-    """Object form of a mask rule, for strategies that take a parameter (#660).
-
-    The flat form (``field: "hash" | "redact"``) covers parameter-less strategies.
-    This object form is used when a strategy needs options, for example
-    ``{strategy: "truncate", length: 2}``.
-    """
-
-    strategy: Literal["hash", "redact", "truncate"]
-    length: int | None = None
-
-    @model_validator(mode="after")
-    def _validate_length(self) -> MaskRule:
-        if self.strategy == "truncate":
-            if self.length is None or self.length < 0:
-                raise ValueError(
-                    "the 'truncate' strategy requires a non-negative 'length'"
-                )
-        elif self.length is not None:
-            raise ValueError(
-                f"'length' is not valid for the '{self.strategy}' strategy"
-            )
-        return self
-
-
-# A mask rule is either a flat strategy name (no params) or the object form above.
-MaskSpec = Literal["hash", "redact"] | MaskRule
-
-
-class MirrorConfig(BaseModel):
-    """``sync.mirror`` — mirror-mode delete behaviour (#686).
-
-    - ``strategy: destination`` (default) — the original #340 behaviour:
-      DELETE destination rows whose ``upsert_key`` was not observed this
-      run. Correct only when drt exclusively owns the table.
-    - ``strategy: tracked`` — DELETE only rows drt itself previously
-      synced, tracked per sync in a drt-managed ``_drt_synced_keys`` side
-      table in the destination. Safe on tables the application also
-      writes to (Census-style semantics: first run baselines without
-      deleting; lost state re-baselines with a warning).
-    - ``scope`` (#687) — restrict destination-strategy deletes to rows
-      whose scope-column values appeared in this run's source. The
-      stateless fit for 1:N regeneration (parent + child link rows):
-      stale children under observed parents are deleted, rows under
-      unobserved parents are untouched.
-    """
-
-    strategy: Literal["destination", "tracked"] = "destination"
-    scope: list[str] | None = Field(default=None, min_length=1)
-
-    @model_validator(mode="after")
-    def _check_scope_strategy(self) -> MirrorConfig:
-        # Composing scope with tracked (pruning the state diff to observed
-        # parents) is a #687 follow-up — reject rather than half-apply.
-        if self.scope is not None and self.strategy == "tracked":
-            raise ValueError(
-                "mirror.scope with strategy: tracked is not supported yet — "
-                "use scope (stateless) or tracked (stateful), not both."
-            )
-        return self
-
-
-class SyncOptions(BaseModel):
-    mode: Literal["full", "incremental", "upsert", "replace", "mirror"] = "full"
-    replace_strategy: Literal["truncate", "swap"] = "truncate"
-    cursor_field: str | None = None  # required when mode=incremental
-    watermark: WatermarkConfig | None = None
-    batch_size: int = 100
-    rate_limit: RateLimitConfig = Field(default_factory=RateLimitConfig)
-    retry: RetryConfig = Field(default_factory=RetryConfig)
-    on_error: Literal["skip", "fail"] = "fail"
-    # Declarative column rename (#415): {source_column: destination_field}.
-    # Applied in the engine after extraction + cursor tracking + lookups,
-    # immediately before the record reaches the destination — so
-    # cursor_field and lookups still reference source-side column names,
-    # while upsert_key / destination columns reference the mapped names.
-    field_mappings: dict[str, str] | None = None
-    # PII masking (#427, #660): {field_name: spec}, where spec is a flat strategy
-    # name ("hash" | "redact") or the object form {strategy, length} for
-    # param-bearing strategies (truncate). Applied in the engine at the same seam
-    # as field_mappings (just before the destination), so keys reference the
-    # post-rename field name. "hash" = SHA-256 hex digest; "redact" = "[REDACTED]";
-    # "truncate" = the first `length` characters. Null passes through; non-strings
-    # are stringified first.
-    mask: dict[str, MaskSpec] | None = None
-    # Dead Letter Queue (#278): opt-in persistence of failed records for
-    # `drt retry`. None means disabled (same as DLQConfig(enabled=False)).
-    dlq: DLQConfig | None = None
-    # Mirror-mode delete behaviour (#686). None = destination strategy (#340).
-    mirror: MirrorConfig | None = None
-
-    # The owning sync's name, injected by SyncConfig after validation (not a
-    # YAML field). Tracked mirror (#686) uses it to scope the per-sync key
-    # state in the destination-side ``_drt_synced_keys`` table.
-    _sync_name: str | None = PrivateAttr(default=None)
-
-    @model_validator(mode="after")
-    def _check_incremental_cursor(self) -> SyncOptions:
-        if self.mode == "incremental" and not self.cursor_field:
-            raise ValueError("cursor_field is required when mode is 'incremental'.")
-        return self
-
-    @model_validator(mode="after")
-    def _check_watermark_lag_mode(self) -> SyncOptions:
-        if (
-            self.watermark is not None
-            and self.watermark.lag is not None
-            and self.mode != "incremental"
-        ):
-            raise ValueError("watermark.lag requires mode='incremental'.")
-        return self
-
-    @model_validator(mode="after")
-    def _check_mirror_config(self) -> SyncOptions:
-        if self.mirror is not None and self.mode != "mirror":
-            raise ValueError("sync.mirror requires mode='mirror'.")
-        return self
-
-    @model_validator(mode="after")
-    def _check_replace_strategy(self) -> SyncOptions:
-        if self.replace_strategy == "swap" and self.mode != "replace":
-            raise ValueError("replace_strategy='swap' requires mode='replace'.")
-        return self
-
-
-class RowCountTest(BaseModel):
-    min: int | None = None
-    max: int | None = None
-
-
-class NotNullTest(BaseModel):
-    columns: list[str]
-
-
-class FreshnessTest(BaseModel):
-    column: str
-    max_age: str  # e.g., "7 days", "1 hour", "30 minutes"
-
-
-class UniqueTest(BaseModel):
-    columns: list[str] = Field(min_length=1)
-
-
-class AcceptedValuesTest(BaseModel):
-    column: str
-    values: list[str] = Field(min_length=1)
-
-
-class SyncTest(BaseModel):
-    row_count: RowCountTest | None = None
-    not_null: NotNullTest | None = None
-    freshness: FreshnessTest | None = None
-    unique: UniqueTest | None = None
-    accepted_values: AcceptedValuesTest | None = None
-
-    @model_validator(mode="after")
-    def _check_exactly_one_test(self) -> SyncTest:
-        configured_tests = [
-            self.row_count,
-            self.not_null,
-            self.freshness,
-            self.unique,
-            self.accepted_values,
-        ]
-        configured_count = sum(test is not None for test in configured_tests)
-        if configured_count != 1:
-            raise ValueError("Exactly one sync test must be configured in each tests entry.")
-        return self
-
-
-class SlackAlertConfig(BaseModel):
-    type: Literal["slack"]
-    webhook_url: str | None = None
-    webhook_url_env: str | None = None
-    message: str = "drt sync `{sync_name}` failed: {error}"
-
-    @model_validator(mode="after")
-    def _check_url(self) -> SlackAlertConfig:
-        if not self.webhook_url and not self.webhook_url_env:
-            raise ValueError("Either webhook_url or webhook_url_env is required.")
-        return self
-
-
-class WebhookAlertConfig(BaseModel):
-    type: Literal["webhook"]
-    url: str | None = None
-    url_env: str | None = None
-    method: Literal["POST", "PUT"] = "POST"
-    headers: dict[str, str] = Field(default_factory=dict)
-    body_template: str | None = None  # JSON template; None → default JSON payload
-
-    @model_validator(mode="after")
-    def _check_url(self) -> WebhookAlertConfig:
-        if not self.url and not self.url_env:
-            raise ValueError("Either url or url_env is required.")
-        return self
-
-
-AlertItem = Annotated[
-    SlackAlertConfig | WebhookAlertConfig,
-    Field(discriminator="type"),
-]
-
-
-class AlertsConfig(BaseModel):
-    on_failure: list[AlertItem] = Field(default_factory=list)
-
-
-class SyncConfig(BaseModel):
-    name: str
-    description: str = ""
-    tags: list[str] = Field(default_factory=list)
-    model: str
-    destination: DestinationConfig
-    sync: SyncOptions = Field(default_factory=SyncOptions)
-    tests: list[SyncTest] = Field(default_factory=list)
-    alerts: AlertsConfig | None = None
-
-    @model_validator(mode="after")
-    def _inject_sync_name(self) -> SyncConfig:
-        # Destinations need the sync name to scope tracked-mirror state
-        # (#686), but the Destination protocol only receives SyncOptions —
-        # so carry it on a private attr rather than widening the protocol
-        # or exposing a user-settable YAML field.
-        self.sync._sync_name = self.name
-        return self

--- a/drt/config/sync_options.py
+++ b/drt/config/sync_options.py
@@ -1,0 +1,400 @@
+"""Sync options, tests, alerts, and the sync config root (#721 split from models.py).
+
+Also home to the :data:`DestinationConfig` discriminated union, assembled from
+the three ``destinations_*`` modules and consumed by :class:`SyncConfig`.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field, PrivateAttr, model_validator
+
+from drt.config.base import RetryConfig
+from drt.config.destinations_saas import (
+    AirtableDestinationConfig,
+    AmplitudeDestinationConfig,
+    DiscordDestinationConfig,
+    EmailSmtpDestinationConfig,
+    GitHubActionsDestinationConfig,
+    GoogleAdsDestinationConfig,
+    GoogleSheetsDestinationConfig,
+    HubSpotDestinationConfig,
+    IntercomDestinationConfig,
+    JiraDestinationConfig,
+    KlaviyoDestinationConfig,
+    LinearDestinationConfig,
+    MixpanelDestinationConfig,
+    NotionDestinationConfig,
+    RestApiDestinationConfig,
+    SalesforceBulkDestinationConfig,
+    SendGridDestinationConfig,
+    SlackDestinationConfig,
+    StagedUploadDestinationConfig,
+    TeamsDestinationConfig,
+    TwilioDestinationConfig,
+    ZendeskDestinationConfig,
+)
+from drt.config.destinations_sql import (
+    BigQueryDestinationConfig,
+    ClickHouseDestinationConfig,
+    DatabricksDestinationConfig,
+    ElasticsearchDestinationConfig,
+    MySQLDestinationConfig,
+    PostgresDestinationConfig,
+    SnowflakeDestinationConfig,
+)
+from drt.config.destinations_storage import (
+    AzureBlobDestinationConfig,
+    FileDestinationConfig,
+    GCSDestinationConfig,
+    ParquetDestinationConfig,
+    S3DestinationConfig,
+)
+from drt.config.duration import parse_duration
+
+
+class RateLimitConfig(BaseModel):
+    requests_per_second: int = 10
+
+
+class WatermarkConfig(BaseModel):
+    """Configuration for remote watermark storage."""
+
+    storage: Literal["local", "gcs", "bigquery"] = "local"
+    # GCS
+    bucket: str | None = None
+    key: str | None = None
+    # BigQuery
+    project: str | None = None
+    dataset: str | None = None
+    # Fallback value used when no watermark exists yet (first run)
+    default_value: str | None = None
+    # Overlap window (#759): widen the incremental *read* window by this much
+    # behind the stored watermark so late-arriving rows are re-synced.
+    # Timestamp cursors take a duration string ("1 hour" — grammar shared with
+    # freshness.max_age); numeric cursors take a positive int (cursor units).
+    # Applies only to storage-sourced watermarks — never to --cursor-value
+    # overrides or default_value first runs — and the persisted watermark is
+    # never lagged, so the window cannot regress. Rows inside the lag window
+    # are re-sent every run: the destination must tolerate duplicates
+    # (e.g. via upsert_key).
+    lag: str | int | None = None
+
+    @model_validator(mode="after")
+    def _check_lag(self) -> WatermarkConfig:
+        if isinstance(self.lag, bool):
+            raise ValueError("watermark.lag must be a duration string or a positive integer.")
+        if self.lag is None:
+            return self
+        if isinstance(self.lag, int):
+            if self.lag <= 0:
+                raise ValueError(
+                    "watermark.lag must be a positive integer (units of the numeric cursor)."
+                )
+        else:
+            parse_duration(self.lag, field_name="watermark.lag")
+        return self
+
+    @model_validator(mode="after")
+    def _check_backend_fields(self) -> WatermarkConfig:
+        if self.storage == "gcs" and not self.bucket:
+            raise ValueError("watermark.bucket is required when storage is 'gcs'.")
+        if self.storage == "gcs" and not self.key:
+            raise ValueError("watermark.key is required when storage is 'gcs'.")
+        if self.storage == "bigquery" and not self.project:
+            raise ValueError("watermark.project is required when storage is 'bigquery'.")
+        if self.storage == "bigquery" and not self.dataset:
+            raise ValueError("watermark.dataset is required when storage is 'bigquery'.")
+        return self
+
+
+class DLQConfig(BaseModel):
+    """Dead Letter Queue — persist per-record load failures for replay (#278).
+
+    Opt-in: when ``enabled``, each record that fails during ``destination.load()``
+    is written verbatim to ``.drt/dlq/<sync_name>.jsonl`` so ``drt retry <sync>``
+    can re-send just the failures. Off by default because it writes full record
+    payloads to disk (a PII decision the operator makes explicitly).
+    """
+
+    enabled: bool = False
+    # Cap queue growth — oldest entries are dropped past this (0 = unbounded).
+    max_records: int = 10_000
+
+    @model_validator(mode="after")
+    def _check_max_records(self) -> DLQConfig:
+        if self.max_records < 0:
+            raise ValueError("dlq.max_records must be >= 0 (0 disables the cap).")
+        return self
+
+
+class MaskRule(BaseModel):
+    """Object form of a mask rule, for strategies that take a parameter (#660).
+
+    The flat form (``field: "hash" | "redact"``) covers parameter-less strategies.
+    This object form is used when a strategy needs options, for example
+    ``{strategy: "truncate", length: 2}``.
+    """
+
+    strategy: Literal["hash", "redact", "truncate"]
+    length: int | None = None
+
+    @model_validator(mode="after")
+    def _validate_length(self) -> MaskRule:
+        if self.strategy == "truncate":
+            if self.length is None or self.length < 0:
+                raise ValueError(
+                    "the 'truncate' strategy requires a non-negative 'length'"
+                )
+        elif self.length is not None:
+            raise ValueError(
+                f"'length' is not valid for the '{self.strategy}' strategy"
+            )
+        return self
+
+
+MaskSpec = Literal["hash", "redact"] | MaskRule
+
+
+class MirrorConfig(BaseModel):
+    """``sync.mirror`` — mirror-mode delete behaviour (#686).
+
+    - ``strategy: destination`` (default) — the original #340 behaviour:
+      DELETE destination rows whose ``upsert_key`` was not observed this
+      run. Correct only when drt exclusively owns the table.
+    - ``strategy: tracked`` — DELETE only rows drt itself previously
+      synced, tracked per sync in a drt-managed ``_drt_synced_keys`` side
+      table in the destination. Safe on tables the application also
+      writes to (Census-style semantics: first run baselines without
+      deleting; lost state re-baselines with a warning).
+    - ``scope`` (#687) — restrict destination-strategy deletes to rows
+      whose scope-column values appeared in this run's source. The
+      stateless fit for 1:N regeneration (parent + child link rows):
+      stale children under observed parents are deleted, rows under
+      unobserved parents are untouched.
+    """
+
+    strategy: Literal["destination", "tracked"] = "destination"
+    scope: list[str] | None = Field(default=None, min_length=1)
+
+    @model_validator(mode="after")
+    def _check_scope_strategy(self) -> MirrorConfig:
+        # Composing scope with tracked (pruning the state diff to observed
+        # parents) is a #687 follow-up — reject rather than half-apply.
+        if self.scope is not None and self.strategy == "tracked":
+            raise ValueError(
+                "mirror.scope with strategy: tracked is not supported yet — "
+                "use scope (stateless) or tracked (stateful), not both."
+            )
+        return self
+
+
+class SyncOptions(BaseModel):
+    mode: Literal["full", "incremental", "upsert", "replace", "mirror"] = "full"
+    replace_strategy: Literal["truncate", "swap"] = "truncate"
+    cursor_field: str | None = None  # required when mode=incremental
+    watermark: WatermarkConfig | None = None
+    batch_size: int = 100
+    rate_limit: RateLimitConfig = Field(default_factory=RateLimitConfig)
+    retry: RetryConfig = Field(default_factory=RetryConfig)
+    on_error: Literal["skip", "fail"] = "fail"
+    # Declarative column rename (#415): {source_column: destination_field}.
+    # Applied in the engine after extraction + cursor tracking + lookups,
+    # immediately before the record reaches the destination — so
+    # cursor_field and lookups still reference source-side column names,
+    # while upsert_key / destination columns reference the mapped names.
+    field_mappings: dict[str, str] | None = None
+    # PII masking (#427, #660): {field_name: spec}, where spec is a flat strategy
+    # name ("hash" | "redact") or the object form {strategy, length} for
+    # param-bearing strategies (truncate). Applied in the engine at the same seam
+    # as field_mappings (just before the destination), so keys reference the
+    # post-rename field name. "hash" = SHA-256 hex digest; "redact" = "[REDACTED]";
+    # "truncate" = the first `length` characters. Null passes through; non-strings
+    # are stringified first.
+    mask: dict[str, MaskSpec] | None = None
+    # Dead Letter Queue (#278): opt-in persistence of failed records for
+    # `drt retry`. None means disabled (same as DLQConfig(enabled=False)).
+    dlq: DLQConfig | None = None
+    # Mirror-mode delete behaviour (#686). None = destination strategy (#340).
+    mirror: MirrorConfig | None = None
+
+    # The owning sync's name, injected by SyncConfig after validation (not a
+    # YAML field). Tracked mirror (#686) uses it to scope the per-sync key
+    # state in the destination-side ``_drt_synced_keys`` table.
+    _sync_name: str | None = PrivateAttr(default=None)
+
+    @model_validator(mode="after")
+    def _check_incremental_cursor(self) -> SyncOptions:
+        if self.mode == "incremental" and not self.cursor_field:
+            raise ValueError("cursor_field is required when mode is 'incremental'.")
+        return self
+
+    @model_validator(mode="after")
+    def _check_watermark_lag_mode(self) -> SyncOptions:
+        if (
+            self.watermark is not None
+            and self.watermark.lag is not None
+            and self.mode != "incremental"
+        ):
+            raise ValueError("watermark.lag requires mode='incremental'.")
+        return self
+
+    @model_validator(mode="after")
+    def _check_mirror_config(self) -> SyncOptions:
+        if self.mirror is not None and self.mode != "mirror":
+            raise ValueError("sync.mirror requires mode='mirror'.")
+        return self
+
+    @model_validator(mode="after")
+    def _check_replace_strategy(self) -> SyncOptions:
+        if self.replace_strategy == "swap" and self.mode != "replace":
+            raise ValueError("replace_strategy='swap' requires mode='replace'.")
+        return self
+
+
+class RowCountTest(BaseModel):
+    min: int | None = None
+    max: int | None = None
+
+
+class NotNullTest(BaseModel):
+    columns: list[str]
+
+
+class FreshnessTest(BaseModel):
+    column: str
+    max_age: str
+
+
+class UniqueTest(BaseModel):
+    columns: list[str] = Field(min_length=1)
+
+
+class AcceptedValuesTest(BaseModel):
+    column: str
+    values: list[str] = Field(min_length=1)
+
+
+class SyncTest(BaseModel):
+    row_count: RowCountTest | None = None
+    not_null: NotNullTest | None = None
+    freshness: FreshnessTest | None = None
+    unique: UniqueTest | None = None
+    accepted_values: AcceptedValuesTest | None = None
+
+    @model_validator(mode="after")
+    def _check_exactly_one_test(self) -> SyncTest:
+        configured_tests = [
+            self.row_count,
+            self.not_null,
+            self.freshness,
+            self.unique,
+            self.accepted_values,
+        ]
+        configured_count = sum(test is not None for test in configured_tests)
+        if configured_count != 1:
+            raise ValueError("Exactly one sync test must be configured in each tests entry.")
+        return self
+
+
+class SlackAlertConfig(BaseModel):
+    type: Literal["slack"]
+    webhook_url: str | None = None
+    webhook_url_env: str | None = None
+    message: str = "drt sync `{sync_name}` failed: {error}"
+
+    @model_validator(mode="after")
+    def _check_url(self) -> SlackAlertConfig:
+        if not self.webhook_url and not self.webhook_url_env:
+            raise ValueError("Either webhook_url or webhook_url_env is required.")
+        return self
+
+
+class WebhookAlertConfig(BaseModel):
+    type: Literal["webhook"]
+    url: str | None = None
+    url_env: str | None = None
+    method: Literal["POST", "PUT"] = "POST"
+    headers: dict[str, str] = Field(default_factory=dict)
+    body_template: str | None = None  # JSON template; None → default JSON payload
+
+    @model_validator(mode="after")
+    def _check_url(self) -> WebhookAlertConfig:
+        if not self.url and not self.url_env:
+            raise ValueError("Either url or url_env is required.")
+        return self
+
+
+AlertItem = Annotated[
+    SlackAlertConfig | WebhookAlertConfig,
+    Field(discriminator="type"),
+]
+
+
+class AlertsConfig(BaseModel):
+    on_failure: list[AlertItem] = Field(default_factory=list)
+
+
+# Discriminated union — add new destination types here.
+# PARITY: the members below are hand-maintained and must match the connector
+# registry. tests/unit/test_cli_list_connectors.py::test_DESTINATIONS_matches_registry
+# guards that DESTINATIONS (and thus this surface) stays in sync with
+# drt/connectors/registry.py — update both when adding a destination.
+DestinationConfig = Annotated[
+    RestApiDestinationConfig
+    | SlackDestinationConfig
+    | DiscordDestinationConfig
+    | GitHubActionsDestinationConfig
+    | HubSpotDestinationConfig
+    | ZendeskDestinationConfig
+    | AmplitudeDestinationConfig
+    | MixpanelDestinationConfig
+    | SendGridDestinationConfig
+    | LinearDestinationConfig
+    | GoogleSheetsDestinationConfig
+    | PostgresDestinationConfig
+    | MySQLDestinationConfig
+    | TeamsDestinationConfig
+    | JiraDestinationConfig
+    | ClickHouseDestinationConfig
+    | ParquetDestinationConfig
+    | GoogleAdsDestinationConfig
+    | FileDestinationConfig
+    | S3DestinationConfig
+    | GCSDestinationConfig
+    | AzureBlobDestinationConfig
+    | EmailSmtpDestinationConfig
+    | NotionDestinationConfig
+    | IntercomDestinationConfig
+    | StagedUploadDestinationConfig
+    | SalesforceBulkDestinationConfig
+    | TwilioDestinationConfig
+    | SnowflakeDestinationConfig
+    | DatabricksDestinationConfig
+    | ElasticsearchDestinationConfig
+    | BigQueryDestinationConfig
+    | AirtableDestinationConfig
+    | KlaviyoDestinationConfig,
+    Field(discriminator="type"),
+]
+
+
+class SyncConfig(BaseModel):
+    name: str
+    description: str = ""
+    tags: list[str] = Field(default_factory=list)
+    model: str
+    destination: DestinationConfig
+    sync: SyncOptions = Field(default_factory=SyncOptions)
+    tests: list[SyncTest] = Field(default_factory=list)
+    alerts: AlertsConfig | None = None
+
+    @model_validator(mode="after")
+    def _inject_sync_name(self) -> SyncConfig:
+        # Destinations need the sync name to scope tracked-mirror state
+        # (#686), but the Destination protocol only receives SyncOptions —
+        # so carry it on a private attr rather than widening the protocol
+        # or exposing a user-settable YAML field.
+        self.sync._sync_name = self.name
+        return self

--- a/tests/unit/test_cli_list_connectors.py
+++ b/tests/unit/test_cli_list_connectors.py
@@ -117,8 +117,9 @@ def test_destinations_detailed_json_includes_field_metadata() -> None:
     assert set(pg.keys()) == expected_keys
     assert "table" in pg["required_fields"]
     assert "type: postgres" in pg["sample_yaml"]
-    # Postgres config class lives in drt.config.models
-    assert pg["config_class"].startswith("drt.config.models.PostgresDestinationConfig")
+    # Postgres config class lives in drt.config.destinations_sql after the #721
+    # split (re-exported from drt.config.models — both import paths work).
+    assert pg["config_class"].startswith("drt.config.destinations_sql.PostgresDestinationConfig")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Phase 1 of 2** off #721 — split `drt/config/models.py`; the credentials→profiles extraction is the follow-up PR. Draft for review (@masukai).

## What changed
Split the ~1300-line `drt/config/models.py` into cohesive modules; `models.py` becomes a **pure re-export facade** with an explicit `__all__` (72 names = the documented public surface). No class behavior, fields, or validation change — a mechanical move plus a `describe()` base.

- `base.py` — `DescribableConfig` (new) + auth, pagination, `RetryConfig`, `LookupConfig`, `SslConfig`, project/source primitives
- `destinations_sql.py` — `BaseSql` family + Snowflake / Databricks / BigQuery / Elasticsearch
- `destinations_saas.py` — webhook / CRM / messaging / issue-tracker / email / staged-upload
- `destinations_storage.py` — S3 / GCS / Azure / Parquet / File
- `sync_options.py` — retry consumers, tests, alerts, the `DestinationConfig` union, `SyncOptions` / `SyncConfig`
- `models.py` — re-exports all 72 + `__all__`

A shared `base.py` was necessary: `RetryConfig` is used by ~19 destination configs while `SyncConfig` needs the `DestinationConfig` union, so keeping `RetryConfig` in `sync_options` would be a circular import. Lifting the shared primitives into `base.py` gives a clean DAG (`base → destinations_* → sync_options → models`).

`DescribableConfig` dedups the **26** trivial `f"{type} (detail)"` `describe()` one-liners via a `_describe_detail` hook; **8** connectors with a hardcoded label keep their own.

## Verification
- **Whole-package `python -m mypy drt/` clean — 0 `no_implicit_reexport` errors across 148 files** (the #729 trap: single-file mypy would pass while the 135 import sites fail without the explicit `__all__`). The only remaining error is the pre-existing `credentials.py:368 [no-any-return]` — that file is **byte-identical to `main`** (`git diff` empty).
- **Structural parity proven:** snapshotted every model's fields / defaults / validators / JSON-schema before vs after — **67/67 schemas identical, all validators identical**. `describe()` output identical across all 34 destination configs.
- **Full `pytest -q`:** green except the known Windows `test_sqlite.py` `os.unlink` `PermissionError` flake (reproduces on clean `main`, passes on CI Linux).
- ruff clean.

## Registry-parity note
A comment at the `DestinationConfig` union points at `tests/unit/test_cli_list_connectors.py::test_DESTINATIONS_matches_registry`, which guards the hand-maintained union/registry drift.

## Two honest notes worth surfacing
1. **Public-surface count.** I enumerated the surface at **72** names; the tracking figure was 74. The gap looks like the new internal `DescribableConfig` (intentionally *not* exported — reachable via `drt.config.base`) plus a counting difference. Every name imported anywhere else is re-exported, and whole-package mypy confirms nothing is dropped — flagging so we can reconcile the 74.
2. **`config_class` output shift.** The split moves classes to real submodules, so `drt destinations --detailed --format json` now reports e.g. `drt.config.destinations_sql.PostgresDestinationConfig` (was `drt.config.models.…`). Both import paths work (re-export). One test asserted the old path; I updated it to the truthful new path rather than pin `__module__`. Called out since it's a (minor) observable output change.
3. **`retry` ForwardRef → eager.** Incidentally, `RetryConfig` was defined *after* its ~19 users in the old file, so their `retry:` field stayed an unresolved `ForwardRef` in `model_fields`; importing `RetryConfig` at the top of each module now resolves it eagerly. **JSON-schema is identical**, so validation is unchanged — reads as a latent tidy, not a behavior change, but noting it.

Acceptance bar met: whole-package mypy clean + full suite green (minus the known sqlite flake) + before/after schema parity.
