### PR TITLE
docs(roadmap): correct v0.8.3 scope — #470 + #693 core, #471/#472 feedback-gated

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -150,11 +150,13 @@ Two additive features accumulated since v0.7.5 — a new **Amplitude destination
 **Theme:** Polish and follow-ups for the `--diff` feature shipped in v0.7.1.
 
 **Scope:**
-- **Diff UX** — `--diff-fields` column filter (#471) · API-based diff for upsert-keyed SaaS destinations (#472)
 - **Diff perf** — batch lookup queries for large diff sets (#470)
-- **Lookup correctness** — first-miss-wins YAML order semantics (#453)
+- **Mirror preview** — `--dry-run --diff` previews mirror deletions for destination / tracked / scoped strategies (#693); tracked is read-only and the highest-value preview
+- **Diff UX** *(feedback-gated, pull in on demand)* — `--diff-fields` column filter (#471, parking spot until wide-table readability is reported) · opt-in API-based diff for upsert-keyed SaaS destinations (#472)
 
-**Out of scope:** New destinations, engine features unrelated to `--diff`.
+**Out of scope:** New destinations, engine features unrelated to `--diff`. Delta/Iceberg predicate pushdown (#679) is a source-side perf item, not `--diff` — tracked separately.
+
+*Already shipped:* lookup first-miss-wins ambiguity warning (#453) landed in **v0.7.5** (PR #521); the stale milestone tag is being cleared.
 
 **Target:** Cut from v0.8 once Cloud Destinations land · **Progress:** [milestone/10](https://github.com/drt-hub/drt/milestone/10)
 


### PR DESCRIPTION
## What

Corrects the **v0.8.3 "Diff Polish"** scope in ROADMAP.md to match reality after auditing merged work against the milestone board.

## Why

The scope section had three inaccuracies:

1. **#453 listed as pending** — but the lookup first-miss-wins ambiguity warning shipped in **v0.7.5** (PR #521). Its `v0.8.3` milestone tag was stale; cleared in this pass.
2. **#471 / #472 flattened into core scope** — both are explicitly **feedback-gated parking spots** in their issue bodies (`--diff-fields` waits on wide-table readability reports; API-based SaaS diff is blocked on per-record API-call cost). They shouldn't read as committed v0.8.3 work.
3. **#679 mislabeled** — it's a **source-side** Delta/Iceberg predicate-pushdown perf item, not a `--diff` feature.

## After this change, v0.8.3 core =

- **#470** — batch destination lookup by source PKs (`WHERE key IN (…)`)
- **#693** — `--dry-run --diff` previews mirror deletions (tracked read-only → scoped → destination)

with #471/#472 as pull-in-on-demand, and #679 noted as a separate source-side track.

## Housekeeping done alongside

- Removed stale `v0.8.3` milestone from **#453** (shipped v0.7.5) with an explanatory comment.

No code change — docs/roadmap only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)