### PR TITLE
fix(cli): drt run --fail-fast --threads deadlocks when syncs are still queued

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,15 @@
 coverage:
   status:
+    # Whole-repo coverage stays advisory — existing low-coverage areas
+    # shouldn't fail a PR that merely touches a file near them.
     project:
       default:
         informational: true
+    # New/changed lines DO gate (#803): untested new code fails its PR.
+    # This is what would have caught the --fail-fast deadlock at review time —
+    # the cancellation branch was unhit and nothing acted on it.
     patch:
       default:
-        informational: true
+        target: 80%
+        threshold: 5%
+        informational: false

--- a/drt/cli/commands/run.py
+++ b/drt/cli/commands/run.py
@@ -143,9 +143,7 @@ def _run_one(
     if not ctx.dry_run and sync.sync.dlq is not None and sync.sync.dlq.enabled:
         from drt.state.dlq import DlqStore
 
-        observers.append(
-            DlqObserver(DlqStore(Path(".")), max_records=sync.sync.dlq.max_records)
-        )
+        observers.append(DlqObserver(DlqStore(Path(".")), max_records=sync.sync.dlq.max_records))
     observer = CompositeObserver(observers)
     if not ctx.json_mode and not ctx.dry_run and not ctx.quiet:
         print_sync_start(sync.name, ctx.dry_run)
@@ -412,7 +410,7 @@ def run(
     if diff and not dry_run:
         print_error("--diff requires --dry-run")
         raise typer.Exit(1)
-    from concurrent.futures import ThreadPoolExecutor, as_completed
+    from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 
     from drt.config.credentials import load_profile
     from drt.config.parser import load_project, load_syncs
@@ -603,20 +601,42 @@ def run(
             console.print(f"[dim]Running {len(syncs)} syncs with {threads} threads[/dim]\n")
         with ThreadPoolExecutor(max_workers=threads) as pool:
             futures = {pool.submit(_run_one, s, ctx, profile): s for s in syncs}
+            reaped: set[Future[Any]] = set()
             for future in as_completed(futures):
+                reaped.add(future)
+                name, entry, had_err = future.result()
+                json_results.append(entry)
+                if had_err:
+                    failed += 1
+                    if fail_fast:
+                        # Stop scheduling, then STOP ITERATING as_completed().
+                        #
+                        # shutdown(cancel_futures=True) calls Future.cancel() on
+                        # everything still queued, but a future cancelled that way
+                        # never reaches as_completed()'s waiter — the waiter is only
+                        # notified from set_running_or_notify_cancel(), which a worker
+                        # calls when it *picks up* the item, and these items were pulled
+                        # off the queue instead. Staying in the loop would block forever
+                        # waiting for futures that can never be delivered.
+                        pool.shutdown(wait=False, cancel_futures=True)
+                        break
+                else:
+                    succeeded += 1
+
+            # Reap what the loop above didn't: cancelled futures (never started —
+            # report them as skipped) and in-flight ones (let them drain; the
+            # with-block would wait for them regardless).
+            for future, sync in futures.items():
+                if future in reaped:
+                    continue
                 if future.cancelled():
-                    # --fail-fast cancelled it before a worker picked it up.
-                    json_results.append(_skipped_entry(futures[future]))
+                    json_results.append(_skipped_entry(sync))
                     skipped += 1
                     continue
                 name, entry, had_err = future.result()
                 json_results.append(entry)
                 if had_err:
                     failed += 1
-                    if fail_fast:
-                        # Stop scheduling; in-flight syncs drain normally
-                        # (the with-block's shutdown(wait=True) still waits).
-                        pool.shutdown(wait=False, cancel_futures=True)
                 else:
                     succeeded += 1
     else:

--- a/tests/unit/test_cli_run_parallel.py
+++ b/tests/unit/test_cli_run_parallel.py
@@ -183,17 +183,13 @@ def test_select_star_runs_every_sync(project: Path, patched_engine: dict[str, An
     assert set(patched_engine["calls"]) == {"sync_a", "sync_b", "sync_c"}
 
 
-def test_select_all_sentinel_runs_every_sync(
-    project: Path, patched_engine: dict[str, Any]
-) -> None:
+def test_select_all_sentinel_runs_every_sync(project: Path, patched_engine: dict[str, Any]) -> None:
     result = runner.invoke(app, ["run", "--select", "all", "--output", "json"])
     assert result.exit_code == 0
     assert set(patched_engine["calls"]) == {"sync_a", "sync_b", "sync_c"}
 
 
-def test_no_select_defaults_to_every_sync(
-    project: Path, patched_engine: dict[str, Any]
-) -> None:
+def test_no_select_defaults_to_every_sync(project: Path, patched_engine: dict[str, Any]) -> None:
     result = runner.invoke(app, ["run", "--output", "json"])
     assert result.exit_code == 0
     assert set(patched_engine["calls"]) == {"sync_a", "sync_b", "sync_c"}
@@ -237,9 +233,7 @@ def test_repeated_select_unions(project: Path, patched_engine: dict[str, Any]) -
     assert set(patched_engine["calls"]) == {"sync_a", "sync_c"}
 
 
-def test_exclude_subtracts_from_selection(
-    project: Path, patched_engine: dict[str, Any]
-) -> None:
+def test_exclude_subtracts_from_selection(project: Path, patched_engine: dict[str, Any]) -> None:
     result = runner.invoke(
         app, ["run", "--select", "tag:crm", "--exclude", "sync_b", "--output", "json"]
     )
@@ -253,9 +247,7 @@ def test_exclude_without_select(project: Path, patched_engine: dict[str, Any]) -
     assert set(patched_engine["calls"]) == {"sync_a", "sync_c"}
 
 
-def test_exclude_everything_exits_nonzero(
-    project: Path, patched_engine: dict[str, Any]
-) -> None:
+def test_exclude_everything_exits_nonzero(project: Path, patched_engine: dict[str, Any]) -> None:
     result = runner.invoke(app, ["run", "--exclude", "*", "--output", "json"])
     assert result.exit_code == 1
     assert patched_engine["calls"] == []
@@ -313,9 +305,7 @@ def test_failed_excludes_never_run_syncs(project: Path, patched_engine: dict[str
 def test_failed_intersects_with_select(project: Path, patched_engine: dict[str, Any]) -> None:
     _seed_state({"sync_a": "failed", "sync_c": "failed"})
 
-    result = runner.invoke(
-        app, ["run", "--failed", "--select", "tag:crm", "--output", "json"]
-    )
+    result = runner.invoke(app, ["run", "--failed", "--select", "tag:crm", "--output", "json"])
 
     assert result.exit_code == 0
     assert patched_engine["calls"] == ["sync_a"]  # sync_c failed but isn't tag:crm
@@ -339,9 +329,7 @@ def test_failed_with_clean_state_exits_zero_without_running(
 
 
 def test_limit_forwarded_to_engine(project: Path, patched_engine: dict[str, Any]) -> None:
-    result = runner.invoke(
-        app, ["run", "--select", "sync_a", "--limit", "10", "--output", "json"]
-    )
+    result = runner.invoke(app, ["run", "--select", "sync_a", "--limit", "10", "--output", "json"])
     assert result.exit_code == 0
     assert patched_engine["calls"] == ["sync_a"]
     assert patched_engine["limits"] == [10]
@@ -420,6 +408,79 @@ def test_fail_fast_with_threads_accounts_for_every_sync(
     assert len(payload["syncs"]) == 3
 
 
+def test_fail_fast_with_threads_cancels_queued_syncs(
+    project: Path, patched_engine: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """More syncs than workers, so some are still *queued* when the first one
+    fails — those get cancelled and must surface as ``skipped``.
+
+    The sibling test above runs 3 syncs on 3 threads, so every future starts
+    immediately and the ``future.cancelled()`` branch never executes. Without
+    this case, a regression that drops cancelled futures on the floor (losing
+    syncs from the report entirely) would go unnoticed.
+    """
+    # Named to sort *after* sync_a, so the failing sync is submitted first and
+    # the rest are still queued when it trips --fail-fast.
+    syncs_dir = project / "syncs"
+    for i in range(8):
+        name = f"zz_queued_{i}"
+        (syncs_dir / f"{name}.yml").write_text(
+            yaml.dump({**SYNC_B, "name": name, "tags": ["queued"]})
+        )
+
+    calls: list[str] = []
+    lock = threading.Lock()
+
+    def fake_run_sync(sync, *_a: Any, **_kw: Any) -> _FakeResult:
+        with lock:
+            calls.append(sync.name)
+        if sync.name == "sync_a":
+            return _FakeResult(success=0, failed=1)  # fails immediately
+        time.sleep(0.3)  # occupies its worker long enough for the queue to be cancelled
+        return _FakeResult(success=1, failed=0)
+
+    from drt.engine import sync as sync_module
+
+    monkeypatch.setattr(sync_module, "run_sync", fake_run_sync, raising=False)
+
+    result = runner.invoke(app, ["run", "--fail-fast", "--threads", "2", "--output", "json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    total = len(payload["syncs"])
+    assert total == 11  # sync_a/b/c + 8 queued
+    assert payload["succeeded"] + payload["failed"] + payload["skipped"] == total
+    # Cancellation actually happened: with 2 workers, most syncs never started.
+    assert payload["skipped"] > 0
+    assert len(calls) < total
+    skipped = [e for e in payload["syncs"] if e["status"] == "skipped"]
+    assert len(skipped) == payload["skipped"]
+    assert all(e["reason"] == "fail_fast" for e in skipped)
+    # A cancelled sync is reported, not silently dropped.
+    assert {e["name"] for e in payload["syncs"]} >= {f"zz_queued_{i}" for i in range(8)}
+
+
+def test_limit_applied_surfaces_in_json(
+    project: Path, patched_engine: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--limit`` must be echoed back per sync in JSON output, so a sampled
+    run is distinguishable from a full one after the fact."""
+    from drt.engine import sync as sync_module
+
+    def fake_run_sync(sync, *_a: Any, **kw: Any) -> _FakeResult:
+        res = _FakeResult(success=1, failed=0)
+        res.limit_applied = kw.get("extract_limit")
+        return res
+
+    monkeypatch.setattr(sync_module, "run_sync", fake_run_sync, raising=False)
+
+    result = runner.invoke(app, ["run", "--select", "sync_a", "--limit", "10", "--output", "json"])
+
+    assert result.exit_code == 0
+    entry = json.loads(result.output)["syncs"][0]
+    assert entry["limit"] == 10
+
+
 def test_limit_refused_for_mirror_and_replace(
     project: Path, patched_engine: dict[str, Any]
 ) -> None:
@@ -454,9 +515,7 @@ def test_limit_refused_for_mirror_and_replace(
 # ---------------------------------------------------------------------------
 
 
-def test_threads_flag_actually_parallelises(
-    project: Path, patched_engine: dict[str, Any]
-) -> None:
+def test_threads_flag_actually_parallelises(project: Path, patched_engine: dict[str, Any]) -> None:
     result = runner.invoke(
         app,
         ["run", "--select", "*", "--threads", "3", "--output", "json"],
@@ -468,9 +527,7 @@ def test_threads_flag_actually_parallelises(
     assert len(patched_engine["threads_seen"]) > 1
 
 
-def test_threads_one_runs_sequentially(
-    project: Path, patched_engine: dict[str, Any]
-) -> None:
+def test_threads_one_runs_sequentially(project: Path, patched_engine: dict[str, Any]) -> None:
     result = runner.invoke(
         app,
         ["run", "--select", "*", "--threads", "1", "--output", "json"],


### PR DESCRIPTION
## `drt run --fail-fast --threads N` hangs forever

Found while chasing an uncovered branch, not by a user report — but it is a real, reproducible deadlock on `main` right now.

### The bug

```python
# run.py (before)
with ThreadPoolExecutor(max_workers=threads) as pool:
    futures = {pool.submit(_run_one, s, ctx, profile): s for s in syncs}
    for future in as_completed(futures):
        if future.cancelled():          # ← never reached
            ...
        if had_err and fail_fast:
            pool.shutdown(wait=False, cancel_futures=True)
            # ...and we keep iterating as_completed()
```

`shutdown(cancel_futures=True)` **pulls the queued work items off the queue** and calls `Future.cancel()` on each. A future cancelled that way never reaches `as_completed()`'s waiter: the waiter is only notified from `set_running_or_notify_cancel()`, which a worker calls when it *picks up* an item — and these items were removed from the queue instead of being picked up.

So `as_completed()` sits in `waiter.event.wait()` waiting for futures that can never be delivered:

```
Current thread (blocked):
  concurrent/futures/_base.py:243 in as_completed
  drt/cli/commands/run.py:606 in run
```

**Trigger:** any `drt run --fail-fast --threads N` where a sync fails while another is still queued — i.e. whenever `len(syncs) > threads`. The command never returns. In CI that's a job that burns until the step timeout.

### Why nobody caught it

The existing threaded fail-fast test runs **3 syncs on 3 threads**. Every future starts immediately, nothing is ever queued, and the `future.cancelled()` branch never executes. Coverage reported `run.py:607-611` as unhit — but nothing acted on it, because `codecov.yml` sets `informational: true` on **both** `project` and `patch`, so codecov can never fail a PR. Combined with #801 (the matrix didn't even run on the stacked PRs), the net was thinner than the green ticks suggested.

### The fix

Break out of `as_completed()` when fail-fast trips, then reap the remaining futures directly:

- **cancelled** (never started) → reported as `skipped` with `reason: fail_fast`
- **in-flight** → drained via `future.result()` (the `with`-block waits for them regardless)

Every sync is still accounted for exactly once.

### Tests

- `test_fail_fast_with_threads_cancels_queued_syncs` — **11 syncs, 2 threads**, the failing sync submitted first, so futures are genuinely still queued when it trips. Asserts cancellation actually happened (`skipped > 0`, fewer syncs executed than defined), every sync appears in the report, and cancelled ones carry `reason: fail_fast`. **This test hangs on the current `main`.**
- `test_limit_applied_surfaces_in_json` — `run.py:240` (`entry["limit"]`) was also unhit; a sampled run must be distinguishable from a full one in JSON output.

Ran the parallel suite 6× to make sure the new timing-sensitive test isn't flaky: 29 passed each time.

### Note

Introduced by #794, which is **unreleased** — this never shipped in a tagged version, so no CHANGELOG `Fixed` entry (it would describe a bug users never saw).

Separately: I'd suggest making codecov's `patch` status a real gate (`target: 80%`) instead of informational, so untested new code fails its PR. Happy to do that in a follow-up if you agree.
