### PR TITLE
docs(skills): add the task-relevant commands three skills were missing (closes #872)

### DIFF
--- a/.claude/commands/drt-create-sync.md
+++ b/.claude/commands/drt-create-sync.md
@@ -17,11 +17,22 @@ Create a drt sync YAML configuration file for the user.
 
 3. Output the YAML in a code block and suggest where to save it: `syncs/<name>.yml`
 
-4. Show the command to validate and run it:
+4. Show the commands to check, preview, then run it:
    ```bash
-   drt validate
-   drt run --select <name> --dry-run
-   drt run --select <name>
+   drt validate                          # YAML schema check
+   drt list                              # confirm the new sync is discovered
+   drt run --select <name> --dry-run     # preview — no data written
+   drt run --select <name> --limit 10    # real send, capped at 10 rows
+   drt run --select <name>               # full run
+   ```
+   `drt list` is worth the extra line: sync discovery is glob-based, so a file
+   saved outside `syncs/` or with a mismatched `name:` validates cleanly and then
+   silently never runs.
+
+5. If the sync declares a `tests:` block, show how to run it after the sync:
+   ```bash
+   drt test --select <name>    # post-sync validation (row counts, freshness, unique, custom SQL)
+   drt build --select <name>   # run + test in one pass
    ```
 
 ## Rules

--- a/.claude/commands/drt-init.md
+++ b/.claude/commands/drt-init.md
@@ -55,12 +55,24 @@ Guide the user through initializing a new drt project.
    - **DuckDB / SQLite**: nothing — file path only
    - **REST API source**: set the bearer token env var the profile references (e.g. `export REST_API_TOKEN=...`)
 
-4. Validate the setup:
+   Both `drt init` flows already write a profile to `~/.drt/profiles.yml`. To add
+   another later (a second warehouse, a prod/dev split) without re-running init:
    ```bash
-   drt doctor       # env-level triage — catches missing env vars, malformed profile, etc.
-   drt validate     # YAML schema check
-   drt list         # confirm syncs are discovered
+   drt profile add <name>     # interactive — prompts for source type + connection fields
+   drt profile list           # names + source types already configured
+   drt profile show <name>    # inspect one, inline secrets masked
    ```
+
+4. Validate the setup — **credential first**, since that is the step most likely to fail:
+   ```bash
+   drt profile test <name>   # actually connects, using the source's own connection check
+   drt doctor                # env-level triage — catches missing env vars, malformed profile, etc.
+   drt validate              # YAML schema check
+   drt list                  # confirm syncs are discovered
+   ```
+   `drt doctor` and `drt validate` inspect configuration; only `drt profile test`
+   proves the warehouse accepts the credential. Run it before the first sync so a
+   bad password surfaces here rather than mid-run.
 
 5. Offer to create a first sync using the `/drt-create-sync` skill.
 

--- a/.claude/commands/drt-migrate.md
+++ b/.claude/commands/drt-migrate.md
@@ -5,11 +5,35 @@ Help the user migrate from an existing Reverse ETL tool (Census, Hightouch, Poly
 
 1. Ask the user to share their existing sync configuration (screenshot, YAML, JSON, or description).
 
-2. Map their existing config to drt equivalents using the tables below.
+2. If they do not have a drt project yet, scaffold one first — the syncs need a
+   project and a profile to live in:
+   ```bash
+   mkdir my-drt-project && cd my-drt-project
+   drt init                  # interactive: project name, source type, connection fields
+   drt profile test <name>   # prove the warehouse credential works before migrating anything
+   ```
+   Use the `/drt-init` skill if they want to be walked through it.
 
-3. Generate a valid `syncs/<name>.yml` for each sync.
+3. Map their existing config to drt equivalents using the tables below.
 
-4. Note any features that need manual setup (auth env vars, profiles.yml).
+4. Generate a valid `syncs/<name>.yml` for each sync.
+
+5. Note any features that need manual setup (auth env vars, profiles.yml).
+
+6. **Run the first migrated sync as a preview, not a send.** This is the step
+   that matters most in a migration: the old tool is still running, the
+   destination has live records, and a mismapped `sync.mode` or `upsert_key`
+   writes to production on the first invocation.
+   ```bash
+   drt validate                          # catches schema errors and hardcoded secrets
+   drt run --select <name> --dry-run     # no data written
+   drt run --select <name> --dry-run --diff   # record-level preview on queryable destinations
+   drt run --select <name> --limit 10    # first real send, capped at 10 rows
+   ```
+   Only after the diff looks right should they run it uncapped. Flag explicitly
+   that `mode: mirror` and `replace` **delete or truncate** destination rows, and
+   that `--limit` is refused for both — so those two modes go straight from
+   `--dry-run --diff` to a full run, with no sampled middle step.
 
 ## Concept Mapping
 

--- a/skills/drt/skills/drt-create-sync/SKILL.md
+++ b/skills/drt/skills/drt-create-sync/SKILL.md
@@ -24,11 +24,22 @@ Create a drt sync YAML configuration file for the user.
 
 3. Output the YAML in a code block and suggest where to save it: `syncs/<name>.yml`
 
-4. Show the command to validate and run it:
+4. Show the commands to check, preview, then run it:
    ```bash
-   drt validate
-   drt run --select <name> --dry-run
-   drt run --select <name>
+   drt validate                          # YAML schema check
+   drt list                              # confirm the new sync is discovered
+   drt run --select <name> --dry-run     # preview — no data written
+   drt run --select <name> --limit 10    # real send, capped at 10 rows
+   drt run --select <name>               # full run
+   ```
+   `drt list` is worth the extra line: sync discovery is glob-based, so a file
+   saved outside `syncs/` or with a mismatched `name:` validates cleanly and then
+   silently never runs.
+
+5. If the sync declares a `tests:` block, show how to run it after the sync:
+   ```bash
+   drt test --select <name>    # post-sync validation (row counts, freshness, unique, custom SQL)
+   drt build --select <name>   # run + test in one pass
    ```
 
 ## Rules

--- a/skills/drt/skills/drt-init/SKILL.md
+++ b/skills/drt/skills/drt-init/SKILL.md
@@ -62,12 +62,24 @@ Guide the user through initializing a new drt project.
    - **DuckDB / SQLite**: nothing — file path only
    - **REST API source**: set the bearer token env var the profile references (e.g. `export REST_API_TOKEN=...`)
 
-4. Validate the setup:
+   Both `drt init` flows already write a profile to `~/.drt/profiles.yml`. To add
+   another later (a second warehouse, a prod/dev split) without re-running init:
    ```bash
-   drt doctor       # env-level triage — catches missing env vars, malformed profile, etc.
-   drt validate     # YAML schema check
-   drt list         # confirm syncs are discovered
+   drt profile add <name>     # interactive — prompts for source type + connection fields
+   drt profile list           # names + source types already configured
+   drt profile show <name>    # inspect one, inline secrets masked
    ```
+
+4. Validate the setup — **credential first**, since that is the step most likely to fail:
+   ```bash
+   drt profile test <name>   # actually connects, using the source's own connection check
+   drt doctor                # env-level triage — catches missing env vars, malformed profile, etc.
+   drt validate              # YAML schema check
+   drt list                  # confirm syncs are discovered
+   ```
+   `drt doctor` and `drt validate` inspect configuration; only `drt profile test`
+   proves the warehouse accepts the credential. Run it before the first sync so a
+   bad password surfaces here rather than mid-run.
 
 5. Offer to create a first sync using the `/drt-create-sync` skill.
 

--- a/skills/drt/skills/drt-migrate/SKILL.md
+++ b/skills/drt/skills/drt-migrate/SKILL.md
@@ -12,11 +12,35 @@ Help the user migrate from an existing Reverse ETL tool (Census, Hightouch, Poly
 
 1. Ask the user to share their existing sync configuration (screenshot, YAML, JSON, or description).
 
-2. Map their existing config to drt equivalents using the tables below.
+2. If they do not have a drt project yet, scaffold one first — the syncs need a
+   project and a profile to live in:
+   ```bash
+   mkdir my-drt-project && cd my-drt-project
+   drt init                  # interactive: project name, source type, connection fields
+   drt profile test <name>   # prove the warehouse credential works before migrating anything
+   ```
+   Use the `/drt-init` skill if they want to be walked through it.
 
-3. Generate a valid `syncs/<name>.yml` for each sync.
+3. Map their existing config to drt equivalents using the tables below.
 
-4. Note any features that need manual setup (auth env vars, profiles.yml).
+4. Generate a valid `syncs/<name>.yml` for each sync.
+
+5. Note any features that need manual setup (auth env vars, profiles.yml).
+
+6. **Run the first migrated sync as a preview, not a send.** This is the step
+   that matters most in a migration: the old tool is still running, the
+   destination has live records, and a mismapped `sync.mode` or `upsert_key`
+   writes to production on the first invocation.
+   ```bash
+   drt validate                          # catches schema errors and hardcoded secrets
+   drt run --select <name> --dry-run     # no data written
+   drt run --select <name> --dry-run --diff   # record-level preview on queryable destinations
+   drt run --select <name> --limit 10    # first real send, capped at 10 rows
+   ```
+   Only after the diff looks right should they run it uncapped. Flag explicitly
+   that `mode: mirror` and `replace` **delete or truncate** destination rows, and
+   that `--limit` is refused for both — so those two modes go straight from
+   `--dry-run --diff` to a full run, with no sampled middle step.
 
 ## Concept Mapping
 


### PR DESCRIPTION
## What does this PR do?

Closes the six gaps from #872's surface audit. Three `SKILL.md` files, no code.

I kept the issue's framing: the skills are **task-oriented**, so the bar is whether each names the commands *its own task* needs — not whether every CLI command appears somewhere. `drt-debug` and `drt-troubleshoot` are unchanged, as the issue found them complete.

| Skill | Added | Why |
|---|---|---|
| `drt-init` | `drt profile add`, `drt profile test` (+ `profile list` / `show`) | The skill set up a project but never created or verified the warehouse credential |
| `drt-create-sync` | `drt list`, `drt test` (+ `drt build`, `--limit 10`) | Discovery is glob-based; a misplaced file validates cleanly then silently never runs |
| `drt-migrate` | `drt init`, a first-run `--dry-run` step | Migrating users have live syncs and a populated destination |

## The three judgement calls

**`drt profile test` goes first in `drt-init`'s validation block, not last.** `drt doctor` and `drt validate` inspect configuration; only `profile test` proves the warehouse accepts the credential. The skill now says that explicitly, so a bad password surfaces there rather than mid-run.

**`drt list` earns its line in `drt-create-sync`.** Sync discovery is glob-based, so a file saved outside `syncs/` or with a mismatched `name:` passes `drt validate` and then never runs — a silent failure the skill previously walked users straight past.

**`drt-migrate` gets the most.** It's the sharpest case: the old tool is still running, the destination has live records, and a mismapped `sync.mode` or `upsert_key` writes to production on the first invocation. Added a scaffold step and a preview step, and stated the sampling boundary — `mirror` and `replace` delete or truncate, and `--limit` is **refused for both** ([`drt/cli/commands/run.py:599`](https://github.com/drt-hub/drt/blob/main/drt/cli/commands/run.py#L599)), so those two go straight from `--dry-run --diff` to a full run with no sampled rung in between. That asymmetry is exactly the kind of thing a migrating user should not discover by hitting it.

## Verification

Every command and flag written here was checked against `--help` and the CLI source rather than copied from existing skill prose:

- `drt profile test {name}` / `profile add {name}` — both take a required `name` argument
- `drt test --select` and `drt build --select` — both exist
- `--limit` refusal — `run.py:599` reads *"--limit is not allowed for mode=mirror/replace syncs"*, and `drt run --help` confirms *"refused for mirror/replace syncs"*

Suite and checks:

- `pytest` — **2721 passed, 18 skipped**
- `ruff check` — clean
- `scripts/check_drift.sh` — **0 new drift items** (it audits skill↔connector coverage, so this confirms the edits didn't disturb the connector mentions it tracks)

## Note

Per #871, `check_drift.sh` covers connectors and MCP tool existence but not CLI options, so it cannot catch this class of gap — it passed both before and after these edits. That check is #871's scope and is untouched here.

## Related Issue

Closes #872. Third finding of the audit trio (#870, #871, #872).

## Checklist

- [x] Tests pass (`make test`) — 2721 passed, 18 skipped
- [x] Linter passes (`make lint`) — `ruff check` clean; no Python changed
- [x] Updated `CHANGELOG.md` — n/a. No change under `drt/` or `pyproject.toml`; `check_changelog_required.py` reports no code change. Skill text ships no user-facing behaviour change.
