### PR TITLE
docs(sources): document why Iceberg pushdown stays deferred (#679)

### DIFF
--- a/drt/sources/iceberg.py
+++ b/drt/sources/iceberg.py
@@ -3,6 +3,21 @@
 Loads a table through a pyiceberg catalog (REST / SQL / Hive / local) into
 Arrow, registers it in an in-memory DuckDB, then runs your model SQL against it.
 
+Unlike ``deltalake.py``, this reads the whole table eagerly (``.scan().to_arrow()``)
+rather than pushing the model's WHERE/column list into the scan — a deliberate,
+not-yet-fixed gap (#679; the Delta leg shipped filter/projection pushdown via
+``to_pyarrow_dataset()`` in #868). pyiceberg 0.11 has no equivalent lazy
+``pyarrow.dataset.Dataset`` for DuckDB to push into: ``DataScan.to_arrow()``
+materializes fully, and the only streaming alternative,
+``to_arrow_batch_reader()``, returns a single-pass ``pa.RecordBatchReader`` —
+a model query that references the registered table more than once (e.g. a
+self-join) would silently get an empty/short result on the second reference
+once the reader's exhausted, rather than an error. True pushdown would need
+drt to parse the model SQL's WHERE/SELECT and pass them as pyiceberg's
+``row_filter``/``selected_fields`` *before* the scan starts — real SQL-parsing
+work with its own fragility, not attempted here. Left materializing on
+purpose until that's worth doing.
+
 Requires: pip install drt-core[iceberg]
 
 Example ~/.drt/profiles.yml:


### PR DESCRIPTION
## Summary

Doc-only change, no behavior change. Adds the reasoning for why Iceberg's leg of #679 stays deferred directly to `drt/sources/iceberg.py` — previously this context only lived in `CLAUDE.md`'s release notes ("Iceberg stays materialising on purpose"), not in the source itself the way `deltalake.py` documents its own `delta_scan()` rejection.

## Why deferred

The Delta leg of #679 shipped filter/projection pushdown via `to_pyarrow_dataset()` in #868. Iceberg can't follow the same recipe:

- pyiceberg 0.11 has no lazy `pyarrow.dataset.Dataset` equivalent for DuckDB to push a query's WHERE/column list into.
- The only streaming alternative, `DataScan.to_arrow_batch_reader()`, returns a single-pass `pa.RecordBatchReader` — a model query that references the registered table more than once (e.g. a self-join) would silently get a short/empty result on the second reference once the reader's exhausted, rather than erroring. This was evaluated and correctly rejected in an earlier session for exactly that correctness risk.
- True pushdown would require drt to parse the model SQL's WHERE/SELECT and hand them to pyiceberg's `row_filter`/`selected_fields` *before* constructing the scan — real SQL-parsing work, not attempted here.

## Testing

- `pytest tests/unit/test_iceberg_source.py`: 10 passed, unchanged.
- `ruff check`: clean.

Recommend closing #679 with this PR's link as the documented rationale — the Delta leg is done, the Iceberg leg is intentionally staying as-is until SQL-parsing pushdown is worth the cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)