### PR TITLE
fix(cli): split warnings[] value/error rather than collapsing them (closes #837)

### DIFF
--- a/drt/cli/commands/test.py
+++ b/drt/cli/commands/test.py
@@ -256,18 +256,28 @@ def execute_tests_for_sync(
 def _collect_warnings(results: list[_SyncTestResult]) -> list[dict[str, object]]:
     """Flatten every ``severity: warn`` failure across *results* into a
     top-level list (#779) — so CI tooling can react without walking the
-    nested per-sync/per-test structure."""
+    nested per-sync/per-test structure.
+
+    Carries ``value`` when the test ran and returned one (a threshold
+    breach — the data quality is known and numeric) or ``error`` when it
+    raised (an infrastructure failure — the data quality is simply unknown)
+    (#837). Never both, mirroring the per-test entry shape in
+    ``results[].tests[]`` that already keeps these separate. A consumer
+    counting "warnings over time" needs to be able to tell them apart —
+    collapsing them into one ``value`` key silently mixed outages into a
+    data-quality signal, and broke a numeric parse of ``value`` on the
+    exception case with no way to have predicted it.
+    """
     warnings: list[dict[str, object]] = []
     for r in results:
         for t in r.get("tests", []):
             if t.get("severity") == "warn" and t.get("passed") is False:
-                warnings.append(
-                    {
-                        "sync": r["sync"],
-                        "test": t.get("name"),
-                        "value": t.get("value", t.get("error")),
-                    }
-                )
+                entry: dict[str, object] = {"sync": r["sync"], "test": t.get("name")}
+                if "error" in t:
+                    entry["error"] = t["error"]
+                else:
+                    entry["value"] = t.get("value")
+                warnings.append(entry)
     return warnings
 
 

--- a/tests/unit/test_store_failures.py
+++ b/tests/unit/test_store_failures.py
@@ -479,6 +479,70 @@ def test_severity_warn_failure_reported_but_exit_zero(
     assert payload["warnings"][0]["sync"] == "s"
 
 
+def test_warnings_carry_value_for_a_threshold_breach(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#837: a warn test that ran and failed its check must surface `value`,
+    not `error` — the data quality is known (3 stale rows), not unknown."""
+    monkeypatch.chdir(tmp_path)
+    _write_sync(
+        tmp_path,
+        {
+            "name": "s",
+            "model": "SELECT 1",
+            "destination": _DEST,
+            "tests": [
+                {
+                    "freshness": {"column": "updated_at", "max_age": "1 hour"},
+                    "severity": "warn",
+                }
+            ],
+        },
+    )
+    _patch_destination_query(monkeypatch, count=3)
+    result = runner.invoke(app, ["test", "--output", "json"])
+    payload = json_mod.loads(result.output)
+    warning = payload["warnings"][0]
+    assert warning["value"] == "3"
+    assert "error" not in warning
+
+
+def test_warnings_carry_error_for_an_exception_not_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#837: a warn test whose query raised must surface `error`, not a
+    `value` masquerading as one — the exception text is not test data."""
+    monkeypatch.chdir(tmp_path)
+    _write_sync(
+        tmp_path,
+        {
+            "name": "s",
+            "model": "SELECT 1",
+            "destination": _DEST,
+            "tests": [
+                {
+                    "freshness": {"column": "updated_at", "max_age": "1 hour"},
+                    "severity": "warn",
+                }
+            ],
+        },
+    )
+    from drt.destinations import query as query_module
+
+    monkeypatch.setattr(query_module, "is_queryable", lambda d: True)
+    monkeypatch.setattr(query_module, "get_table_name", lambda d: "test_table")
+
+    def _raise(dest: object, q: str) -> int:
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(query_module, "execute_test_query", _raise)
+    result = runner.invoke(app, ["test", "--output", "json"])
+    payload = json_mod.loads(result.output)
+    warning = payload["warnings"][0]
+    assert warning["error"] == "connection refused"
+    assert "value" not in warning
+
+
 def test_severity_error_failure_exits_nonzero(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #837 — a follow-up from the #830 review, landing before `warnings[]` ships as public contract.

## Problem

`_collect_warnings()` emitted:
```python
"value": t.get("value", t.get("error"))
```
so a consumer reading `warnings[].value` couldn't tell a threshold breach (the test ran, returned `"3"`) from an exception (the destination was unreachable, `value` is exception text). A dashboard counting "warnings over time" would silently mix in outages; a numeric parse of `value` fails unpredictably on the exception case.

## Fix

Carries `value` when the test produced one, `error` when it raised — never both — mirroring the shape `results[].tests[]` already uses (that dict distinguishes `value` vs `error` per-entry; only the flattened `warnings[]` view was collapsing them).

## Why now

`warnings[]` is new public contract introduced by #830 (not yet released to users at the time of this PR). Splitting the key now is free; splitting it after release is a breaking change for anyone who started consuming it.

## Verification

- Reproduced the bug before fixing: the exception-case test fails against the old implementation with `KeyError: 'error'` (collapsed under `value` instead).
- Two new tests: the threshold-breach case carries `value` and no `error` key; the exception case carries `error` and no `value` key.
- Full suite: **2325 passed, 5 skipped**. `mypy` / `ruff` clean.

Sets up #838 (`drt build` adopting the same shape) — coordinated per that issue's note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)