### PR TITLE
docs(adr): manifest schema v1 + docs theme — the two written records #500 still owed (closes #500)

### DIFF
--- a/docs/adr/0001-drt-docs-manifest.md
+++ b/docs/adr/0001-drt-docs-manifest.md
@@ -1,0 +1,102 @@
+# ADR 0001 — `drt docs` manifest schema v1
+
+- **Status:** Accepted (implemented; shipped across v0.7.5 – v0.7.11)
+- **Issue:** [#500](https://github.com/drt-hub/drt/issues/500), under epic [#499](https://github.com/drt-hub/drt/issues/499)
+- **Implementation:** `drt/docs/manifest.py` (schema), `drt/docs/builder.py` (producer)
+
+## Context
+
+The `drt docs` epic (#499) ships in phases — P1 Mermaid text, P2 `manifest.json`,
+P3 static HTML site, P4 `drt docs serve` — and every phase needs the same facts:
+which syncs exist, what they read and write, how they relate. Deriving those
+facts inside each renderer would couple every output format to the config
+parser and the state store, and would let the formats drift apart.
+
+dbt's `manifest.json` is the precedent worth copying: one documented artifact
+between "understand the project" and "render something", stable enough that
+third parties build on it.
+
+## Decision
+
+### One intermediate artifact, one producer
+
+`build_manifest()` is the only code that reads project config and run state for
+documentation purposes. Every renderer (Mermaid, HTML, and the emitted
+`manifest.json` itself) consumes a `Manifest` — never the config parser or
+state manager directly. The MCP server's docs tool returns the same manifest,
+so LLM consumers and the static site can never disagree.
+
+### Schema v1 shape
+
+Frozen dataclasses (`Project`, `Source`, `Destination`, `Sync`,
+`SyncStateSnapshot`, `Edge`, `Manifest`), serialized by hand in
+`to_dict()`/`from_dict()` (round-trip safe). Not pydantic: the builder is the
+only writer, so there is nothing to validate on the way in, and frozen
+dataclasses make accidental mutation in a renderer a `TypeError` instead of a
+subtle bug.
+
+The graph model is three node kinds plus typed edges:
+
+```
+sources ── source_to_sync ──> syncs ── sync_to_destination ──> destinations
+                              syncs <────── lookup ─────────── syncs
+```
+
+`EdgeKind = source_to_sync | sync_to_destination | lookup`. Lookup edges are
+heuristic — sync A's `lookups.*.table` matched against sync B's
+`destination.table` (with a short-name alias for `schema.table`) draws
+`B → A`. Heuristic is acceptable in v1 because a false negative only omits a
+dashed edge; nothing downstream breaks.
+
+### Versioning
+
+`schema_version` is a single integer, currently `1`. Additive, optional fields
+do **not** bump it; renames and removals do. `drt_version` rides alongside for
+debugging, but consumers must key behaviour off `schema_version` only.
+
+### Public names decoupled from runtime names
+
+`SyncStateSnapshot` deliberately renames the runtime fields
+(`last_run_at → last_sync_at`, `records_synced → rows_synced`): the manifest is
+a public contract, `drt/state/manager.py` is not, and the persistence layer
+must be free to evolve without a schema bump.
+
+### State is opt-in
+
+Run state (`include_state=True`, CLI default; `--no-state` to disable) attaches
+a `state` block per sync; syncs that never ran omit the block entirely. The
+split exists because the catalog half of the manifest is a **function of the
+repo** (reproducible anywhere from the YAML alone) while state is a function of
+one machine's `.drt/state.json` — CI-generated docs and locally generated docs
+should differ only in the parts that honestly differ.
+
+### Determinism
+
+Same project in, same bytes out, with exactly one exception: `generated_at`
+(ISO-8601 UTC) lives **only** in `manifest.json` — never in rendered pages —
+so regenerating docs for an unchanged project produces a one-line git diff
+(#697, enforced by `test_regeneration_is_byte_identical`). Iteration order is
+pinned (sorted sync files, insertion-ordered node maps); the builder reads no
+clocks (beyond that one stamp), randomness, or unordered sets.
+
+### Destination identity and labels
+
+Syncs that target the same destination share one node. v1 as shipped derived
+the node id from a slug of `describe()` and carried `describe()` verbatim as
+`label`. **Amended by #696:** ids are now `dest_<type>_<sha1(describe())[:8]>`
+and labels are docs-safe by default (`describe_safe()`; `--full-labels`
+restores verbatim output) — the slugged form baked endpoints into page
+filenames, and verbatim labels published internal endpoints and contact
+identities the moment `target/docs/` was hosted. Both changes are
+`schema_version`-neutral: the field shapes are unchanged, only the values.
+
+## Consequences
+
+- Renderers are independent and testable against hand-built manifests; the
+  HTML suite never touches a real project.
+- `manifest.json` ships inside the site output, so anything that applies to
+  hosted pages (redaction, determinism) applies to the manifest too.
+- Known v2 candidates, deliberately excluded from v1: `field_mappings`/`mask`
+  exposure for column-level lineage (L2, #702), run/DLQ history for the DLQ
+  badge (#698), and model-SQL source-table extraction (needs SQL parsing).
+  Each is additive in spirit but reshapes `Sync`, so they land together as v2.

--- a/docs/adr/0002-drt-docs-theme.md
+++ b/docs/adr/0002-drt-docs-theme.md
@@ -1,0 +1,99 @@
+# ADR 0002 — `drt docs` visual design: tokens, layout chrome, lineage language
+
+- **Status:** Accepted (implemented; shipped across v0.7.11 and the #702 design train)
+- **Issue:** [#500](https://github.com/drt-hub/drt/issues/500), under epic [#499](https://github.com/drt-hub/drt/issues/499); follow-ups tracked in [#702](https://github.com/drt-hub/drt/issues/702)
+- **Implementation:** `drt/docs/_html_assets.py` (tokens + CSS), `drt/docs/dag.py` / `_svg.py` (lineage)
+- **Design artifacts:** `docs/design/drt-docs-prototype.html` (chrome + palette), `docs/design/drt-docs-lineage-mock.html` (lineage language), screenshots alongside
+
+## Context
+
+`drt docs generate --format html` (#677) produces a static site that must work
+**hosted or opened via `file://`**, with no CDN, no runtime framework, and no
+build step. The audience is the same as dbt docs': engineers checking "what
+syncs exist, what feeds what, what ran last". Design decisions were made
+against ASCII mockups on #500, then two HTML prototypes, and refined through
+the #702 train (#704 tokens/tabs/badges · #751 empty states · #752 code chrome
+& mobile · #753 a11y/finishing · #796 static SVG DAG).
+
+## Decision
+
+### Layout chrome: dbt-docs-shaped
+
+Top bar (brand · project · nav · search) + collapsible left sidebar
+(syncs / sources / destinations / tags) + right detail panel. All five views
+share this chrome; only the panel content changes. This is the layout data
+engineers already know how to read — familiarity is a feature, not a lack of
+imagination.
+
+### Design tokens: one `:root` block, nowhere else
+
+Every color, radius, and font stack is a CSS custom property declared in a
+single `:root` block in `_html_assets.py`, with one `prefers-color-scheme:
+dark` override block beside it. **New tokens are added there, never mid-file**
+— the block is the palette's single source of truth, and the dark theme stays
+complete because it overrides the same names it can see.
+
+- **Brand:** violet scale around `--brand-600: #7c3aed` (50→900). Used for
+  nav-active, links, the "managed by drt" zone, and lookup edges.
+- **Neutrals:** `--ink-*` scale (50→900) feeding semantic surface/text tokens
+  (`--bg`, `--fg`, `--muted`, `--line`, `--surface`, `--chip`).
+- **Status:** `--success` / `--warning` / `--error`, always rendered as
+  **dot + word pairs — never color alone** (color-blind safety is a hard rule,
+  not a preference).
+- **Type & shape:** system font stacks only (`ui-sans-serif`, `ui-monospace` —
+  no webfonts, keeps `file://` and offline honest), 14px base, `--radius: 8px`.
+
+### Theming: `prefers-color-scheme`, no JS toggle
+
+Light/dark follows the OS. A manual toggle needs JS and persisted preference —
+both against the site's no-runtime baseline. Revisit only if the interactivity
+layer (#702) lands and users ask.
+
+### Lineage visual language (settled on #677/#702)
+
+The DAG page renders the language of `drt-docs-lineage-mock.html`:
+
+- **Ownership zone bands**, left to right: `SOURCES — external · read` |
+  `SYNCS — managed by drt` (brand-tinted band + pill) | `DESTINATIONS —
+  external · write`. The zones state drt's contract at a glance: drt owns the
+  middle column and only *touches* the outer two.
+- **Forward edges** as bezier curves with arrowheads; **lookup back-edges** as
+  dashed brand-colored "subway lanes" routed over the top — visually secondary,
+  because they are derived hints, not data flow.
+- **Node cards** (fixed 54px height) with connector **brand badges**, each
+  linked to its detail page; the same card component serves the per-sync ego
+  lineage on sync pages.
+- **Detail levels:** L0 project DAG and L1 ego lineage shipped; L2
+  column-level lineage is deferred until manifest v2 carries
+  `field_mappings`/`mask` (ADR 0001, consequences).
+
+### Static SVG, not a rendering library
+
+The DAG is an inline SVG emitted from a hand-rolled deterministic layout engine
+(#713/#796), replacing runtime Mermaid. Reasons, in order: **byte-identical
+output** (same manifest, same bytes — #697's diffability contract extends to
+the diagram), **`file://` safety** (no CDN script tag), and **themeability**
+(the SVG references the same CSS tokens, so dark mode is free). The trade —
+maintaining our own layout code — was accepted because docs-shaped DAGs are
+narrow: three ranks, modest fan-out, no cycles.
+
+### Accessibility & robustness floor (#753)
+
+Skip link, `:focus-visible` rings, tab ARIA, print styles, and a search empty
+state are part of the theme, not optional polish. Anything interactive added
+later (#702's ego-view/hover layer) must degrade to plain links when JS is
+unavailable.
+
+## Consequences
+
+- The site has **zero runtime dependencies**; the whole theme is vendored CSS
+  plus inline SVG. Framework churn cannot break old docs.
+- Visual regression is guarded by the byte-identical test rather than
+  screenshot diffing; a Playwright screenshot lane remains a future option
+  (#702) if the CSS surface grows.
+- The single `:root` contract makes palette changes one-block diffs — and
+  makes it obvious in review when someone tries to introduce a color anywhere
+  else.
+- Scale mode (compact density for large projects) and the interactivity layer
+  remain open on #702 and must work within these tokens and the no-JS
+  baseline.


### PR DESCRIPTION
## Summary

Closes #500 — the last item on the v0.8 release gate (after #697 closed verified-done and #696 → #805).

#500 listed three deliverables; `drt/docs/manifest.py` shipped long ago, so what remained was the **written record**. This adds it:

- **`docs/adr/0001-drt-docs-manifest.md`** — schema v1: one-producer/many-renderers, frozen dataclasses, versioning policy (additive ≠ bump), public-vs-runtime name decoupling, opt-in state, the determinism contract (#697), heuristic lookup edges, and the #696 amendment (hashed ids + safe labels). Ends with the v2 candidates and why they wait.
- **`docs/adr/0002-drt-docs-theme.md`** — the settled visual design: dbt-docs chrome, single-`:root` token contract (brand `#7c3aed`), `prefers-color-scheme` no-JS theming, the lineage language (ownership zones / bezier + dashed subway edges / node cards), static-SVG-over-library reasoning, and the #753 a11y floor. Points at the prototypes under `docs/design/`.

Everything in both documents describes decisions **already implemented** — every claim is checkable against `_html_assets.py`, `dag.py`/`_svg.py`, `manifest.py`, and the #702 train. Nothing changes behaviour; docs-only.

## Note for @masukai

0002 is a written record of *your* design decisions (#677/#702/#704 and the mockups you posted on #500) as reconstructed from the code and issue history. Worth a read to confirm the reasoning matches your actual intent — especially the zone-band rationale and the no-JS-toggle call. Happy to reword anything that puts words in your mouth.