### PR TITLE
fix(test): disambiguate --store-failures slug collisions (closes #835)

### DIFF
--- a/drt/cli/commands/test.py
+++ b/drt/cli/commands/test.py
@@ -47,21 +47,38 @@ class _SyncTestResult(TypedDict, total=False):
     reason: str
 
 
-def _test_id(test_def: SyncTest, index: int) -> str:
+def _test_id(test_def: SyncTest, index: int, seen: set[str] | None = None) -> str:
     """Filesystem-safe identifier for one test, for --store-failures paths (#779).
 
     An explicit ``name:`` is trusted as unique (the operator chose it — same
-    convention as dbt's singular-test-by-filename). Without one, falls back to
-    a slugified display name prefixed with the test's position in ``tests:``,
-    so two same-shaped tests (e.g. two ``not_null`` tests) never collide.
+    convention as dbt's singular-test-by-filename) *unless* it collides with
+    another test's slug in the same sync (#835): ``"email nn"`` and
+    ``"email/nn"`` both slugify to ``email-nn``, and without disambiguation the
+    second write silently overwrites the first test's sample — the one thing
+    ``--store-failures`` exists to preserve. ``seen`` tracks slugs already
+    claimed in this sync; a collision falls back to the same
+    ``{index}-{slug}`` prefixing the no-``name:`` path already uses, so it
+    only changes the filename for the tests that would otherwise clobber each
+    other, not every explicitly-named test.
+
+    Without a ``name:``, falls back to a slugified display name prefixed with
+    the test's position in ``tests:``, so two same-shaped tests (e.g. two
+    ``not_null`` tests) never collide in the first place.
     """
     from drt.engine.test_runner import test_display_name
 
     if test_def.name:
-        return _TEST_ID_RE.sub("-", test_def.name).strip("-").lower() or f"{index}-test"
-    base = test_display_name(test_def)
-    slug = _TEST_ID_RE.sub("-", base).strip("-").lower() or "test"
-    return f"{index}-{slug}"
+        slug = _TEST_ID_RE.sub("-", test_def.name).strip("-").lower() or f"{index}-test"
+    else:
+        base = test_display_name(test_def)
+        base_slug = _TEST_ID_RE.sub("-", base).strip("-").lower() or "test"
+        slug = f"{index}-{base_slug}"
+
+    if seen is not None:
+        if slug in seen:
+            slug = f"{index}-{slug}"
+        seen.add(slug)
+    return slug
 
 
 def _store_or_clear_failure_sample(
@@ -165,6 +182,7 @@ def execute_tests_for_sync(
         return sync_results, False
 
     table = get_table_name(sync.destination)
+    seen_test_ids: set[str] = set()
     for index, test_def in enumerate(sync.tests):
         test_name = test_display_name(test_def)
         if dry_run:
@@ -220,7 +238,7 @@ def execute_tests_for_sync(
                     stored = _store_or_clear_failure_sample(
                         sync=sync,
                         test_def=test_def,
-                        test_id=_test_id(test_def, index),
+                        test_id=_test_id(test_def, index, seen_test_ids),
                         failing_rows_query=failing_rows_query,
                         passed=passed,
                         project_dir=project_dir,

--- a/tests/unit/test_store_failures.py
+++ b/tests/unit/test_store_failures.py
@@ -587,3 +587,72 @@ def test_default_severity_matches_pre_779_behavior(
     assert payload["status"] == "failed"
     assert payload["warnings"] == []
     assert payload["results"][0]["tests"][0]["severity"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# --store-failures slug collisions (#835): two differently-named tests whose
+# `name:` slugifies to the same string must not overwrite each other's file.
+# ---------------------------------------------------------------------------
+
+
+def test_store_failures_disambiguates_colliding_slugs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`"email nn"` and `"email/nn"` both slugify to `email-nn` — without
+    disambiguation the second write silently clobbers the first test's
+    sample, which is exactly the failure `--store-failures` exists to let an
+    operator see."""
+    monkeypatch.chdir(tmp_path)
+    _write_sync(
+        tmp_path,
+        {
+            "name": "orders_sync",
+            "model": "SELECT 1",
+            "destination": _DEST,
+            "tests": [
+                {"not_null": {"columns": ["email"]}, "name": "email nn"},
+                {"not_null": {"columns": ["other"]}, "name": "email/nn"},
+            ],
+        },
+    )
+    _patch_destination_query(
+        monkeypatch, count=1, rows=[{"id": 1, "email": "a@example.com"}]
+    )
+    result = runner.invoke(app, ["test", "--store-failures"])
+
+    assert result.exit_code == 1
+    failures_dir = tmp_path / ".drt" / "test_failures" / "orders_sync"
+    # Both tests failed and both must have left a sample — a collision would
+    # leave only one file (the second write clobbering the first).
+    written = sorted(p.name for p in failures_dir.glob("*.jsonl"))
+    assert len(written) == 2, f"expected 2 sample files, found {written}"
+
+
+def test_test_id_disambiguates_within_seen_set() -> None:
+    from drt.cli.commands.test import _test_id
+    from drt.config.sync_options import NotNullTest, SyncTest
+
+    a = SyncTest(name="email nn", not_null=NotNullTest(columns=["email"]))
+    b = SyncTest(name="email/nn", not_null=NotNullTest(columns=["other"]))
+
+    seen: set[str] = set()
+    id_a = _test_id(a, 0, seen)
+    id_b = _test_id(b, 1, seen)
+
+    assert id_a != id_b
+    assert id_a == "email-nn"  # first claim keeps the clean slug
+    assert id_b == "1-email-nn"  # collision falls back to the index prefix
+
+    # Without a seen set (the old call shape), both still collide — locks the
+    # bug this issue reports, not just the fix.
+    assert _test_id(a, 0) == _test_id(b, 1) == "email-nn"
+
+
+def test_test_id_path_traversal_stays_neutralized() -> None:
+    """Regression guard requested by #835: the collision fix must not
+    reopen the path-traversal case that was already handled correctly."""
+    from drt.cli.commands.test import _test_id
+    from drt.config.sync_options import NotNullTest, SyncTest
+
+    t = SyncTest(name="../../etc/passwd", not_null=NotNullTest(columns=["id"]))
+    assert _test_id(t, 0, set()) == "etc-passwd"


### PR DESCRIPTION
Closes #835 — a follow-up from the #830 review.

## The bug

Two differently-named tests in one sync can slug to the same `--store-failures` filename:

```yaml
tests:
  - name: "email nn"      # -> email-nn.jsonl
    not_null: {columns: [email]}
  - name: "email/nn"      # -> email-nn.jsonl  (same file — clobbered)
    not_null: {columns: [other]}
```

The second write silently overwrote the first test's sample — exactly the failure `--store-failures` exists to preserve. The `index` prefix that would have prevented it was applied only on the no-`name:` fallback path, which is the one that doesn't need it.

## Why not the config-layer fix (issue's option (c))

The issue calls out `_check_exactly_one_test`'s fail-loud pydantic convention as the more honest fix. I looked at it first, and it's not reachable: computing the no-`name:` fallback slug needs `test_display_name` from `engine/test_runner.py`, which already imports `config.models` — so a config-layer validator calling back into it would be circular.

## What this does instead (option (b))

`_test_id` takes an optional `seen: set[str]`, threaded through `execute_tests_for_sync`'s loop. A slug already claimed in this sync falls back to the same `{index}-{slug}` prefix the no-`name:` path already uses. Only the *colliding* tests' filenames change — every other explicitly-named test keeps its clean slug, so this isn't a blanket rename.

## Verification

- **Reproduced the bug before fixing it**: stashed the implementation change, ran the new collision test, confirmed it fails with 1 file where 2 were expected. Restored and confirmed green.
- New tests: the CLI-level collision case (two failing tests, both must leave a sample), a focused `_test_id` unit test asserting disambiguation, and a path-traversal regression guard per the issue's acceptance criteria (`"../../etc/passwd"` still slugs to `etc-passwd`).
- Full suite: **2327 passed, 5 skipped**. `mypy` / `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)