### PR TITLE
fix(ci): publish workflows' verify job was missing SQL driver extras

### DIFF
--- a/.github/workflows/publish-dagster-drt.yml
+++ b/.github/workflows/publish-dagster-drt.yml
@@ -24,7 +24,7 @@ jobs:
         run: pip install uv
 
       - name: Install dependencies
-        run: uv pip install --system -e ".[dev,mcp,duckdb]"
+        run: uv pip install --system -e ".[dev,mcp,duckdb,postgres,mysql,clickhouse,sqlserver]"
 
       - name: Lint (ruff)
         run: ruff check drt tests

--- a/.github/workflows/publish-drt-core.yml
+++ b/.github/workflows/publish-drt-core.yml
@@ -24,7 +24,7 @@ jobs:
         run: pip install uv
 
       - name: Install dependencies
-        run: uv pip install --system -e ".[dev,mcp,duckdb]"
+        run: uv pip install --system -e ".[dev,mcp,duckdb,postgres,mysql,clickhouse,sqlserver]"
 
       - name: Lint (ruff)
         run: ruff check drt tests
@@ -58,7 +58,7 @@ jobs:
         # SBOM must reflect what users actually install. Mirror the extras
         # set used by `verify` so optional integrations shipped to PyPI are
         # represented in the bill of materials.
-        run: uv pip install --system -e ".[dev,mcp,duckdb]"
+        run: uv pip install --system -e ".[dev,mcp,duckdb,postgres,mysql,clickhouse,sqlserver]"
 
       - name: Generate CycloneDX SBOM
         run: |


### PR DESCRIPTION
## Summary

Found while tagging v0.8.4: `publish-drt-core.yml`'s `verify` job installed only `.[dev,mcp,duckdb]`, unlike `ci.yml`'s full test job (`.[dev,mcp,duckdb,postgres,mysql,clickhouse,sqlserver]`). This has been the install line since the workflow was first written — never exercised, because no prior `v*` tag landed after a test started hard-importing an optional driver without `pytest.importorskip`.

v0.8.4's own streaming-extraction MySQL tests (#765) do exactly that, so pushing the `v0.8.4` tag surfaced it: 8 tests failed with `ModuleNotFoundError: No module named 'pymysql'`. The release-verify gate correctly failed and PyPI publish was skipped — **no bad release shipped**, the tag has been deleted and will be re-pushed once this lands.

## Changes

- `publish-drt-core.yml`: fixed both the `verify` job's install line and the `publish` job's SBOM-scope install line (the latter's own comment says to mirror `verify`'s extras)
- `publish-dagster-drt.yml`: same fix for its `verify` job — it runs the same root-level `pytest` suite via the identical narrow install line, and would fail the same way on its first `dagster-drt-v*` tag pushed after #765

## Test plan

- [x] Workflow-only change (install line), no application code touched
- [x] Will be validated for real when the `v0.8.4` tag is re-pushed after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)