### PR TITLE
refactor(state): extract StateStore/HistoryStore/DlqBackend Protocols (#756)

### DIFF
--- a/drt/state/dlq.py
+++ b/drt/state/dlq.py
@@ -24,7 +24,7 @@ import threading
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 
 @dataclass
@@ -43,7 +43,29 @@ class DeadLetter:
     attempts: int = 1
 
 
-class DlqStore:
+@runtime_checkable
+class DlqBackend(Protocol):
+    """Persist and replay records that failed during load (#756).
+
+    Extracted first among the three stores because it carries the sharpest
+    reported pain: on an ephemeral runner the queue dies with the container,
+    so ``drt retry`` can never see a previous run's failures.
+    """
+
+    def append(
+        self, sync_name: str, entries: list[DeadLetter], *, max_records: int = 10_000
+    ) -> int:
+        """Append ``entries`` and return the resulting depth (FIFO-capped)."""
+        ...
+
+    def replace(self, sync_name: str, entries: list[DeadLetter]) -> None: ...
+    def clear(self, sync_name: str) -> None: ...
+    def read(self, sync_name: str) -> list[DeadLetter]: ...
+    def depth(self, sync_name: str) -> int: ...
+    def all_depths(self) -> dict[str, int]: ...
+
+
+class LocalDlqStore:
     """Append / read / replace dead-letter entries under ``.drt/dlq/``.
 
     One JSONL file per sync (``<sync_name>.jsonl``). All mutating methods run
@@ -146,3 +168,7 @@ class DlqStore:
             if depth:
                 out[path.stem] = depth
         return out
+
+
+# Back-compat alias — see the note on ``StateManager`` in state/manager.py.
+DlqStore = LocalDlqStore

--- a/drt/state/history.py
+++ b/drt/state/history.py
@@ -22,6 +22,7 @@ import threading
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +43,27 @@ class HistoryEntry:
     dry_run: bool = False  # always False on disk; reserved for future use
 
 
-class HistoryManager:
+@runtime_checkable
+class HistoryStore(Protocol):
+    """Append and read per-sync execution history (#756).
+
+    Extracted so history can outlive the runner that produced it — a fresh CI
+    checkout currently shows nothing, and the docs manifest's ``runs`` data
+    (#698) is blank in any ephemeral container.
+    """
+
+    def append(self, entry: HistoryEntry) -> None: ...
+
+    def read(self, sync_name: str | None = None, limit: int = 20) -> list[HistoryEntry]:
+        """Most recent ``limit`` entries, newest first; all syncs when ``sync_name`` is None."""
+        ...
+
+    def prune(self, sync_name: str, retention_days: int) -> int:
+        """Drop entries older than ``retention_days``; return how many went."""
+        ...
+
+
+class LocalHistoryManager:
     """Append-only per-sync execution history.
 
     Files live under ``<project_dir>/.drt/history/<sync_name>.jsonl``. All
@@ -140,6 +161,10 @@ class HistoryManager:
                     f.write(json.dumps(asdict(entry), default=str) + "\n")
             tmp.replace(path)
             return removed
+
+
+# Back-compat alias — see the note on ``StateManager`` in state/manager.py.
+HistoryManager = LocalHistoryManager
 
 
 def _read_jsonl(path: Path) -> list[HistoryEntry]:

--- a/drt/state/manager.py
+++ b/drt/state/manager.py
@@ -1,4 +1,8 @@
-"""StateManager — persists sync state to local JSON.
+"""Run-state persistence — the ``StateStore`` Protocol and its local impl.
+
+``LocalStateManager`` persists to local JSON and is the default. The Protocol
+exists so state can also live somewhere that survives an ephemeral runner
+(#756); ``StateManager`` remains as an alias for it.
 
 Simple by design: no external dependencies, no infrastructure.
 Future: bincode (Rust) for fast binary serialization.

--- a/drt/state/manager.py
+++ b/drt/state/manager.py
@@ -16,7 +16,7 @@ import threading
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 
 @dataclass
@@ -29,7 +29,36 @@ class SyncState:
     last_cursor_value: str | None = None  # watermark for incremental sync
 
 
-class StateManager:
+@runtime_checkable
+class StateStore(Protocol):
+    """Read and write per-sync run state (#756).
+
+    Extracted so state can live somewhere that survives an ephemeral runner —
+    object storage or a warehouse — rather than only in ``.drt/state.json``.
+    Same optional-backend shape as :class:`~drt.state.watermark.WatermarkStorage`,
+    which already has local, GCS and BigQuery implementations.
+
+    Writes reach this through ``StatePersistingObserver``; the engine never
+    calls it directly (guarded by ``tests/unit/test_engine_observer.py``).
+    """
+
+    def get_last_sync(self, sync_name: str) -> SyncState | None: ...
+    def get_all(self) -> dict[str, SyncState]: ...
+    def save_sync(self, state: SyncState) -> None: ...
+
+    def reset(self, sync_name: str) -> bool:
+        """Drop recorded state for ``sync_name``; return whether anything went.
+
+        Part of the Protocol rather than a local-only extra: ``drt state reset``,
+        ``drt run --full-refresh`` and two MCP tools all call it, so a backend
+        without it is not a usable substitute for the local store.
+        """
+        ...
+
+    def now(self) -> str: ...
+
+
+class LocalStateManager:
     """Read and write sync state from .drt/state.json.
 
     All public methods are thread-safe via ``self._lock``. The lock
@@ -110,3 +139,9 @@ class StateManager:
 
     def now(self) -> str:
         return datetime.now(timezone.utc).isoformat()
+
+
+# Back-compat alias — every existing caller imports ``StateManager``. Kept so
+# this refactor is a pure introduce-interface step; call sites move to the
+# backend factory Part by Part as each remote implementation lands (#756).
+StateManager = LocalStateManager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,3 +44,24 @@ def fake_source() -> FakeSource:
     import dance (#364).
     """
     return FakeSource()
+
+
+def public_methods(cls: type) -> set[str]:
+    """Public callables on ``cls``, **including inherited ones**.
+
+    Used by the Protocol-coverage tests in ``test_state.py`` / ``test_history.py``
+    / ``test_dlq_store.py`` to assert a Protocol declares exactly what its local
+    implementation exposes.
+
+    Walks the MRO rather than reading ``vars(cls)`` directly: the three state
+    stores have no base class today, but a shared base for the remote backends
+    (#756) is a plausible next step, and an inherited public method must not
+    escape the check — a Protocol that silently stops covering its
+    implementation is the exact failure this guard exists to catch.
+    """
+    names: set[str] = set()
+    for klass in cls.__mro__:
+        if klass is object:
+            continue
+        names |= {name for name in vars(klass) if not name.startswith("_")}
+    return {name for name in names if callable(getattr(cls, name))}

--- a/tests/unit/test_dlq_store.py
+++ b/tests/unit/test_dlq_store.py
@@ -114,3 +114,31 @@ def test_all_depths_reports_every_nonempty_queue(tmp_path: Path) -> None:
 
 def test_all_depths_empty_when_no_dir(tmp_path: Path) -> None:
     assert DlqStore(tmp_path).all_depths() == {}
+
+
+# --- DlqBackend Protocol (#756) ----------------------------------------------
+
+_DLQ_BACKEND_METHODS = {"append", "replace", "clear", "read", "depth", "all_depths"}
+
+
+def test_local_dlq_store_satisfies_dlq_backend(tmp_path: Path) -> None:
+    from drt.state.dlq import DlqBackend, LocalDlqStore
+
+    assert isinstance(LocalDlqStore(tmp_path), DlqBackend)
+
+
+def test_dlq_store_alias_preserved() -> None:
+    from drt.state.dlq import DlqStore, LocalDlqStore
+
+    assert DlqStore is LocalDlqStore
+
+
+def test_dlq_backend_protocol_covers_local_public_api() -> None:
+    from drt.state.dlq import LocalDlqStore
+
+    public = {
+        name
+        for name in vars(LocalDlqStore)
+        if not name.startswith("_") and callable(getattr(LocalDlqStore, name))
+    }
+    assert public == _DLQ_BACKEND_METHODS

--- a/tests/unit/test_dlq_store.py
+++ b/tests/unit/test_dlq_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from drt.state.dlq import DeadLetter, DlqStore
+from tests.conftest import public_methods
 
 
 def _dl(value: int, *, attempts: int = 1) -> DeadLetter:
@@ -136,9 +137,4 @@ def test_dlq_store_alias_preserved() -> None:
 def test_dlq_backend_protocol_covers_local_public_api() -> None:
     from drt.state.dlq import LocalDlqStore
 
-    public = {
-        name
-        for name in vars(LocalDlqStore)
-        if not name.startswith("_") and callable(getattr(LocalDlqStore, name))
-    }
-    assert public == _DLQ_BACKEND_METHODS
+    assert public_methods(LocalDlqStore) == _DLQ_BACKEND_METHODS

--- a/tests/unit/test_history.py
+++ b/tests/unit/test_history.py
@@ -288,3 +288,31 @@ class TestEngineHistoryIntegration:
         e = entries[0]
         assert e.status == "failed"
         assert any("upstream down" in err for err in e.errors)
+
+
+# --- HistoryStore Protocol (#756) --------------------------------------------
+
+_HISTORY_STORE_METHODS = {"append", "read", "prune"}
+
+
+def test_local_history_manager_satisfies_history_store(tmp_path: Path) -> None:
+    from drt.state.history import HistoryStore, LocalHistoryManager
+
+    assert isinstance(LocalHistoryManager(tmp_path), HistoryStore)
+
+
+def test_history_manager_alias_preserved() -> None:
+    from drt.state.history import HistoryManager, LocalHistoryManager
+
+    assert HistoryManager is LocalHistoryManager
+
+
+def test_history_store_protocol_covers_local_public_api() -> None:
+    from drt.state.history import LocalHistoryManager
+
+    public = {
+        name
+        for name in vars(LocalHistoryManager)
+        if not name.startswith("_") and callable(getattr(LocalHistoryManager, name))
+    }
+    assert public == _HISTORY_STORE_METHODS

--- a/tests/unit/test_history.py
+++ b/tests/unit/test_history.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from drt.state.history import HistoryEntry, HistoryManager
+from tests.conftest import public_methods
 
 
 def _entry(
@@ -310,9 +311,4 @@ def test_history_manager_alias_preserved() -> None:
 def test_history_store_protocol_covers_local_public_api() -> None:
     from drt.state.history import LocalHistoryManager
 
-    public = {
-        name
-        for name in vars(LocalHistoryManager)
-        if not name.startswith("_") and callable(getattr(LocalHistoryManager, name))
-    }
-    assert public == _HISTORY_STORE_METHODS
+    assert public_methods(LocalHistoryManager) == _HISTORY_STORE_METHODS

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from drt.state.manager import StateManager, SyncState
+from tests.conftest import public_methods
 
 
 def test_get_last_sync_missing(tmp_path: Path) -> None:
@@ -143,9 +144,4 @@ def test_state_store_protocol_covers_local_public_api() -> None:
     """
     from drt.state.manager import LocalStateManager
 
-    public = {
-        name
-        for name in vars(LocalStateManager)
-        if not name.startswith("_") and callable(getattr(LocalStateManager, name))
-    }
-    assert public == _STATE_STORE_METHODS
+    assert public_methods(LocalStateManager) == _STATE_STORE_METHODS

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -109,3 +109,43 @@ class TestReset:
 
     def test_reset_with_no_state_file_is_a_noop(self, tmp_path: Path) -> None:
         StateManager(tmp_path).reset("a")
+
+
+# --- StateStore Protocol (#756) ----------------------------------------------
+
+# The public method set LocalStateManager exposes and StateStore must declare.
+# Kept as a literal so drift fails loudly: `reset` was added by #776 nine days
+# after the #756 plan listed these methods, and the plan's list was never
+# updated — a remote backend written against it would have satisfied the
+# Protocol while silently breaking `drt state reset`.
+_STATE_STORE_METHODS = {"get_last_sync", "get_all", "save_sync", "reset", "now"}
+
+
+def test_local_state_manager_satisfies_state_store(tmp_path: Path) -> None:
+    from drt.state.manager import LocalStateManager, StateStore
+
+    assert isinstance(LocalStateManager(tmp_path), StateStore)
+
+
+def test_state_manager_alias_preserved() -> None:
+    """Existing callers import StateManager — the name must keep working."""
+    from drt.state.manager import LocalStateManager, StateManager
+
+    assert StateManager is LocalStateManager
+
+
+def test_state_store_protocol_covers_local_public_api() -> None:
+    """Every public method on the local impl must be in the Protocol.
+
+    isinstance() against a runtime_checkable Protocol only checks presence,
+    so it would pass even if the Protocol declared fewer methods than callers
+    actually use. This asserts the sets match exactly, in both directions.
+    """
+    from drt.state.manager import LocalStateManager
+
+    public = {
+        name
+        for name in vars(LocalStateManager)
+        if not name.startswith("_") and callable(getattr(LocalStateManager, name))
+    }
+    assert public == _STATE_STORE_METHODS


### PR DESCRIPTION
First step of #756. Turns the three concrete stores — `StateManager`, `HistoryManager`, `DlqStore` — into `Protocol` + `Local*` implementation, the shape [`WatermarkStorage`](https://github.com/drt-hub/drt/blob/main/drt/state/watermark.py) already has.

**Pure introduce-interface step.** Every caller keeps working through a back-compat alias (`StateManager = LocalStateManager`), so no call site moves here. Remote backends land against these Protocols Part by Part.

## Why now

This is the dependency root for every remaining part of #756, and it is independent of how that issue's substrate question resolves (see #899) — extracting the interfaces is the same work either way.

| Protocol | Methods |
|---|---|
| `StateStore` | `get_last_sync` · `get_all` · `save_sync` · **`reset`** · `now` |
| `HistoryStore` | `append` · `read` · `prune` |
| `DlqBackend` | `append` · `replace` · `clear` · `read` · `depth` · `all_depths` |

## The `reset()` near-miss, and the test that prevents the next one

`isinstance()` against a `runtime_checkable` Protocol **only checks for method presence**. It would happily pass a Protocol that declared *fewer* methods than callers actually use — so the obvious test is close to worthless on its own.

That is not hypothetical here. `StateManager.reset()` arrived with #776, nine days after #756's implementation plan enumerated the `StateStore` methods, and that list was never updated. A remote backend written from it would have satisfied the Protocol while silently breaking `drt state reset` — which four call sites depend on (`run.py`, `cli/commands/state.py`, `mcp/tools/state.py`, `mcp/tools/run_sync.py`).

So each Protocol is paired with a test asserting **set equality** between the Protocol's methods and the local implementation's public API, in both directions:

```python
def test_state_store_protocol_covers_local_public_api() -> None:
    public = {
        name for name in vars(LocalStateManager)
        if not name.startswith("_") and callable(getattr(LocalStateManager, name))
    }
    assert public == _STATE_STORE_METHODS
```

Add a public method to a local store without adding it to the Protocol and this fails loudly. `reset()` is also documented in the Protocol as load-bearing rather than a local-only convenience, for the same reason.

## Verification

- Affected suites: **104 passed → 113 passed** (9 new tests)
- Full suite: **2912 passed, 21 skipped**
- `ruff check` clean, `mypy` clean (175 source files)
- Engine boundary guard (`tests/unit/test_engine_observer.py`) green — nothing in this PR touches `engine/sync.py`

## Note for review

These Protocols are what #300/#304 freezes at v1.0, and #297's plugin system may put third-party implementations behind them. **The shape is worth arguing with now rather than after the backends land** — that is the main thing I'd like eyes on, more than the mechanics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)