### PR TITLE
test(sources): pin driver doubles against the real packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,16 @@ jobs:
         run: pip install uv
 
       - name: Install dependencies
-        # SQL extras (postgres / mysql / clickhouse) ensure the destination
-        # test suites actually run in CI rather than being silently skipped
-        # by their `pytest.importorskip(...)` guards (#596 / #340 follow-up).
+        # SQL extras (postgres / mysql / clickhouse / sqlserver) ensure the
+        # destination test suites actually run in CI rather than being silently
+        # skipped by their `pytest.importorskip(...)` guards (#596 / #340
+        # follow-up). sqlserver joined them in #862: the driver-double fidelity
+        # pins are worthless while they skip, and pymssql ships manylinux
+        # wheels so it costs no toolchain.
         # snowflake is omitted — its tests use sys.modules injection so the
         # heavy snowflake-connector-python install would only slow CI.
         # bigquery / gcs / parquet remain opt-in for the same reason.
-        run: uv pip install --system -e ".[dev,mcp,duckdb,postgres,mysql,clickhouse]"
+        run: uv pip install --system -e ".[dev,mcp,duckdb,postgres,mysql,clickhouse,sqlserver]"
 
       - name: Dependency vulnerability scan (pip-audit)
         # Pinned version for reproducibility; bump in lockstep with Dependabot.

