### PR TITLE
feat(destinations): query tagging — comment header + native tags on the write path

### DIFF
--- a/docs/connectors/bigquery.md
+++ b/docs/connectors/bigquery.md
@@ -107,6 +107,7 @@ then drops the temp table. Composite keys are supported (`upsert_key: [tenant_id
 ## Notes
 
 - Requires `pip install drt-core[bigquery]` (`google-cloud-bigquery`).
+- **Query tagging** ([#768](https://github.com/drt-hub/drt/issues/768)): `mode: merge`'s load + `MERGE` jobs get `labels` (BigQuery's native cost-attribution mechanism, queryable via `INFORMATION_SCHEMA.JOBS`) by default. `mode: insert`'s streaming insert (`insert_rows_json`) is a REST call, not a job, so it isn't labeled — labels are job-scoped. See `query_tagging` in `docs/llm/API_REFERENCE.md`.
 - Tables are addressed fully-qualified as `<project>.<dataset>.<table>`.
 - The target table must already exist with a compatible schema — drt writes into it, it does not create it.
 - `--dry-run` is honoured — `destination.load()` is never called when dry_run is on.

--- a/docs/connectors/clickhouse.md
+++ b/docs/connectors/clickhouse.md
@@ -170,6 +170,7 @@ into the destination and cannot be un-sent. See
 ## Notes
 
 - Requires `pip install drt-core[clickhouse]` (uses `clickhouse-connect`)
+- **Query tagging** ([#768](https://github.com/drt-hub/drt/issues/768)): `TRUNCATE`/DDL/mirror-`DELETE` statements get a leading `/* drt app=drt sync=<name> run_id=<id> ... */` comment by default. The row-write path itself (`client.insert()`) is a streaming API call, not SQL text, so it isn't tagged — see `query_tagging` in `docs/llm/API_REFERENCE.md`.
 - Each record is inserted individually to enable row-level error tracking (consistent with PostgreSQL and MySQL destination patterns)
 - For deduplication on the INSERT path, **create the destination table with `ReplacingMergeTree`** — `upsert_key` on the config is informational only for non-mirror modes
 - `drt test` validators (row_count, not_null, freshness, unique, accepted_values, query) work with ClickHouse

--- a/docs/connectors/databricks.md
+++ b/docs/connectors/databricks.md
@@ -243,6 +243,7 @@ not retried.
 ## Notes
 
 - Requires `pip install drt-core[databricks]` (depends on `databricks-sql-connector>=3.0`).
+- **Query tagging** ([#768](https://github.com/drt-hub/drt/issues/768)): every write query gets both the driver's native `query_tags` connect kwarg (a `QUERY_TAGS` session config applied to every query the session runs) and a leading `/* drt app=drt sync=<name> run_id=<id> ... */` comment, by default — see `query_tagging` in `docs/llm/API_REFERENCE.md`.
 - Target table must be a **Delta Lake table**. Non-Delta formats fail at `MERGE INTO` time with a Databricks server error.
 - Empty batches short-circuit before any `databricks.sql` import or warehouse call — the same "no driver was imported" contract used by the SQL destinations (#595). A run with zero source rows produces zero warehouse statements.
 - Errors during the connect step (missing env vars, bad token, network) raise immediately; errors during row INSERT are captured per-row and surface in `result.row_errors`.

--- a/docs/connectors/mysql.md
+++ b/docs/connectors/mysql.md
@@ -208,6 +208,7 @@ into the destination and cannot be un-sent. See
 ## Notes
 
 - Requires `pip install drt-core[mysql]` (uses `pymysql`)
+- **Query tagging** ([#768](https://github.com/drt-hub/drt/issues/768)): every write query gets a leading `/* drt app=drt sync=<name> run_id=<id> ... */` comment by default (MySQL has no native session/job-tagging mechanism) — see `query_tagging` in `docs/llm/API_REFERENCE.md`.
 - `upsert_key` columns must have a UNIQUE or PRIMARY KEY constraint on the target table
 - `drt test` validators (row_count, not_null, freshness, unique, accepted_values, query) work with MySQL
 - `--dry-run` shows row count diff for `mode: replace`

--- a/docs/connectors/postgres.md
+++ b/docs/connectors/postgres.md
@@ -287,6 +287,7 @@ a short `idle_in_transaction_session_timeout`, a slow destination can now trip i
 ## Notes
 
 - Requires `pip install drt-core[postgres]` (uses `psycopg2`)
+- **Query tagging** ([#768](https://github.com/drt-hub/drt/issues/768)): every write query gets a leading `/* drt app=drt sync=<name> run_id=<id> ... */` comment by default (Postgres has no native session/job-tagging mechanism) — see `query_tagging` in `docs/llm/API_REFERENCE.md`.
 - `upsert_key` columns must have a UNIQUE constraint on the target table
 - `drt test` validators (row_count, not_null, freshness, unique, accepted_values, query) work with PostgreSQL
 - `--dry-run` shows row count diff for `mode: replace`

--- a/docs/connectors/snowflake.md
+++ b/docs/connectors/snowflake.md
@@ -237,6 +237,7 @@ yielded is not retried.
 ## Notes
 
 - Requires `pip install drt-core[snowflake]` (uses `snowflake-connector-python`)
+- **Query tagging** ([#768](https://github.com/drt-hub/drt/issues/768)): every write query gets both a `QUERY_TAG` session parameter (set at connect, JSON payload — Snowflake's native cost-attribution mechanism, visible in `QUERY_HISTORY.QUERY_TAG`) and a leading `/* drt app=drt sync=<name> run_id=<id> ... */` comment, by default — see `query_tagging` in `docs/llm/API_REFERENCE.md`.
 - Tables are addressed fully-qualified as `<database>.<schema>.<table>` (e.g. `ANALYTICS.PUBLIC.USER_SCORES`)
 - The `schema:` YAML key maps to `schema_` on the model — see the model alias note above
 - `upsert_key` columns identify a logical primary key for `mode: merge` and `sync.mode: mirror`

--- a/drt/config/sync_options.py
+++ b/drt/config/sync_options.py
@@ -236,6 +236,13 @@ class SyncOptions(BaseModel):
     # state in the destination-side ``_drt_synced_keys`` table.
     _sync_name: str | None = PrivateAttr(default=None)
 
+    # Query-tagging payload (#768), injected by the engine at run time (not a
+    # YAML field, and not set by ``_inject_sync_name`` below — unlike the sync
+    # name, this needs a fresh run_id per execution, not just per parse).
+    # ``None`` when query_tagging.enabled is false. Destinations render it
+    # into a SQL comment / native tag; see ``drt.config.query_tags``.
+    _query_tags: dict[str, str] | None = PrivateAttr(default=None)
+
     @model_validator(mode="after")
     def _check_incremental_cursor(self) -> SyncOptions:
         if self.mode == "incremental" and not self.cursor_field:

--- a/drt/destinations/bigquery.py
+++ b/drt/destinations/bigquery.py
@@ -29,6 +29,7 @@ import os
 from typing import Any
 
 from drt.config.models import BigQueryDestinationConfig, DestinationConfig, SyncOptions
+from drt.config.query_tags import normalize_bigquery_label
 from drt.destinations.base import SyncResult
 from drt.destinations.row_errors import RowError
 
@@ -110,14 +111,24 @@ class BigQueryDestination:
         sync_options: SyncOptions,
         result: SyncResult,
     ) -> None:
-        """Upsert via a temp table + a single MERGE statement."""
+        """Upsert via a temp table + a single MERGE statement.
+
+        Both calls are BigQuery *jobs* (unlike ``_insert``'s streaming-insert
+        REST call, which has no job to label), so both get ``labels`` from
+        ``sync_options._query_tags`` (#768) — the load and the query use
+        different config classes (``LoadJobConfig`` / ``QueryJobConfig``),
+        so this builds one of each rather than sharing a single object.
+        """
         keys = config.upsert_key
         assert keys  # guarded in load()
         tmp_table_id = f"{table_id}_drt_tmp"
         columns = list(records[0].keys())
+        labels = self._labels(sync_options._query_tags)
 
         try:
-            client.load_table_from_json(records, tmp_table_id).result()
+            client.load_table_from_json(
+                records, tmp_table_id, job_config=self._load_job_config(labels)
+            ).result()
 
             on_clause = " AND ".join([f"T.{k} = S.{k}" for k in keys])
             update_cols = [c for c in columns if c not in keys]
@@ -134,7 +145,7 @@ class BigQueryDestination:
                 f"{matched}"
                 f"WHEN NOT MATCHED THEN INSERT ({insert_cols}) VALUES ({insert_vals})"
             )
-            client.query(merge_sql).result()
+            client.query(merge_sql, job_config=self._query_job_config(labels)).result()
             result.success += len(records)
         except Exception as e:
             result.failed += len(records)
@@ -150,6 +161,31 @@ class BigQueryDestination:
                 raise
         finally:
             client.delete_table(tmp_table_id, not_found_ok=True)
+
+    def _labels(self, query_tags: dict[str, str] | None) -> dict[str, str] | None:
+        """BigQuery-safe label dict from the raw tag payload (#768), or
+        ``None`` when tagging is off — see :func:`normalize_bigquery_label`
+        for the constraint (lowercase ``[a-z0-9_-]``, <=63 chars)."""
+        if not query_tags:
+            return None
+        return {
+            normalize_bigquery_label(k): normalize_bigquery_label(v)
+            for k, v in query_tags.items()
+        }
+
+    def _load_job_config(self, labels: dict[str, str] | None) -> Any:
+        if labels is None:
+            return None
+        from google.cloud import bigquery
+
+        return bigquery.LoadJobConfig(labels=labels)
+
+    def _query_job_config(self, labels: dict[str, str] | None) -> Any:
+        if labels is None:
+            return None
+        from google.cloud import bigquery
+
+        return bigquery.QueryJobConfig(labels=labels)
 
     def test_connection(self, config: DestinationConfig) -> None:
         """Test connectivity by running ``SELECT 1``."""

--- a/drt/destinations/clickhouse.py
+++ b/drt/destinations/clickhouse.py
@@ -43,6 +43,7 @@ from drt.config.credentials import resolve_env
 from drt.config.models import ClickHouseDestinationConfig, DestinationConfig, SyncOptions
 from drt.destinations.base import SyncResult
 from drt.destinations.row_errors import RowError
+from drt.destinations.sql_utils import tag_query
 
 
 class ClickHouseDestination:
@@ -92,7 +93,9 @@ class ClickHouseDestination:
             else:
                 if sync_options.mode == "replace" and not self._replace_truncated:
                     client.command(
-                        f"TRUNCATE TABLE {self._quote_ident(config.table)}"
+                        tag_query(
+                            f"TRUNCATE TABLE {self._quote_ident(config.table)}", sync_options
+                        )
                     )
                     self._replace_truncated = True
 
@@ -171,8 +174,8 @@ class ClickHouseDestination:
         table_q = self._quote_ident(table)
 
         if not self._swap_shadow_created:
-            client.command(f"DROP TABLE IF EXISTS {shadow_q}")
-            client.command(f"CREATE TABLE {shadow_q} AS {table_q}")
+            client.command(tag_query(f"DROP TABLE IF EXISTS {shadow_q}", sync_options))
+            client.command(tag_query(f"CREATE TABLE {shadow_q} AS {table_q}", sync_options))
             self._swap_shadow_created = True
             self._swap_table = table
 
@@ -197,7 +200,7 @@ class ClickHouseDestination:
                     # try/finally guarantees state reset even if DROP fails;
                     # at worst we leave an orphan shadow (tracked by #433).
                     try:
-                        client.command(f"DROP TABLE IF EXISTS {shadow_q}")
+                        client.command(tag_query(f"DROP TABLE IF EXISTS {shadow_q}", sync_options))
                     finally:
                         self._swap_shadow_created = False
                         self._swap_table = None
@@ -240,9 +243,9 @@ class ClickHouseDestination:
 
         client = self._connect(config)
         try:
-            client.command(f"EXCHANGE TABLES {table_q} AND {shadow_q}")
+            client.command(tag_query(f"EXCHANGE TABLES {table_q} AND {shadow_q}", sync_options))
             # Shadow now contains the OLD data — drop it.
-            client.command(f"DROP TABLE {shadow_q}")
+            client.command(tag_query(f"DROP TABLE {shadow_q}", sync_options))
         finally:
             client.close()
             self._swap_shadow_created = False
@@ -311,7 +314,9 @@ class ClickHouseDestination:
                 params = {
                     "keys": [tuple(str(v) for v in k) for k in keys]
                 }
-            client.command(sql, parameters=params, settings={"mutations_sync": 1})
+            client.command(
+                tag_query(sql, sync_options), parameters=params, settings={"mutations_sync": 1}
+            )
         finally:
             client.close()
 

--- a/drt/destinations/databricks.py
+++ b/drt/destinations/databricks.py
@@ -56,6 +56,7 @@ from drt.config.credentials import resolve_env
 from drt.config.models import DatabricksDestinationConfig, DestinationConfig, SyncOptions
 from drt.destinations.base import SyncResult
 from drt.destinations.row_errors import RowError
+from drt.destinations.sql_utils import tagged_cursor
 
 _SWAP_SUFFIX = "__drt_swap"
 
@@ -202,7 +203,7 @@ class DatabricksDestination:
             return SyncResult()
 
         result = SyncResult()
-        conn = self._connect(config)
+        conn = self._connect(config, query_tags=sync_options._query_tags)
 
         # sync.mode: mirror forces the MERGE write path regardless of
         # config.mode — mirror semantics require upsert. Validate
@@ -220,7 +221,7 @@ class DatabricksDestination:
             conn.close()
             raise
         try:
-            with conn.cursor() as cur:
+            with tagged_cursor(conn.cursor(), sync_options) as cur:
                 columns = list(records[0].keys())
                 table_fq = f"{config.catalog}.{config.schema_}.{config.table}"
                 # Layer 3 (#317): map columns to type categories + json DDLs once
@@ -572,9 +573,9 @@ class DatabricksDestination:
         assert isinstance(config, DatabricksDestinationConfig)
         table_fq = self._swap_table
         shadow_fq = f"{table_fq}{_SWAP_SUFFIX}"
-        conn = self._connect(config)
+        conn = self._connect(config, query_tags=sync_options._query_tags)
         try:
-            with conn.cursor() as cur:
+            with tagged_cursor(conn.cursor(), sync_options) as cur:
                 # Atomic data overwrite — Delta snapshot isolation; the target
                 # table object (grants / properties / clustering) is preserved.
                 cur.execute(f"INSERT OVERWRITE {table_fq} SELECT * FROM {shadow_fq}")
@@ -623,9 +624,9 @@ class DatabricksDestination:
         keys_table = f"{config.catalog}.{config.schema_}.__drt_mirror_keys_{config.table}"
         row_marker = "(" + ", ".join(["?"] * len(upsert_cols)) + ")"
 
-        conn = self._connect(config)
+        conn = self._connect(config, query_tags=sync_options._query_tags)
         try:
-            with conn.cursor() as cur:
+            with tagged_cursor(conn.cursor(), sync_options) as cur:
                 cur.execute(
                     f"CREATE OR REPLACE TABLE {keys_table} AS "
                     f"SELECT {key_cols} FROM {table_fq} WHERE 1=0"
@@ -713,8 +714,16 @@ class DatabricksDestination:
         return dropped, failed
 
     @classmethod
-    def _connect(cls, config: DatabricksDestinationConfig) -> Any:
-        """Establish a connection to Databricks via SQL Connector."""
+    def _connect(
+        cls, config: DatabricksDestinationConfig, *, query_tags: dict[str, str] | None = None
+    ) -> Any:
+        """Establish a connection to Databricks via SQL Connector.
+
+        ``query_tags`` (#768) passes straight through to the driver's native
+        ``query_tags`` connect kwarg (serialized into a ``QUERY_TAGS`` session
+        config, applied to every query the session runs). Same approach as
+        the Databricks source's ``_connect``.
+        """
         try:
             from databricks import sql  # type: ignore[import-untyped]
         except ImportError as e:
@@ -737,8 +746,12 @@ class DatabricksDestination:
         # binding). No `use_inline_params` opt-in: its client-side inline
         # rendering is deprecated upstream and carries an escaping-based
         # injection surface that native binding removes.
-        return sql.connect(
-            server_hostname=host,
-            http_path=http_path,
-            access_token=token,
-        )
+        connect_args: dict[str, Any] = {
+            "server_hostname": host,
+            "http_path": http_path,
+            "access_token": token,
+        }
+        if query_tags:
+            connect_args["query_tags"] = query_tags
+
+        return sql.connect(**connect_args)

--- a/drt/destinations/snowflake.py
+++ b/drt/destinations/snowflake.py
@@ -32,6 +32,7 @@ from drt.config.credentials import resolve_env
 from drt.config.models import DestinationConfig, SnowflakeDestinationConfig, SyncOptions
 from drt.destinations.base import SyncResult
 from drt.destinations.row_errors import RowError
+from drt.destinations.sql_utils import tagged_cursor
 
 _SWAP_SUFFIX = "__drt_swap"
 
@@ -122,7 +123,7 @@ class SnowflakeDestination:
         assert isinstance(config, SnowflakeDestinationConfig)
         if not records:
             return SyncResult()
-        conn = self._connect(config)
+        conn = self._connect(config, query_tags=sync_options._query_tags)
         result = SyncResult()
 
         # sync.mode: mirror forces the MERGE write path regardless of
@@ -141,7 +142,7 @@ class SnowflakeDestination:
             conn.close()
             raise
         try:
-            with conn.cursor() as cur:
+            with tagged_cursor(conn.cursor(), sync_options) as cur:
                 columns = list(records[0].keys())
                 table_fq = f"{config.database}.{config.schema_}.{config.table}"
                 # Layer 3 (#317): map columns to type categories once per sync.
@@ -410,9 +411,9 @@ class SnowflakeDestination:
         assert isinstance(config, SnowflakeDestinationConfig)
         table_fq = self._swap_table
         shadow_fq = f"{table_fq}{_SWAP_SUFFIX}"
-        conn = self._connect(config)
+        conn = self._connect(config, query_tags=sync_options._query_tags)
         try:
-            with conn.cursor() as cur:
+            with tagged_cursor(conn.cursor(), sync_options) as cur:
                 # Atomic exchange — preserves grants on the original name.
                 # Snowflake autocommits, so the SWAP commits before the DROP
                 # (mirrors the separate-transaction split in postgres.py).
@@ -465,9 +466,9 @@ class SnowflakeDestination:
         keys = list({tuple(k) for k in self._mirror_keys})
         table_fq = f"{config.database}.{config.schema_}.{config.table}"
 
-        conn = self._connect(config)
+        conn = self._connect(config, query_tags=sync_options._query_tags)
         try:
-            with conn.cursor() as cur:
+            with tagged_cursor(conn.cursor(), sync_options) as cur:
                 if len(upsert_cols) == 1:
                     placeholders = ", ".join(["%s"] * len(keys))
                     stmt = f"DELETE FROM {table_fq} WHERE {upsert_cols[0]} NOT IN ({placeholders})"
@@ -553,8 +554,15 @@ class SnowflakeDestination:
         return dropped, failed
 
     @classmethod
-    def _connect(cls, config: SnowflakeDestinationConfig) -> Any:
-        """Establish a connection to Snowflake."""
+    def _connect(
+        cls, config: SnowflakeDestinationConfig, *, query_tags: dict[str, str] | None = None
+    ) -> Any:
+        """Establish a connection to Snowflake.
+
+        ``query_tags`` (#768) sets the session's ``QUERY_TAG`` — Snowflake's
+        native cost-attribution mechanism, applied to every query the session
+        runs. Same approach as the Snowflake source's ``_connect``.
+        """
         try:
             import snowflake.connector
         except ImportError as e:
@@ -584,6 +592,11 @@ class SnowflakeDestination:
             )
         else:
             auth["password"] = password
+
+        if query_tags:
+            import json
+
+            auth["session_parameters"] = {"QUERY_TAG": json.dumps(query_tags, sort_keys=True)}
 
         return snowflake.connector.connect(
             account=account,

--- a/drt/destinations/sql_base.py
+++ b/drt/destinations/sql_base.py
@@ -25,6 +25,7 @@ from typing import Any
 from drt.config.models import DestinationConfig, SyncOptions
 from drt.destinations.base import SyncResult
 from drt.destinations.row_errors import RowError
+from drt.destinations.sql_utils import tagged_cursor as _tagged_cursor
 
 
 class BaseSqlDestination:
@@ -79,7 +80,7 @@ class BaseSqlDestination:
         result = SyncResult()
 
         try:
-            cur = conn.cursor()
+            cur = _tagged_cursor(conn.cursor(), sync_options)
             columns = list(records[0].keys())
 
             if sync_options.mode == "replace":
@@ -156,7 +157,7 @@ class BaseSqlDestination:
 
         conn = self._dialect_connect(config)
         try:
-            cur = conn.cursor()
+            cur = _tagged_cursor(conn.cursor(), sync_options)
             self._rename_swap(conn, cur, table, shadow, old)
         finally:
             conn.close()
@@ -215,7 +216,7 @@ class BaseSqlDestination:
 
         conn = self._dialect_connect(config)
         try:
-            cur = conn.cursor()
+            cur = _tagged_cursor(conn.cursor(), sync_options)
             stmt, params = self._build_mirror_delete(
                 config.table,
                 upsert_cols,
@@ -507,7 +508,7 @@ class BaseSqlDestination:
 
         conn = self._dialect_connect(config)
         try:
-            cur = conn.cursor()
+            cur = _tagged_cursor(conn.cursor(), sync_options)
             # Pre-provisioning (#695): check existence before issuing DDL so a
             # locked-down destination user (no CREATE privilege) can run against
             # a state table an admin created ahead of time. Only CREATE when the

--- a/drt/destinations/sql_utils.py
+++ b/drt/destinations/sql_utils.py
@@ -1,14 +1,16 @@
 """Shared utilities for SQL destinations.
 
-Identifier quoting, row-count capability discovery, and mirror-mode guard
-messages — factored out so the SQL destinations don't each hand-roll them.
+Identifier quoting, row-count capability discovery, mirror-mode guard
+messages, and query tagging — factored out so the SQL destinations don't
+each hand-roll them.
 """
 
 from __future__ import annotations
 
 from typing import Any, Protocol, runtime_checkable
 
-from drt.config.models import DestinationConfig
+from drt.config.models import DestinationConfig, SyncOptions
+from drt.config.query_tags import render_comment_header
 
 
 def backtick_quote_ident(table: str) -> str:
@@ -96,3 +98,88 @@ def check_mirror_supported(config: Any, sync_options: Any, dialect: str) -> None
         sync_options.mirror.strategy == "tracked" or sync_options.mirror.scope
     ):
         raise ValueError(unsupported_tracked_scope_msg(dialect))
+
+
+class TaggedCursor:
+    """Cursor wrapper that prepends the query-tagging comment header (#768)
+    to every statement — used by every SQL destination that has no
+    warehouse-native tagging mechanism of its own (Postgres, MySQL,
+    ClickHouse) or that needs the comment in addition to its native
+    mechanism (Snowflake, Databricks — session-level tags don't retroactively
+    label queries issued before they were set).
+
+    Wrapping once, where a dialect obtains its cursor, tags every subsequent
+    ``execute()`` on it without touching each individual call site.
+
+    Handles both plain strings (every dialect here except Postgres's DDL) and
+    ``psycopg2.sql.Composable`` objects (``+`` against a plain string raises
+    ``TypeError``).
+
+    Explicitly implements ``__enter__``/``__exit__`` rather than relying on
+    ``__getattr__`` to find them on the wrapped cursor: Python looks up
+    dunder methods used by implicit protocols (``with``, ``len()``, ...) on
+    the *type*, bypassing instance-level ``__getattr__`` entirely. Snowflake's
+    destination uses ``with conn.cursor() as cur:``; without this override
+    that would raise ``TypeError: ... does not support the context manager
+    protocol`` on a wrapped cursor.
+    """
+
+    def __init__(self, cursor: Any, comment: str) -> None:
+        self._cursor = cursor
+        self._comment = comment
+
+    def __enter__(self) -> TaggedCursor:
+        # DB-API cursors conventionally return ``self`` from ``__enter__``,
+        # but nothing guarantees it — honour whatever comes back rather than
+        # assuming identity, same as any other context-manager consumer would.
+        self._cursor = self._cursor.__enter__()
+        return self
+
+    def __exit__(self, *exc_info: Any) -> Any:
+        return self._cursor.__exit__(*exc_info)
+
+    def execute(self, query: Any, *args: Any, **kwargs: Any) -> Any:
+        if isinstance(query, str):
+            tagged = f"{self._comment}\n{query}"
+        else:
+            from psycopg2 import sql as _pgsql
+
+            tagged = _pgsql.SQL(f"{self._comment}\n") + query
+        return self._cursor.execute(tagged, *args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._cursor, name)
+
+
+def tagged_cursor(cur: Any, sync_options: SyncOptions) -> Any:
+    """Wrap ``cur`` with :class:`TaggedCursor` when query tags are present;
+    returns ``cur`` unchanged (no wrapper overhead) when tagging is off.
+
+    ``getattr`` rather than direct attribute access: plenty of existing
+    white-box tests build a bare ``SimpleNamespace(mode=..., mirror=...)``
+    in place of a real ``SyncOptions`` (they only need the fields their own
+    dialect hook reads), and ``_query_tags`` is a private attr those fakes
+    were never told about. Treating it as optional keeps this backward
+    compatible with every fake already in the test suite rather than
+    requiring each one to grow a field it doesn't otherwise care about.
+    """
+    tags = getattr(sync_options, "_query_tags", None)
+    if not tags:
+        return cur
+    return TaggedCursor(cur, render_comment_header(tags))
+
+
+def tag_query(query: str, sync_options: SyncOptions) -> str:
+    """Prepend the query-tagging comment header (#768) to a plain SQL string.
+
+    For destinations with no cursor ``execute()`` to wrap wholesale —
+    ClickHouse's ``client.command()`` / ``client.query()`` take a string
+    directly, so there's no single seam to intercept the way there is for
+    ``BaseSqlDestination``'s shared ``cur = conn.cursor()``. Returns ``query``
+    unchanged when tagging is off. ``getattr`` for the same reason as
+    :func:`tagged_cursor` above.
+    """
+    tags = getattr(sync_options, "_query_tags", None)
+    if not tags:
+        return query
+    return f"{render_comment_header(tags)}\n{query}"

--- a/drt/engine/sync.py
+++ b/drt/engine/sync.py
@@ -492,11 +492,18 @@ def _run_sync_body(
     # directly into ``query`` here so it works for every dialect with zero
     # per-connector support required. Pure string/dict work — no I/O — so
     # this stays inside the Rust-boundary-safe engine.
+    #
+    # Also stashed on ``sync.sync._query_tags`` (a ``SyncOptions`` private
+    # attr, same smuggling pattern ``_sync_name`` already uses for tracked
+    # mirror, #686) so the destination side can render the same payload —
+    # the ``Destination`` Protocol only receives ``sync_options``, not this
+    # local variable.
     query_tags: dict[str, str] | None = None
     if query_tagging is None or query_tagging.enabled:
         extra = query_tagging.extra if query_tagging else {}
         query_tags = build_query_tags(sync.name, new_run_id(), extra)
         query = f"{render_comment_header(query_tags)}\n{query}"
+    sync.sync._query_tags = query_tags
 
     # Source extraction wrapped via generator helper so exceptions raised
     # during iteration (not just the initial call) carry stage="source" (#544).

--- a/tests/unit/test_bigquery_destination.py
+++ b/tests/unit/test_bigquery_destination.py
@@ -194,6 +194,38 @@ class TestBigQueryDestinationLoad:
         assert result.failed == 2
         assert result.success == 0
 
+    def test_merge_query_tags_become_labels_on_both_jobs(self) -> None:
+        """#768 — the load-into-tmp-table and the MERGE are both jobs, so
+        both get `labels`; `_insert`'s streaming API has no job to label
+        (see test_insert_ignores_query_tags_no_job_to_label below)."""
+        client = _fake_client()
+        modules = _mocked_bq_modules(client)
+        records = [{"id": 1, "score": 0.95}]
+        config = _config(mode="merge", upsert_key=["id"])
+        options = _options()
+        options._query_tags = {"sync": "s", "run_id": "r"}
+        with patch.dict("sys.modules", modules):
+            result = BigQueryDestination().load(records, config, options)
+
+        assert result.success == 1
+        bq_mod = modules["google.cloud.bigquery"]
+        bq_mod.LoadJobConfig.assert_called_once_with(labels={"sync": "s", "run_id": "r"})
+        bq_mod.QueryJobConfig.assert_called_once_with(labels={"sync": "s", "run_id": "r"})
+
+    def test_insert_ignores_query_tags_no_job_to_label(self) -> None:
+        """insert_rows_json is a streaming-insert REST call, not a job —
+        BigQuery labels are job-scoped, so there's nothing to attach to."""
+        client = _fake_client()
+        modules = _mocked_bq_modules(client)
+        options = _options()
+        options._query_tags = {"sync": "s", "run_id": "r"}
+        with patch.dict("sys.modules", modules):
+            BigQueryDestination().load([{"id": 1}], _config(), options)
+
+        client.insert_rows_json.assert_called_once_with(
+            "my-proj.analytics.user_scores", [{"id": 1}]
+        )
+
     def test_merge_success(self) -> None:
         client = _fake_client()
         modules = _mocked_bq_modules(client)
@@ -203,7 +235,7 @@ class TestBigQueryDestinationLoad:
             result = BigQueryDestination().load(records, config, _options())
         assert result.success == 1
         client.load_table_from_json.assert_called_once_with(
-            records, "my-proj.analytics.user_scores_drt_tmp"
+            records, "my-proj.analytics.user_scores_drt_tmp", job_config=None
         )
         merge = next(s for s in _sqls(client) if "MERGE" in s)
         assert "MERGE `my-proj.analytics.user_scores` T" in merge

--- a/tests/unit/test_clickhouse_destination.py
+++ b/tests/unit/test_clickhouse_destination.py
@@ -122,6 +122,21 @@ class TestClickHouseDestinationLoad:
         mock_connect.assert_not_called()
 
     @patch("drt.destinations.clickhouse.ClickHouseDestination._connect")
+    def test_query_tags_prepend_a_comment_on_the_truncate(self, mock_connect: MagicMock) -> None:
+        """#768 — client.insert() (the main row-write path) has no SQL to
+        tag, but client.command() (TRUNCATE/DDL/mutations) does."""
+        client = _fake_client()
+        mock_connect.return_value = client
+
+        options = _options(mode="replace")
+        options._query_tags = {"sync": "s", "run_id": "r"}
+        ClickHouseDestination().load([{"id": 1, "score": 0.95}], _config(), options)
+
+        command_sql = client.command.call_args.args[0]
+        assert command_sql.startswith("/* drt sync=s run_id=r */\n")
+        assert "TRUNCATE TABLE" in command_sql
+
+    @patch("drt.destinations.clickhouse.ClickHouseDestination._connect")
     def test_row_error_on_error_skip(self, mock_connect: MagicMock) -> None:
         client = _fake_client()
         # First row fails, second succeeds

--- a/tests/unit/test_databricks_destination.py
+++ b/tests/unit/test_databricks_destination.py
@@ -149,6 +149,37 @@ class TestDatabricksDestinationLoad:
             with pytest.raises(ImportError, match=r"drt-core\[databricks\]"):
                 DatabricksDestination().load([{"id": 1}], config, options)
 
+    def test_query_tags_set_native_kwarg_and_comment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """#768 — query_tags pass straight through to the driver's native
+        `query_tags` connect kwarg, and also land as a SQL comment."""
+        _set_creds(monkeypatch)
+        conn = _fake_conn()
+        modules = _mocked_databricks_modules(conn)
+
+        options = _options()
+        options._query_tags = {"sync": "s", "run_id": "r"}
+        with patch.dict("sys.modules", modules):
+            result = DatabricksDestination().load([{"id": 1}], _config(), options)
+
+        assert result.failed == 0
+        connect_kwargs = modules["databricks.sql"].connect.call_args[1]
+        assert connect_kwargs["query_tags"] == {"sync": "s", "run_id": "r"}
+        query = conn._cur.execute.call_args.args[0]
+        assert query.startswith("/* drt sync=s run_id=r */\n")
+
+    def test_no_query_tags_omits_native_kwarg(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_creds(monkeypatch)
+        conn = _fake_conn()
+        modules = _mocked_databricks_modules(conn)
+
+        with patch.dict("sys.modules", modules):
+            DatabricksDestination().load([{"id": 1}], _config(), _options())
+
+        connect_kwargs = modules["databricks.sql"].connect.call_args[1]
+        assert "query_tags" not in connect_kwargs
+        query = conn._cur.execute.call_args.args[0]
+        assert not query.startswith("/* drt")
+
     def test_connect_uses_databricks_sql_kwargs(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Confirm the connect() call uses the Databricks SQL Connector
         kwargs (``server_hostname``, ``http_path``, ``access_token``)

--- a/tests/unit/test_databricks_schema_aware.py
+++ b/tests/unit/test_databricks_schema_aware.py
@@ -71,7 +71,7 @@ def _load(
     cfg = _cfg(mode=mode, upsert_key=upsert_key)
     dest = DatabricksDestination()
     cur = _FakeCursor()
-    dest._connect = lambda c: _FakeConn(cur)  # type: ignore[method-assign]
+    dest._connect = lambda c, **_kw: _FakeConn(cur)  # type: ignore[method-assign]
     dest._schema_cache = {"t": category}
     dest._ddl_cache = {"t": ddls}
     dest.load(records, cfg, sync or SyncOptions(mode="full"))
@@ -173,7 +173,7 @@ def test_introspect_schema_off_skips_introspection() -> None:
         cfg = _cfg(introspect_schema=False)
         dest = DatabricksDestination()
         cur = _FakeCursor()
-        dest._connect = lambda c: _FakeConn(cur)  # type: ignore[method-assign]
+        dest._connect = lambda c, **_kw: _FakeConn(cur)  # type: ignore[method-assign]
         dest.load([{"id": 1, "doc": {"x": 1}}], cfg, SyncOptions(mode="full"))
     finally:
         schema_mod.describe_columns = orig  # type: ignore[assignment]

--- a/tests/unit/test_mysql_destination.py
+++ b/tests/unit/test_mysql_destination.py
@@ -149,6 +149,32 @@ class TestMySQLDestinationLoad:
         conn.commit.assert_called_once()
 
     @patch("drt.destinations.mysql.MySQLDestination._connect")
+    def test_query_tags_prepend_a_comment_when_present(self, mock_connect: MagicMock) -> None:
+        """#768 — sync_options._query_tags flows through load() and lands on
+        the actual executed query, via the sql_base.py cursor wrapper."""
+        conn = _fake_connection()
+        mock_connect.return_value = conn
+
+        options = _options()
+        options._query_tags = {"sync": "s", "run_id": "r"}
+        records = [{"user_id": 1, "company_id": 5, "score": 0.95}]
+        MySQLDestination().load(records, _config(), options)
+
+        query = conn.cursor().execute.call_args.args[0]
+        assert query.startswith("/* drt sync=s run_id=r */\n")
+
+    @patch("drt.destinations.mysql.MySQLDestination._connect")
+    def test_no_query_tags_is_byte_identical_to_before(self, mock_connect: MagicMock) -> None:
+        conn = _fake_connection()
+        mock_connect.return_value = conn
+
+        records = [{"user_id": 1, "company_id": 5, "score": 0.95}]
+        MySQLDestination().load(records, _config(), _options())
+
+        query = conn.cursor().execute.call_args.args[0]
+        assert not query.startswith("/* drt")
+
+    @patch("drt.destinations.mysql.MySQLDestination._connect")
     def test_empty_records(self, mock_connect: MagicMock) -> None:
         result = MySQLDestination().load([], _config(), _options())
         assert result.success == 0

--- a/tests/unit/test_postgres_destination.py
+++ b/tests/unit/test_postgres_destination.py
@@ -170,6 +170,36 @@ class TestPostgresDestinationLoad:
         assert _split_identifier_text("marketing", "email_events") in query
 
     @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_query_tags_prepend_a_comment_when_present(self, mock_connect: MagicMock) -> None:
+        """#768 — sync_options._query_tags flows through load() and lands on
+        the actual executed query, via the sql_base.py cursor wrapper."""
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        options = _options()
+        options._query_tags = {"sync": "s", "run_id": "r"}
+        PostgresDestination().load([{"id": 1, "score": 0.95}], _config(), options)
+
+        # The upsert path composes a psycopg2.sql.Composed object rather than
+        # a plain string, so str() gives its repr — the comment fragment is
+        # still the leading component (asserted precisely for the plain-str
+        # and Composable cases in test_sql_base_tagging.py).
+        query = _query_text(cur.execute.call_args.args[0])
+        assert query.startswith("Composed([SQL('/* drt sync=s run_id=r */\\n')")
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
+    def test_no_query_tags_is_byte_identical_to_before(self, mock_connect: MagicMock) -> None:
+        conn = _fake_connection()
+        cur = conn.cursor()
+        mock_connect.return_value = conn
+
+        PostgresDestination().load([{"id": 1, "score": 0.95}], _config(), _options())
+
+        query = _query_text(cur.execute.call_args.args[0])
+        assert not query.startswith("/* drt")
+
+    @patch("drt.destinations.postgres.PostgresDestination._connect")
     def test_empty_records(self, mock_connect: MagicMock) -> None:
         result = PostgresDestination().load([], _config(), _options())
         assert result.success == 0

--- a/tests/unit/test_snowflake_destination.py
+++ b/tests/unit/test_snowflake_destination.py
@@ -151,6 +151,44 @@ class TestSnowflakeDestinationLoad:
         assert conn_kwargs["user"] == "user"
         assert conn_kwargs["password"] == "pwd"
 
+    def test_query_tags_set_session_parameter_and_comment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#768 — query_tags become both the native QUERY_TAG session
+        parameter at connect and a SQL comment on the executed statement."""
+        _set_creds(monkeypatch)
+        conn = _fake_conn()
+        modules = _mocked_snowflake_modules(conn)
+
+        options = _options()
+        options._query_tags = {"sync": "s", "run_id": "r"}
+        with patch.dict("sys.modules", modules):
+            result = SnowflakeDestination().load([{"id": 1}], _config(), options)
+
+        assert result.failed == 0
+        conn_kwargs = modules["snowflake.connector"].connect.call_args[1]
+        import json
+
+        assert json.loads(conn_kwargs["session_parameters"]["QUERY_TAG"]) == {
+            "sync": "s",
+            "run_id": "r",
+        }
+        query = conn._cur.execute.call_args.args[0]
+        assert query.startswith("/* drt sync=s run_id=r */\n")
+
+    def test_no_query_tags_omits_session_parameter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_creds(monkeypatch)
+        conn = _fake_conn()
+        modules = _mocked_snowflake_modules(conn)
+
+        with patch.dict("sys.modules", modules):
+            SnowflakeDestination().load([{"id": 1}], _config(), _options())
+
+        conn_kwargs = modules["snowflake.connector"].connect.call_args[1]
+        assert "session_parameters" not in conn_kwargs
+        query = conn._cur.execute.call_args.args[0]
+        assert not query.startswith("/* drt")
+
     def test_import_error_when_extras_missing(self) -> None:
         # Build config/options BEFORE patching __import__ — pydantic may
         # lazily finish a deferred validator on first model_validate, and

--- a/tests/unit/test_sql_utils_tagging.py
+++ b/tests/unit/test_sql_utils_tagging.py
@@ -1,0 +1,102 @@
+"""Unit tests for the query-tagging cursor wrapper in sql_utils.py (#768).
+
+``tagged_cursor`` / ``TaggedCursor`` are the seam every SQL destination uses
+to tag its SQL from wherever it obtains a cursor, without touching each
+individual ``execute()`` call site.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from drt.config.models import SyncOptions
+from drt.destinations.sql_utils import tagged_cursor as _tagged_cursor
+
+
+def _options_with_tags(tags: dict[str, str] | None) -> SyncOptions:
+    opts = SyncOptions()
+    opts._query_tags = tags
+    return opts
+
+
+class TestTaggedCursorPassthrough:
+    def test_no_tags_returns_the_same_cursor_object(self) -> None:
+        """No wrapper overhead when tagging is off — existing dialect-hook
+        tests that assert on the exact query string keep working unchanged."""
+        cur = MagicMock()
+        result = _tagged_cursor(cur, _options_with_tags(None))
+        assert result is cur
+
+    def test_empty_tags_returns_the_same_cursor_object(self) -> None:
+        result = _tagged_cursor(MagicMock(), _options_with_tags({}))
+        assert isinstance(result, MagicMock)
+
+
+class TestTaggedCursorStringQueries:
+    def test_prepends_comment_to_a_plain_string_query(self) -> None:
+        cur = MagicMock()
+        tagged = _tagged_cursor(cur, _options_with_tags({"sync": "s", "run_id": "r"}))
+        tagged.execute("INSERT INTO t VALUES (%s)", (1,))
+        query, params = cur.execute.call_args.args
+        assert query == "/* drt sync=s run_id=r */\nINSERT INTO t VALUES (%s)"
+        assert params == (1,)
+
+    def test_positional_and_keyword_args_pass_through(self) -> None:
+        cur = MagicMock()
+        tagged = _tagged_cursor(cur, _options_with_tags({"sync": "s"}))
+        tagged.execute("SELECT 1")
+        cur.execute.assert_called_once_with("/* drt sync=s */\nSELECT 1")
+
+
+class TestTaggedCursorComposableQueries:
+    def test_prepends_comment_to_a_psycopg2_composable_query(self) -> None:
+        pytest.importorskip("psycopg2.sql")
+        from psycopg2 import sql as pgsql
+
+        cur = MagicMock()
+        tagged = _tagged_cursor(cur, _options_with_tags({"sync": "s"}))
+        composed = pgsql.SQL("TRUNCATE TABLE {}").format(pgsql.Identifier("t"))
+        tagged.execute(composed)
+        (sent,) = cur.execute.call_args.args
+        # Composable objects don't stringify with the comment inline the way
+        # a plain str does, but the comment SQL() fragment must be present
+        # as the leading component of the composed statement.
+        assert isinstance(sent, pgsql.Composed)
+        assert sent.seq[0].string == "/* drt sync=s */\n"
+
+
+class TestTaggedCursorContextManager:
+    def test_supports_with_statement(self) -> None:
+        """Snowflake's destination uses `with conn.cursor() as cur:` —
+        __getattr__ alone would not find __enter__/__exit__, since dunder
+        lookups for implicit protocols bypass instance-level __getattr__."""
+        real_cursor = MagicMock()
+        real_cursor.__enter__ = MagicMock(return_value=real_cursor)
+        real_cursor.__exit__ = MagicMock(return_value=False)
+
+        tagged = _tagged_cursor(real_cursor, _options_with_tags({"sync": "s"}))
+        with tagged as cur:
+            assert cur is tagged  # the wrapper, not the raw cursor
+            cur.execute("SELECT 1")
+        real_cursor.__enter__.assert_called_once()
+        real_cursor.__exit__.assert_called_once()
+        real_cursor.execute.assert_called_once_with("/* drt sync=s */\nSELECT 1")
+
+
+class TestTaggedCursorAttributeDelegation:
+    def test_non_execute_attributes_delegate_to_the_real_cursor(self) -> None:
+        """fetchall/rowcount/description etc. — every dialect hook reads
+        these off ``cur`` directly; the wrapper must not shadow them."""
+        cur = MagicMock()
+        cur.fetchall.return_value = [(1, "a")]
+        cur.rowcount = 3
+        tagged = _tagged_cursor(cur, _options_with_tags({"sync": "s"}))
+        assert tagged.fetchall() == [(1, "a")]
+        assert tagged.rowcount == 3
+
+
+class TestSyncOptionsQueryTagsDefault:
+    def test_defaults_to_none(self) -> None:
+        assert SyncOptions()._query_tags is None


### PR DESCRIPTION
Stacked on #879 (source-side leg). Closes #768 once both land — this is the destination-side half.

## What

Same cost-attribution problem as #879, on the write path: every INSERT/UPSERT/MERGE/DELETE drt issues against a destination arrived at the warehouse anonymously. `sync_options._query_tags` — a new private attr on `SyncOptions`, injected by `engine/sync.py` the same way `_sync_name` already is for tracked mirror (#686) — carries the same tag payload #879's source side computed, so the `Destination` Protocol doesn't need widening.

- **Postgres / MySQL** (`BaseSqlDestination`, `sql_base.py`): a `TaggedCursor` wrapper around the *one* `cur = conn.cursor()` in `load()` / `finalize_sync()` / `_finalize_mirror*()` tags every dialect hook's SQL without touching each individual `cur.execute()` call site (~20 of them across the two files). Handles both plain strings and `psycopg2.sql.Composable` objects — Postgres's DDL (TRUNCATE/CREATE/DROP/shadow-rename) is composed via `psycopg2.sql`, which raises `TypeError` on `+` against a plain string.
- **ClickHouse**: `client.command()` / `client.query()` (TRUNCATE, swap DDL, the mirror `ALTER TABLE ... DELETE` mutation) get the comment. `client.insert()` — the actual row-write path — is a streaming API call with no SQL text to tag; documented as a real gap, not silently skipped.
- **Snowflake**: native `QUERY_TAG` session parameter at connect (JSON payload, same convention as the source side) *and* the comment. Session tags cover every query on that connection, but the comment stays useful wherever someone's looking at query text directly rather than `QUERY_HISTORY`.
- **Databricks**: the driver already has a native `query_tags` connect kwarg (found via source inspection, same discovery as #879's source-side leg) plus the comment.
- **BigQuery**: `mode: merge`'s load-into-temp-table and the `MERGE` are both jobs, so both get `labels`. `mode: insert`'s streaming insert (`insert_rows_json`) has no job to label — labels are job-scoped, and a streaming insert isn't a job.

## Two things worth flagging explicitly

**`TaggedCursor` needed its own `__enter__`/`__exit__`.** Snowflake and Databricks both use `with conn.cursor() as cur:`. Python looks up dunder methods used by implicit protocols (`with`, `len()`, ...) on the *type*, bypassing instance-level `__getattr__` — so without explicit `__enter__`/`__exit__`, wrapping their cursor would raise `TypeError: ... does not support the context manager protocol`. Found by a test written specifically to exercise the `with` path (`test_supports_with_statement`), not by any happy-path assertion — worth calling out since it's the kind of thing that's easy to miss if the wrapper is only ever exercised through Postgres/MySQL's non-context-manager `cur = conn.cursor()`.

**`tagged_cursor()` / `tag_query()` use `getattr(sync_options, "_query_tags", None)`, not direct attribute access.** A fair number of existing white-box tests (`test_sql_base.py`, `test_databricks_schema_aware.py`) build a bare `SimpleNamespace(mode=..., mirror=...)` in place of a real `SyncOptions`, since they only need the fields their own dialect hook reads. Direct attribute access broke 21 of those on first pass; `getattr` with a `None` default keeps every existing fake working unchanged instead of requiring each one to grow a field it doesn't otherwise care about.

`TaggedCursor` ended up living in a new `drt/destinations/sql_utils.py` addition rather than `sql_base.py` once it became clear Snowflake and Databricks needed the identical wrapper — one shared implementation instead of three near-copies.

## What's NOT in this PR

`drt/destinations/query.py` / `lookup.py` — the lookup (`lookups:` FK resolution), `--dry-run --diff` record-level diff, and `drt test` custom SQL queries. These currently take no `sync_name`/`run_id` at all (verified against the code, not assumed), so tagging them means widening those function signatures *and* every caller (`engine/diff.py`, `cli/commands/test.py`, `mcp/tools/run_test.py`) — a comparably-sized change in its own right, and a genuinely different call shape than the write path this PR covers. Follow-up.

## Testing

- New `tests/unit/test_sql_utils_tagging.py` — `TaggedCursor`/`tagged_cursor`/`tag_query` in isolation: plain-string and `Composable` prepending, the context-manager fix (regression-guarded), attribute delegation, the `getattr` fallback.
- Every destination test file (`test_postgres_destination.py`, `test_mysql_destination.py`, `test_clickhouse_destination.py`, `test_snowflake_destination.py`, `test_databricks_destination.py`, `test_bigquery_destination.py`) gained a tagged/untagged pair asserting the comment (and native mechanism, where applicable) actually lands on the executed query — plus a "no tags → byte-identical to before" test per destination, since `tagged_cursor` returning the cursor unchanged when tagging is off is the property that keeps every *pre-existing* exact-query-text assertion passing without modification.
- Full suite: 2654 passed, 5 skipped (pre-existing driver-not-installed skips) — including the 21 pre-existing `SimpleNamespace`-based tests the `getattr` fix keeps green.

Connector docs (`docs/connectors/{postgres,mysql,clickhouse,snowflake,databricks,bigquery}.md`) each got a `## Notes` bullet describing exactly what is and isn't tagged for that destination.

## Test plan

- [x] `pytest tests/unit` — 2654 passed
- [x] `ruff check drt tests` — clean
- [x] `mypy drt` — clean, 173 files