### PR TITLE
feat(cli): drt build --output json gets warnings[] parity with drt test (closes #838)

### DIFF
--- a/drt/cli/commands/build.py
+++ b/drt/cli/commands/build.py
@@ -187,6 +187,19 @@ def build(
         )
 
     if json_mode:
+        from drt.cli.commands.test import _collect_warnings
+
+        # (#838) drt build runs the same tests through the same
+        # execute_tests_for_sync seam as drt test and honours the same
+        # severity rule, but its JSON had no warnings[] — a CI pipeline
+        # running drt build had to reimplement _collect_warnings in jq to
+        # get what drt test hands over directly. Each entry already carries
+        # "tests" in exactly the shape _collect_warnings expects; only the
+        # sync-name key differs (entry["name"] here vs. "sync" there, since
+        # entries also holds run-level fields _collect_warnings doesn't
+        # touch), so remap that one key rather than re-deriving the list.
+        warning_input = [{**e, "sync": e["name"]} for e in entries]
+
         print(
             json.dumps(
                 {
@@ -195,6 +208,7 @@ def build(
                     "failed": failed,
                     "skipped": skipped,
                     "total_duration_seconds": total_duration,
+                    "warnings": _collect_warnings(warning_input),
                 },
                 indent=2,
             )

--- a/drt/cli/commands/test.py
+++ b/drt/cli/commands/test.py
@@ -17,8 +17,9 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import typer
 
@@ -271,10 +272,17 @@ def execute_tests_for_sync(
     return sync_results, had_failures
 
 
-def _collect_warnings(results: list[_SyncTestResult]) -> list[dict[str, object]]:
+def _collect_warnings(
+    results: Sequence[_SyncTestResult] | Sequence[Mapping[str, Any]],
+) -> list[dict[str, object]]:
     """Flatten every ``severity: warn`` failure across *results* into a
     top-level list (#779) — so CI tooling can react without walking the
     nested per-sync/per-test structure.
+
+    Accepts either ``drt test``'s own ``_SyncTestResult`` or ``drt build``'s
+    per-sync ``dict[str, object]`` entries (#838) — both carry the same
+    ``sync`` + ``tests`` shape this function actually reads, so ``drt build``
+    reuses this rather than re-implementing it against a narrower type.
 
     Carries ``value`` when the test ran and returned one (a threshold
     breach — the data quality is known and numeric) or ``error`` when it

--- a/tests/unit/test_cli_build.py
+++ b/tests/unit/test_cli_build.py
@@ -278,3 +278,64 @@ def test_build_missing_project_exits_nonzero(
     result = runner.invoke(app, ["build"])
 
     assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# warnings[] parity with `drt test` (#838)
+# ---------------------------------------------------------------------------
+
+
+def test_build_json_includes_warnings_array_matching_drt_test_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, patched_runtime: dict[str, Any]
+) -> None:
+    """`drt build` shares execute_tests_for_sync and honours the same
+    severity rule as `drt test`, but its JSON had no top-level `warnings[]`
+    — a CI pipeline running `drt build` had to reimplement `_collect_warnings`
+    in jq to get what `drt test` hands over directly (#838)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "drt_project.yml").write_text("name: demo\nprofile: default\n")
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    (syncs_dir / "warn_sync.yml").write_text(
+        yaml.dump(
+            {
+                "name": "warn_sync",
+                "model": "SELECT 1",
+                "destination": QUERYABLE_DEST,
+                "tests": [
+                    {
+                        "not_null": {"columns": ["id"]},
+                        "severity": "warn",
+                        "name": "id_nn",
+                    }
+                ],
+            }
+        )
+    )
+    patched_runtime["null_count"]["value"] = 3  # fails the check
+
+    result = runner.invoke(app, ["build", "--output", "json"])
+
+    # A severity: warn failure is reported but must not fail the build.
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["succeeded"] == 1
+    assert len(payload["warnings"]) == 1
+    warning = payload["warnings"][0]
+    assert warning["sync"] == "warn_sync"
+    assert warning["test"] == "not_null(id_nn)"
+    # #837's split: a threshold breach carries `value`, never `error`.
+    assert warning["value"] == "3"
+    assert "error" not in warning
+
+
+def test_build_json_warnings_empty_when_no_warn_severity_failures(
+    project: Path, patched_runtime: dict[str, Any]
+) -> None:
+    """The default fixture has no severity: warn tests — warnings[] must be
+    present and empty, not absent, so JSON consumers see a stable shape."""
+    result = runner.invoke(app, ["build", "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["warnings"] == []


### PR DESCRIPTION
Closes #838 — a follow-up from the #830 review.

**Stacked on #852 (#837).** This branch includes that commit because #838 needs its `value`/`error` split rather than the old collapsed shape — GitHub will show both diffs until #852 merges, at which point this PR reduces to just the `#838` commit. Please land #852 first.

## Problem

`drt build` runs tests through the same `execute_tests_for_sync` seam as `drt test` and honours the same `severity: warn` rule, but its `--output json` had no top-level `warnings[]` array. Since `drt build` (sync + validate) is the more likely CI entrypoint of the two, it was the *harder* one to get a warn-severity signal out of — a pipeline had to reimplement `_collect_warnings` in `jq`.

## Fix

`_collect_warnings()`'s parameter type widened from `list[_SyncTestResult]` to `Sequence[_SyncTestResult] | Sequence[Mapping[str, Any]]`, so `drt build`'s per-sync entries can reuse it directly. One wrinkle: `drt build`'s entries key the sync name as `"name"`, not `"sync"` (`_run_one`'s return shape, unrelated to this issue) — remapped that one key before calling, rather than re-deriving the whole list. `mypy` needed `Sequence` specifically (not `list`, which is invariant) to accept both callers without a `type: ignore`.

## Verification

- Reverted `build.py`'s change, confirmed both new tests fail with `KeyError('warnings')`, restored.
- Two new tests: `warnings[]` present with the right shape when a `severity: warn` test fails (adopting #837's `value`/`error` split), and present-but-empty (not absent) when there's nothing to report — JSON consumers get a stable shape either way.
- Full suite: **2327 passed, 5 skipped**. `mypy` / `ruff` clean, no `type: ignore` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)