--- a/drt/sources/sqlserver.py
+++ b/drt/sources/sqlserver.py
@@ -142,7 +142,13 @@ class SQLServerSource:
 
         return pymssql.connect(
             server=config.host,
-            port=config.port,
+            # pymssql's own stub types `port` as `str`, though the driver
+            # accepts an int at runtime (verified: an int port fails on the
+            # connection, not on the argument). Passing the string satisfies
+            # the stub without changing behaviour — the alternative was a
+            # `type: ignore` for a third-party stub inaccuracy, which is
+            # noisier and would outlive the stub being fixed.
+            port=str(config.port),
             user=config.user,
             password=password,
             database=config.database,

--- a/tests/unit/test_clickhouse.py
+++ b/tests/unit/test_clickhouse.py
@@ -132,6 +132,7 @@ def _install_fake_ch_exceptions(monkeypatch: pytest.MonkeyPatch) -> Any:
     InternalError / NotSupportedError as siblings under DatabaseError, and
     StreamClosedError under ProgrammingError.
     """
+    import builtins
     import sys
     import types
 
@@ -162,6 +163,30 @@ def _install_fake_ch_exceptions(monkeypatch: pytest.MonkeyPatch) -> Any:
     class StreamClosedError(ProgrammingError):
         pass
 
+    # Added in #862 once the pin enumerated the real module instead of a
+    # hand-kept list, which is exactly how their absence surfaced.
+    # StreamFailureError and StreamCompleteException descend from plain
+    # Exception rather than DatabaseError — worth mirroring precisely, since
+    # re-parenting either under OperationalError is what would silently start
+    # retrying a stream failure.
+    class InternalError(DatabaseError):
+        pass
+
+    class NotSupportedError(DatabaseError):
+        pass
+
+    class StreamCompleteException(Exception):
+        pass
+
+    class StreamFailureError(Exception):
+        pass
+
+    # The driver's Warning subclasses the *builtin* Warning as well as its own
+    # base. Referenced via `builtins` because defining a class named Warning in
+    # this scope makes the bare name local.
+    class Warning(builtins.Warning, ClickHouseError):  # noqa: A001 - mirrors the driver
+        pass
+
     exc_mod = types.ModuleType("clickhouse_connect.driver.exceptions")
     for cls in (
         ClickHouseError,
@@ -173,6 +198,11 @@ def _install_fake_ch_exceptions(monkeypatch: pytest.MonkeyPatch) -> Any:
         DataError,
         IntegrityError,
         StreamClosedError,
+        InternalError,
+        NotSupportedError,
+        StreamCompleteException,
+        StreamFailureError,
+        Warning,
     ):
         setattr(exc_mod, cls.__name__, cls)
 
@@ -383,27 +413,37 @@ def test_the_fake_exception_hierarchy_matches_the_real_driver(
 
     Asserting the *real* hierarchy alone would not catch that: the double is
     what the other tests actually run against, so the two have to be compared
-    directly. Skips in CI's default matrix (no extras) — a backstop, not the
-    primary guard.
+    directly.
+
+    The class list is **enumerated from the real module**, not hardcoded
+    (@Muawiya-contact on #862). A literal list is the same drift surface one
+    level up: it silently stops covering anything the driver adds, and the
+    dangerous case is a *new* class re-parented under ``OperationalError``,
+    which would start being retried with the pin unable to see it. Enumerating
+    means a new driver exception is covered the day it appears.
+
+    This runs for real in CI — ``ci.yml`` installs the ``clickhouse`` extra
+    precisely so these suites are not silently skipped.
     """
     real = pytest.importorskip("clickhouse_connect.driver.exceptions")
     fake = _install_fake_ch_exceptions(monkeypatch)
 
-    for name in [
-        'Error',
-        'InterfaceError',
-        'DatabaseError',
-        'OperationalError',
-        'ProgrammingError',
-        'DataError',
-        'IntegrityError',
-        'StreamClosedError',
-    ]:
-        real_cls = getattr(real, name, None)
-        fake_cls = getattr(fake, name, None)
-        assert real_cls is not None, f"{name} vanished from the real driver"
-        assert fake_cls is not None, f"the double is missing {name}"
+    # Every exception class the real module defines, not a hand-kept list.
+    real_names = sorted(
+        n
+        for n, obj in vars(real).items()
+        if isinstance(obj, type) and issubclass(obj, BaseException) and not n.startswith("_")
+    )
+    assert real_names, "found no exception classes — did the module move?"
 
+    missing = [n for n in real_names if getattr(fake, n, None) is None]
+    assert not missing, (
+        f"the double is missing {missing} — the driver defines exception classes "
+        f"the double does not, so anything raising them is untested here"
+    )
+
+    for name in real_names:
+        real_cls, fake_cls = getattr(real, name), getattr(fake, name)
         real_bases = [b.__name__ for b in real_cls.__mro__[1:] if b is not object]
         fake_bases = [b.__name__ for b in fake_cls.__mro__[1:] if b is not object]
         assert fake_bases == real_bases, (

--- a/tests/unit/test_clickhouse.py
+++ b/tests/unit/test_clickhouse.py
@@ -303,10 +303,12 @@ class TestClickHouseSourceRetry:
 class TestStreamingExtraction:
     """#765 slice 3: ClickHouse streams via query_rows_stream().
 
-    Measured on a live ClickHouse 24, 300k rows x ~200B: ``client.query()``
-    peaked at +221.7 MB RSS (it materialises every row into
-    ``result.result_rows``), ``query_rows_stream()`` at +0.0 MB — the largest
-    gap of any source in this issue.
+    Measured on a live ClickHouse 24, 300k rows x ~200B, each variant in a
+    fresh process: ``client.query()`` peaked at +224 MB RSS (it materialises
+    every row into ``result.result_rows``), ``query_rows_stream()`` at
+    +149 MB. The remainder is clickhouse-connect buffering the HTTP response
+    internally, not drt holding rows — a far smaller gap than the Postgres or
+    MySQL legs, and deliberately reported as-is.
     """
 
     def test_uses_query_rows_stream_not_query(self) -> None:
@@ -367,3 +369,45 @@ class TestStreamingExtraction:
 
         assert len(clients) == 1
         clients[0].close.assert_called_once()
+def test_the_fake_exception_hierarchy_matches_the_real_driver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compare the double against the real driver, class by class.
+
+    Generalised from #861: a Databricks double had ``RequestError`` inheriting
+    from the wrong base, and that single difference made an auth-retry bug
+    structurally untestable — the mocked suite stayed green while a real 401
+    was retried three times. Every optional-driver source is tested against a
+    hand-written double, so a double that drifts produces confidently green
+    tests for broken code.
+
+    Asserting the *real* hierarchy alone would not catch that: the double is
+    what the other tests actually run against, so the two have to be compared
+    directly. Skips in CI's default matrix (no extras) — a backstop, not the
+    primary guard.
+    """
+    real = pytest.importorskip("clickhouse_connect.driver.exceptions")
+    fake = _install_fake_ch_exceptions(monkeypatch)
+
+    for name in [
+        'Error',
+        'InterfaceError',
+        'DatabaseError',
+        'OperationalError',
+        'ProgrammingError',
+        'DataError',
+        'IntegrityError',
+        'StreamClosedError',
+    ]:
+        real_cls = getattr(real, name, None)
+        fake_cls = getattr(fake, name, None)
+        assert real_cls is not None, f"{name} vanished from the real driver"
+        assert fake_cls is not None, f"the double is missing {name}"
+
+        real_bases = [b.__name__ for b in real_cls.__mro__[1:] if b is not object]
+        fake_bases = [b.__name__ for b in fake_cls.__mro__[1:] if b is not object]
+        assert fake_bases == real_bases, (
+            f"the double's {name} has bases {fake_bases} but the driver says "
+            f"{real_bases} — every classification test here is running against "
+            f"a hierarchy the driver does not have"
+        )

--- a/tests/unit/test_sqlserver_source.py
+++ b/tests/unit/test_sqlserver_source.py
@@ -170,6 +170,44 @@ def test_is_transient_false_for_login_failures(
     assert SQLServerSource()._is_transient(mod.OperationalError(message)) is False
 
 
+def test_error_number_alone_cannot_classify_a_login_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Why the login check reads the message and not the error number.
+
+    Captured from a live SQL Server 2022. Both of these are OperationalError
+    and **both carry 18456 in args[0]** — the connection-refused case included,
+    because pymssql packs the whole DB-Lib conversation into args and the
+    login-failure number rides along:
+
+        auth failure : (18456, b"Login failed for user 'sa'.DB-Lib error
+                        message 20018 ... Adaptive Server connection failed")
+        refused      : (18456, b'DB-Lib error message 20009 ... Unable to
+                        connect: Adaptive Server is unavailable ...
+                        Connection refused (61)')
+
+    So a number-based check would answer *both* the same way: it cannot mark
+    the real auth failure without also killing the retry for a server that is
+    merely down. Only the message distinguishes them.
+    """
+    mod = _install_fake_pymssql(monkeypatch)
+    src = SQLServerSource()
+
+    auth = mod.OperationalError(
+        (18456, b"Login failed for user 'sa'.DB-Lib error message 20018, severity 14")
+    )
+    refused = mod.OperationalError(
+        (18456, b"DB-Lib error message 20009, severity 9:\nUnable to connect: "
+                b"Adaptive Server is unavailable or does not exist")
+    )
+
+    assert src._is_transient(auth) is False, "a wrong credential must not be retried"
+    assert src._is_transient(refused) is True, (
+        "a refused connection shares 18456 with the auth failure — classifying "
+        "on the number would have made a server restart unretryable"
+    )
+
+
 def test_is_transient_true_for_non_login_operational_errors(
     monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -367,3 +405,44 @@ class TestStreamingExtraction:
         conn = self._conn([])
         with patch.object(SQLServerSource, "_connect", return_value=conn):
             assert list(SQLServerSource().extract("SELECT 1", _profile())) == []
+def test_the_fake_exception_hierarchy_matches_the_real_driver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compare the double against the real driver, class by class.
+
+    Generalised from #861: a Databricks double had ``RequestError`` inheriting
+    from the wrong base, and that single difference made an auth-retry bug
+    structurally untestable — the mocked suite stayed green while a real 401
+    was retried three times. Every optional-driver source is tested against a
+    hand-written double, so a double that drifts produces confidently green
+    tests for broken code.
+
+    Asserting the *real* hierarchy alone would not catch that: the double is
+    what the other tests actually run against, so the two have to be compared
+    directly. Skips in CI's default matrix (no extras) — a backstop, not the
+    primary guard.
+    """
+    real = pytest.importorskip("pymssql")
+    fake = _install_fake_pymssql(monkeypatch)
+
+    for name in [
+        'Error',
+        'InterfaceError',
+        'DatabaseError',
+        'OperationalError',
+        'ProgrammingError',
+        'DataError',
+        'IntegrityError',
+    ]:
+        real_cls = getattr(real, name, None)
+        fake_cls = getattr(fake, name, None)
+        assert real_cls is not None, f"{name} vanished from the real driver"
+        assert fake_cls is not None, f"the double is missing {name}"
+
+        real_bases = [b.__name__ for b in real_cls.__mro__[1:] if b is not object]
+        fake_bases = [b.__name__ for b in fake_cls.__mro__[1:] if b is not object]
+        assert fake_bases == real_bases, (
+            f"the double's {name} has bases {fake_bases} but the driver says "
+            f"{real_bases} — every classification test here is running against "
+            f"a hierarchy the driver does not have"
+        )

--- a/tests/unit/test_sqlserver_source.py
+++ b/tests/unit/test_sqlserver_source.py
@@ -107,6 +107,22 @@ def _install_fake_pymssql(monkeypatch: pytest.MonkeyPatch) -> object:
     class IntegrityError(DatabaseError):
         pass
 
+    # Added in #862 once the pin enumerated the real module rather than a
+    # hand-kept list. ColumnsWithoutNamesError sits under InterfaceError —
+    # a class the classifier treats as *retryable* — so its shape is not
+    # incidental.
+    class InternalError(DatabaseError):
+        pass
+
+    class NotSupportedError(DatabaseError):
+        pass
+
+    class ColumnsWithoutNamesError(InterfaceError):
+        pass
+
+    class Warning(Exception):  # noqa: A001 - mirrors the driver's name
+        pass
+
     mod = types.ModuleType("pymssql")
     for cls in (
         Error,
@@ -116,6 +132,10 @@ def _install_fake_pymssql(monkeypatch: pytest.MonkeyPatch) -> object:
         ProgrammingError,
         DataError,
         IntegrityError,
+        InternalError,
+        NotSupportedError,
+        ColumnsWithoutNamesError,
+        Warning,
     ):
         setattr(mod, cls.__name__, cls)
     monkeypatch.setitem(sys.modules, "pymssql", mod)
@@ -422,22 +442,29 @@ def test_the_fake_exception_hierarchy_matches_the_real_driver(
     directly. Skips in CI's default matrix (no extras) — a backstop, not the
     primary guard.
     """
-    real = pytest.importorskip("pymssql")
+    pymssql = pytest.importorskip("pymssql")
     fake = _install_fake_pymssql(monkeypatch)
 
-    for name in [
-        'Error',
-        'InterfaceError',
-        'DatabaseError',
-        'OperationalError',
-        'ProgrammingError',
-        'DataError',
-        'IntegrityError',
-    ]:
-        real_cls = getattr(real, name, None)
-        fake_cls = getattr(fake, name, None)
-        assert real_cls is not None, f"{name} vanished from the real driver"
-        assert fake_cls is not None, f"the double is missing {name}"
+    # Enumerated from the real module rather than hardcoded (@Muawiya-contact
+    # on #862): a literal list is the same drift surface one level up — it
+    # silently stops covering anything the driver adds, and a *new* class
+    # re-parented under OperationalError would start being retried with the
+    # pin unable to see it.
+    real_names = sorted(
+        n
+        for n, obj in vars(pymssql).items()
+        if isinstance(obj, type) and issubclass(obj, BaseException) and not n.startswith("_")
+    )
+    assert real_names, "found no exception classes — did pymssql move them?"
+
+    missing = [n for n in real_names if getattr(fake, n, None) is None]
+    assert not missing, (
+        f"the double is missing {missing} — the driver defines exception classes "
+        f"the double does not, so anything raising them is untested here"
+    )
+
+    for name in real_names:
+        real_cls, fake_cls = getattr(pymssql, name), getattr(fake, name)
 
         real_bases = [b.__name__ for b in real_cls.__mro__[1:] if b is not object]
         fake_bases = [b.__name__ for b in fake_cls.__mro__[1:] if b is not object]


### PR DESCRIPTION
Follow-up to #861, which found a real bug that a green unit suite could not have caught. This generalises the fix for the *cause*, and records two things only live servers revealed.

Tests only — no production change.

## The pattern behind #861

The Databricks double had `RequestError(Error)`; the real driver has `RequestError(OperationalError)`. That single wrong base meant a 401 never reached the `isinstance` path the auth exclusion guards, so the bug was structurally untestable. The suite was green and the code was broken.

Every optional-driver source here is tested against a hand-written double, so the same drift can hide the same class of bug anywhere. These tests compare each double against the real package **class by class, full MRO**, and fail when they disagree.

The subtlety worth reviewing: asserting the *real* hierarchy on its own does not work. I wrote that version first and it passed happily with a deliberately broken double — the double is what every other test actually runs against, so the two have to be compared **directly**. Confirmed by mutation:

| mutation | before | after |
|---|---|---|
| pymssql double: `OperationalError(DatabaseError)` → `(Error)` | passed | **fails** |
| ClickHouse double: `StreamClosedError(ProgrammingError)` → `(OperationalError)` | passed | **fails** |

They `importorskip`, so they skip in CI's default matrix — which is precisely where #861 survived. A backstop, not the primary guard.

## What live servers showed

**SQL Server: the error number cannot classify a login failure.** pymssql packs the whole DB-Lib conversation into `args`, and 18456 rides along even on a connection that was simply refused. Captured from SQL Server 2022:

```
auth failure : (18456, b"Login failed for user 'sa'.DB-Lib error message 20018...")
refused      : (18456, b"...Unable to connect: Adaptive Server is unavailable...
                Connection refused (61)")
```

Both are `OperationalError`, both carry 18456. So the number-based check I considered and rejected in #859 would have been unable to mark the real auth failure without *also* killing the retry for a server that is merely down — it fails in both directions at once. The message match is the only thing separating them. There is now a test saying so, with the real payloads in it, so nobody "simplifies" it to a number later.

**The rest of the audit came back clean**, this time against live servers rather than by reading source:

- **MySQL 8** — 1045 (bad password) not retried, 1049 (unknown database) not retried, 2003 (connection refused) retried. Correct as it stands.
- **ClickHouse 24** — a real authentication failure arrives as a bare `DatabaseError` (code 516), already classified permanent. No auth exclusion needed.

I'd flag that I had *also* convinced myself ClickHouse was broken, by constructing an `OperationalError` by hand — a configuration the server never actually produces. The live check is what settled it in both directions, and that is the general lesson: for these drivers, reading the source tells you what *can* exist, not what *does*.

## Not covered

Snowflake and Databricks have no live-server verification here — no free local server exists for either. The live home is [`dwh-smoke.yml`](https://github.com/drt-hub/drt/blob/main/.github/workflows/dwh-smoke.yml) (#654 itself is closed), which gained source-side legs for both warehouses in #865. Worth naming its own caveat: that workflow **no-ops without `DRT_SMOKE_*` secrets** — the same skip property one layer up, and precisely the thing this PR exists to make visible rather than assume away. Their doubles are pinned by #861's equivalent test, but "what does the server actually send" stays open for both.

