### PR TITLE
ci: run the full matrix on every PR, not just PRs based on main (closes #801)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,11 @@ name: CI
 on:
   push:
     branches: [main]
+  # No `branches:` filter here on purpose (#801). That filter matches the PR's
+  # *base*, so gating it on `main` exempted every stacked PR — a PR based on a
+  # feature branch ran only `cla` and still showed a green tick. It hid a real
+  # bug through five PRs. Every PR gets the matrix, whatever it targets.
   pull_request:
-    branches: [main]
   schedule:
     # Weekly nightly run (Mon 00:00 UTC) to catch env-drift / flaky tests
     # against fresh upstream dependencies, independent of PR/push activity.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,9 @@ name: CodeQL
 on:
   push:
     branches: [main]
+  # No `branches:` filter — see #801: it matches the PR's base, so gating on
+  # `main` silently exempts every stacked PR.
   pull_request:
-    branches: [main]
   schedule:
     # Weekly scan (Mon 03:00 UTC) — offset from ci.yml nightly (00:00 UTC)
     # so the two scheduled runs don't compete for runner capacity.

--- a/.github/workflows/vscode-schema-drift.yml
+++ b/.github/workflows/vscode-schema-drift.yml
@@ -28,8 +28,9 @@ on:
       - 'integrations/vscode-drt/schemas/**'
       - 'integrations/vscode-drt/scripts/regenerate-schemas.sh'
       - '.github/workflows/vscode-schema-drift.yml'
+  # No `branches:` filter — see #801: it matches the PR's base, so gating on
+  # `main` silently exempts every stacked PR. The `paths:` filter stays.
   pull_request:
-    branches: [main]
     paths:
       - 'drt/config/**'
       - 'integrations/vscode-drt/schemas/**'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,16 @@ drt uses **GitHub Flow** — all development happens on feature branches that me
 - No `develop` or `release` branches
 - Releases are marked with tags (`v0.2.0`, `v0.3.0`, …)
 
+### Stacked PRs — retarget the children *before* merging the parent
+
+A stacked PR (base = another feature branch, not `main`) is fine to open, but the merge order matters:
+
+1. **Retarget every child PR to `main` first** (`gh pr edit <child> --base main`).
+2. Then merge the parent, deleting its branch.
+3. Rebase each child onto `main` and merge in turn.
+
+Merging the parent *first* deletes a branch that an open PR still points at, and **GitHub silently closes that PR**. Worse, a force-push after the auto-close makes it permanently un-reopenable (`state cannot be changed. The <branch> branch was force-pushed or recreated`) — the PR, its review history, and its approvals are gone, and the work has to be re-filed. This is exactly how #792 was lost and had to come back as #800.
+
 ## Commit Signing (Required)
 
 The `main` branch requires **signed commits** to protect against supply chain attacks. All PRs are merged with **Squash & merge**, and GitHub automatically signs the squash commit — so **you don't need to set up signing just to contribute**.


### PR DESCRIPTION
## Summary

```yaml
  pull_request:
-   branches: [main]
```

The `branches:` filter on a `pull_request` trigger matches the PR's **base**. Gating it on `main` exempted **every stacked PR** — a PR based on a feature branch ran only `cla`. No tests, no ruff, no mypy, no codecov, and a green tick that meant nothing.

## Why this isn't theoretical

The #771 → #773 → #774 → #775 → #777 CLI stack (#791–#795) sat green for days. When #795 was finally retargeted to `main`, the matrix ran **for the first time** and all 6 `drt build` tests failed instantly:

```
AttributeError: '_FakeResult' object has no attribute 'watermark_lag'
```

A real bug — #788 added `watermark_lag` to `SyncResult`, the test fake never got it. @Muawiya-contact caught it by *reading the code*; CI was structurally incapable of catching it.

## Changes

- **`ci.yml`**, **`codeql.yml`** — drop the `branches:` filter from `pull_request` (keep it on `push`).
- **`vscode-schema-drift.yml`** — same, but its `paths:` filter stays; that one is doing real work.
- **`CONTRIBUTING.md`** — documents the merge-order rule the same incident taught us: **retarget child PRs to `main` before merging the parent.** Deleting a base branch out from under an open PR auto-closes it, and a force-push afterwards makes it permanently un-reopenable (`state cannot be changed. The <branch> branch was force-pushed or recreated`). That is how #792 was lost and had to be re-filed as #800.

Stacked PRs now cost Actions minutes. That is the point.

Closes #801