### PR TITLE
feat(config): per-sync file fingerprint for state:modified (#772)

### DIFF
--- a/drt/config/fingerprint.py
+++ b/drt/config/fingerprint.py
@@ -81,15 +81,31 @@ def sync_fingerprints(project_dir: Path | str = Path(".")) -> dict[str, str]:
     # project's syncs are.
     for path in sorted(syncs_dir.glob("*.yml")):
         raw = path.read_bytes()
-        name = _resolved_name(raw, variables)
+        data = _parse(raw)
+        if data is None:
+            continue
+        name = _resolved_name(data, variables)
         if name is None:
             continue
-        fingerprints[name] = _digest(raw, _model_bytes(raw, root))
+        fingerprints[name] = _digest(raw, _model_bytes(data, root))
 
     return fingerprints
 
 
-def _resolved_name(raw: bytes, variables: dict[str, Any]) -> str | None:
+def _parse(raw: bytes) -> dict[str, Any] | None:
+    """Parse one sync file, or None if it is not a YAML mapping.
+
+    The single parse point for the module: everything downstream takes the
+    parsed mapping, so no helper has to re-check that it got one.
+    """
+    try:
+        data = yaml.safe_load(raw)
+    except Exception:  # noqa: BLE001 — malformed files are drt validate's job
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _resolved_name(data: dict[str, Any], variables: dict[str, Any]) -> str | None:
     """The sync's ``name:`` with env vars and ``var()`` applied, or None.
 
     Expansion is applied to the **name value alone**, never to the whole
@@ -102,16 +118,10 @@ def _resolved_name(raw: bytes, variables: dict[str, Any]) -> str | None:
     to avoid. Isolating the name keeps an unresolvable field elsewhere from
     deciding whether the sync is visible at all.
 
-    Only a file that is not parseable YAML, or has no ``name:``, is skipped —
-    reporting those is ``drt validate``'s job, and a selector that raised on an
-    unrelated malformed file would be worse than one that cannot see it.
+    Only a sync with no ``name:`` is skipped here — reporting a broken sync is
+    ``drt validate``'s job, and a selector that raised on an unrelated malformed
+    file would be worse than one that cannot see it.
     """
-    try:
-        data = yaml.safe_load(raw)
-    except Exception:  # noqa: BLE001 — malformed files are drt validate's job
-        return None
-    if not isinstance(data, dict):
-        return None
     name = data.get("name")
     if not name:
         return None
@@ -121,7 +131,7 @@ def _resolved_name(raw: bytes, variables: dict[str, Any]) -> str | None:
         return str(name)
 
 
-def _model_bytes(raw: bytes, project_dir: Path) -> bytes:
+def _model_bytes(data: dict[str, Any], project_dir: Path) -> bytes:
     """Raw bytes of the ``.sql`` file a ``ref()`` resolves to, else empty.
 
     Read straight off disk rather than through
@@ -133,12 +143,6 @@ def _model_bytes(raw: bytes, project_dir: Path) -> bytes:
     A missing file is not an error: ``ref()`` may name a dbt model or a bare
     warehouse table with no local SQL.
     """
-    try:
-        data = yaml.safe_load(raw)
-    except Exception:  # noqa: BLE001 — see _resolved_name
-        return b""
-    if not isinstance(data, dict):
-        return b""
     model = data.get("model")
     if not isinstance(model, str):
         return b""

--- a/drt/config/fingerprint.py
+++ b/drt/config/fingerprint.py
@@ -1,0 +1,154 @@
+"""Per-sync fingerprints for the ``state:modified`` selector (#772).
+
+Answers "which syncs did this PR change?" so CI can run only those, instead of
+dry-running the whole project or nothing. dbt's ``state:modified`` is the model.
+
+**What is hashed: the sync file exactly as written on disk**, before ``${VAR}``
+substitution and before ``var()`` rendering — plus the raw bytes of the
+``syncs/models/<name>.sql`` a ``ref()`` points at, since editing the SQL is
+editing the sync.
+
+Two consequences, both deliberate:
+
+*Secrets cannot enter the input.* The file holds ``${API_TOKEN}`` or
+``token_env: NAME``, never a value, so there is no "which fields are secret?"
+classification to maintain or get wrong. That is the same structural choice
+every comparable tool makes — dbt keeps credentials in ``profiles.yml`` outside
+the project (which is why its ``manifest.json`` is documented as safe to share
+as a CI artifact), and Hightouch Git Sync / Census Git-backed Models keep them
+in the vendor workspace, referenced by id. An earlier draft of this hashed the
+*resolved* config and had to decide whether ``upsert_key`` was a secret
+(``config/secrets.py``'s name-suffix heuristic says yes, wrongly, and redacting
+it would have hidden a real change in write semantics). Hashing the file removes
+the question rather than answering it carefully.
+
+*Environment changes are invisible.* Changing ``API_TOKEN``'s value, or a
+``DRT_VAR_*``, does not move the fingerprint. dbt has and documents the same
+blind spot ("dbt is unable to identify that lineage ... because the ``var`` or
+``env_var`` value has changed"). The upside is that a baseline generated in one
+environment compares meaningfully against another, because file bytes do not
+depend on the environment.
+
+Not covered, and documented rather than silently missing: a change to
+``drt_project.yml`` (project ``vars``, profile) affects every sync but no sync
+file, so ``state:modified`` will not select anything. This is a per-sync-file
+change detector, not a whole-project one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from drt.config.parser import expand_env_vars, expand_sync_vars, project_vars
+from drt.engine.resolver import parse_ref
+
+# Long enough that collisions are not a practical concern, short enough to read
+# in a manifest diff or a CI log line.
+_DIGEST_CHARS = 16
+
+# Keeps the two inputs from running together — without it, a yaml file ending in
+# "x" plus SQL "y" would hash identically to one ending "xy" with empty SQL.
+_SEPARATOR = b"\x00drt-model\x00"
+
+
+def sync_fingerprints(project_dir: Path | str = Path(".")) -> dict[str, str]:
+    """Map each sync's **resolved** name to a fingerprint of its definition.
+
+    The name is resolved (env vars and ``var()`` expanded) so it lines up with
+    ``SyncConfig.name`` at the call site; the *fingerprint* is computed from the
+    unresolved bytes. Those two treatments are intentionally different: the key
+    has to match what the rest of drt calls this sync, while the value must not
+    depend on the environment it was computed in.
+
+    Files that cannot be parsed are skipped rather than raising — ``drt
+    validate`` is where a broken sync file gets reported, and a selector that
+    explodes on an unrelated malformed file would be worse than one that cannot
+    see it.
+    """
+    root = Path(project_dir)
+    syncs_dir = root / "syncs"
+    if not syncs_dir.exists():
+        return {}
+
+    variables = project_vars(root)
+    fingerprints: dict[str, str] = {}
+
+    # Same glob and ordering as parser.load_syncs, so the two agree on what a
+    # project's syncs are.
+    for path in sorted(syncs_dir.glob("*.yml")):
+        raw = path.read_bytes()
+        name = _resolved_name(raw, variables)
+        if name is None:
+            continue
+        fingerprints[name] = _digest(raw, _model_bytes(raw, root))
+
+    return fingerprints
+
+
+def _resolved_name(raw: bytes, variables: dict[str, Any]) -> str | None:
+    """The sync's ``name:`` with env vars and ``var()`` applied, or None.
+
+    Expansion is applied to the **name value alone**, never to the whole
+    document. Expanding the document would make an undefined ``${VAR}``
+    *anywhere* in the file — a destination token env var not yet configured on
+    this machine, most likely — throw away the sync entirely, so
+    ``state:modified`` would silently not select it. A PR that adds a sync
+    referencing a not-yet-provisioned secret is exactly a PR CI should be
+    looking at, and dropping it is the quiet failure this whole feature exists
+    to avoid. Isolating the name keeps an unresolvable field elsewhere from
+    deciding whether the sync is visible at all.
+
+    Only a file that is not parseable YAML, or has no ``name:``, is skipped —
+    reporting those is ``drt validate``'s job, and a selector that raised on an
+    unrelated malformed file would be worse than one that cannot see it.
+    """
+    try:
+        data = yaml.safe_load(raw)
+    except Exception:  # noqa: BLE001 — malformed files are drt validate's job
+        return None
+    if not isinstance(data, dict):
+        return None
+    name = data.get("name")
+    if not name:
+        return None
+    try:
+        return str(expand_sync_vars(expand_env_vars(name), variables))
+    except Exception:  # noqa: BLE001 — an unresolvable name still names a sync
+        return str(name)
+
+
+def _model_bytes(raw: bytes, project_dir: Path) -> bytes:
+    """Raw bytes of the ``.sql`` file a ``ref()`` resolves to, else empty.
+
+    Read straight off disk rather than through
+    :func:`drt.engine.resolver.resolve_model_ref`, which takes
+    ``last_cursor_value`` and substitutes the **current watermark** into the SQL
+    it returns. Fingerprinting that would move the hash after every incremental
+    run, so ``state:modified`` would select every sync, every time.
+
+    A missing file is not an error: ``ref()`` may name a dbt model or a bare
+    warehouse table with no local SQL.
+    """
+    try:
+        data = yaml.safe_load(raw)
+    except Exception:  # noqa: BLE001 — see _resolved_name
+        return b""
+    if not isinstance(data, dict):
+        return b""
+    model = data.get("model")
+    if not isinstance(model, str):
+        return b""
+
+    table = parse_ref(model)
+    if table is None:
+        return b""  # inline SQL or a table name — already covered by the yaml bytes
+    sql_file = project_dir / "syncs" / "models" / f"{table}.sql"
+    return sql_file.read_bytes() if sql_file.exists() else b""
+
+
+def _digest(yaml_bytes: bytes, model_bytes: bytes) -> str:
+    return hashlib.sha256(yaml_bytes + _SEPARATOR + model_bytes).hexdigest()[:_DIGEST_CHARS]

--- a/drt/config/fingerprint.py
+++ b/drt/config/fingerprint.py
@@ -10,17 +10,23 @@ editing the sync.
 
 Two consequences, both deliberate:
 
-*Secrets cannot enter the input.* The file holds ``${API_TOKEN}`` or
-``token_env: NAME``, never a value, so there is no "which fields are secret?"
-classification to maintain or get wrong. That is the same structural choice
-every comparable tool makes — dbt keeps credentials in ``profiles.yml`` outside
-the project (which is why its ``manifest.json`` is documented as safe to share
-as a CI artifact), and Hightouch Git Sync / Census Git-backed Models keep them
-in the vendor workspace, referenced by id. An earlier draft of this hashed the
+*Secrets don't enter the input, given the recommended pattern.* The file
+holds ``${API_TOKEN}`` or ``token_env: NAME``, never a value, so there is no
+"which fields are secret?" classification to maintain or get wrong for a sync
+written that way. That is the same structural choice every comparable tool
+makes — dbt keeps credentials in ``profiles.yml`` outside the project (which
+is why its ``manifest.json`` is documented as safe to share as a CI
+artifact), and Hightouch Git Sync / Census Git-backed Models keep them in the
+vendor workspace, referenced by id. An earlier draft of this hashed the
 *resolved* config and had to decide whether ``upsert_key`` was a secret
 (``config/secrets.py``'s name-suffix heuristic says yes, wrongly, and redacting
 it would have hidden a real change in write semantics). Hashing the file removes
-the question rather than answering it carefully.
+the question rather than answering it carefully — but it's not an absolute
+guarantee: nothing here stops a sync from holding a literal hardcoded value
+instead of ``_env``/``${VAR}`` indirection. ``config/secrets.py``'s scanner
+flags that as a ``drt validate`` warning, but it's advisory, not a block, so a
+misconfigured file's literal secret would still be hashed into the
+fingerprint.
 
 *Environment changes are invisible.* Changing ``API_TOKEN``'s value, or a
 ``DRT_VAR_*``, does not move the fingerprint. dbt has and documents the same

--- a/drt/config/parser.py
+++ b/drt/config/parser.py
@@ -102,7 +102,7 @@ def load_project(project_dir: Path = Path(".")) -> ProjectConfig:
     return ProjectConfig.model_validate(data)
 
 
-def _expand_sync_vars(data: Any, variables: dict[str, Any]) -> Any:
+def expand_sync_vars(data: Any, variables: dict[str, Any]) -> Any:
     """Render ``var()`` in a sync's YAML string fields, leaving ``model:`` alone.
 
     Model SQL shares its template surface with ``{{ cursor_value }}`` /
@@ -155,7 +155,7 @@ def load_syncs(
         with path.open() as f:
             data = yaml.safe_load(f)
         data = expand_env_vars(data)
-        data = _expand_sync_vars(data, resolved)
+        data = expand_sync_vars(data, resolved)
         syncs.append(SyncConfig.model_validate(data))
     return syncs
 
@@ -178,7 +178,7 @@ def load_syncs_safe(
             data = yaml.safe_load(f)
         try:
             data = expand_env_vars(data)
-            data = _expand_sync_vars(data, resolved)
+            data = expand_sync_vars(data, resolved)
             # Check for deprecated keys before validation
             deprecations = _check_deprecated_keys(data)
             sync = SyncConfig.model_validate(data)

--- a/tests/unit/test_fingerprint.py
+++ b/tests/unit/test_fingerprint.py
@@ -1,0 +1,214 @@
+"""Tests for the per-sync file fingerprint backing ``state:modified`` (#772).
+
+The properties matter far more than the digest algorithm. A fingerprint that
+moves when the user changed nothing makes ``state:modified`` select everything
+(useless); one that stays put when the user *did* change something makes it
+select nothing (dangerous, and silent). Each test below pins one of those.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from drt.config.fingerprint import sync_fingerprints
+
+_SYNC_YAML = textwrap.dedent(
+    """\
+    name: users_to_api
+    model: ref('users')
+    destination:
+      type: rest_api
+      url: https://example.com/users
+    sync:
+      mode: full
+    """
+)
+
+
+def _project(tmp_path: Path, syncs: dict[str, str], models: dict[str, str]) -> Path:
+    (tmp_path / "drt_project.yml").write_text("name: demo\nprofile: default\n")
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    (syncs_dir / "models").mkdir()
+    for filename, body in syncs.items():
+        (syncs_dir / filename).write_text(body)
+    for filename, body in models.items():
+        (syncs_dir / "models" / filename).write_text(body)
+    return tmp_path
+
+
+def _one(tmp_path: Path, yaml_body: str = _SYNC_YAML, sql: str = "SELECT 1") -> str:
+    _project(tmp_path, {"a.yml": yaml_body}, {"users.sql": sql})
+    return sync_fingerprints(tmp_path)["users_to_api"]
+
+
+# --- stability ---------------------------------------------------------------
+
+
+def test_fingerprint_is_stable_across_processes(tmp_path: Path) -> None:
+    """Two interpreters with different hash seeds must agree.
+
+    A second call in the *same* process would pass even if the implementation
+    leaned on ``hash()`` or iterated a set, so this deliberately shells out
+    twice with ``PYTHONHASHSEED`` pinned to different values.
+    """
+    _project(tmp_path, {"a.yml": _SYNC_YAML}, {"users.sql": "SELECT 1"})
+    snippet = (
+        "from drt.config.fingerprint import sync_fingerprints;"
+        f"print(sync_fingerprints({str(tmp_path)!r})['users_to_api'])"
+    )
+    results = []
+    for seed in ("0", "1"):
+        proc = subprocess.run(
+            [sys.executable, "-c", snippet],
+            capture_output=True,
+            text=True,
+            check=True,
+            env={"PATH": "/usr/bin:/bin", "PYTHONHASHSEED": seed, "HOME": str(tmp_path)},
+        )
+        results.append(proc.stdout.strip())
+    assert results[0] == results[1]
+    assert results[0]  # non-empty
+
+
+def test_same_input_same_fingerprint(tmp_path: Path, tmp_path_factory) -> None:
+    other = tmp_path_factory.mktemp("other")
+    assert _one(tmp_path) == _one(other)
+
+
+# --- what MUST change it -----------------------------------------------------
+
+
+def test_model_sql_change_changes_fingerprint(tmp_path: Path) -> None:
+    """The issue calls this out explicitly: ref()'d SQL files must be covered."""
+    before = _one(tmp_path, sql="SELECT 1")
+    (tmp_path / "syncs" / "models" / "users.sql").write_text("SELECT 2")
+    assert sync_fingerprints(tmp_path)["users_to_api"] != before
+
+
+def test_sync_yaml_change_changes_fingerprint(tmp_path: Path) -> None:
+    before = _one(tmp_path)
+    changed = _SYNC_YAML.replace("mode: full", "mode: upsert\n  upsert_key: [id]")
+    (tmp_path / "syncs" / "a.yml").write_text(changed)
+    assert sync_fingerprints(tmp_path)["users_to_api"] != before
+
+
+def test_comment_only_change_still_marks_modified(tmp_path: Path) -> None:
+    """Pinned deliberately, not discovered.
+
+    Hashing raw bytes means a comment counts as a change. That is what dbt does
+    with its file checksums, and being conservative here costs one extra dry-run
+    while the opposite would be a silent miss. If this ever becomes intolerable
+    it should be a deliberate change, so it fails loudly first.
+    """
+    before = _one(tmp_path)
+    (tmp_path / "syncs" / "a.yml").write_text("# just a comment\n" + _SYNC_YAML)
+    assert sync_fingerprints(tmp_path)["users_to_api"] != before
+
+
+# --- what must NOT change it -------------------------------------------------
+
+
+def test_run_state_does_not_change_fingerprint(tmp_path: Path) -> None:
+    """Trap A regression: the watermark must never reach the hash input.
+
+    ``resolve_model_ref`` substitutes the current cursor value into the SQL it
+    returns, so fingerprinting *that* would move the hash on every run of an
+    incremental sync and select everything, forever. The fingerprint must read
+    files, not resolved queries.
+    """
+    before = _one(tmp_path)
+    state_dir = tmp_path / ".drt"
+    state_dir.mkdir(exist_ok=True)
+    (state_dir / "state.json").write_text(
+        '{"users_to_api": {"sync_name": "users_to_api", "last_run_at": "2026-08-03T00:00:00",'
+        ' "records_synced": 10, "status": "success", "last_cursor_value": "2026-08-03"}}'
+    )
+    (state_dir / "watermarks.json").write_text('{"users_to_api": "2026-08-03T12:00:00"}')
+    assert sync_fingerprints(tmp_path)["users_to_api"] == before
+
+
+def test_secret_value_never_reaches_the_fingerprint(
+    tmp_path: Path, tmp_path_factory, monkeypatch
+) -> None:
+    """Trap B regression: secrets are excluded *by construction*, not by a list.
+
+    The file holds ``${API_TOKEN}``, never the value, so no field-classification
+    exists to get wrong — the reason this hashes the file as written rather than
+    the resolved config. Both the digest and the hashed bytes are checked: equal
+    digests alone could also mean the token was dropped from the input for some
+    other reason.
+    """
+    body = _SYNC_YAML.replace(
+        "  url: https://example.com/users\n",
+        "  url: https://example.com/users\n  auth:\n    type: bearer\n    token: ${API_TOKEN}\n",
+    )
+    monkeypatch.setenv("API_TOKEN", "secret-value-one")
+    first = _one(tmp_path, yaml_body=body)
+
+    other = tmp_path_factory.mktemp("other")
+    monkeypatch.setenv("API_TOKEN", "totally-different-secret-two")
+    second = _one(other, yaml_body=body)
+
+    assert first == second
+    assert "secret-value-one" not in (tmp_path / "syncs" / "a.yml").read_text()
+
+    # The two assertions above would also hold if the implementation simply
+    # ignored the whole auth block, so prove it does not: swapping which env
+    # var is referenced is a real config change and must move the fingerprint.
+    renamed = tmp_path_factory.mktemp("renamed")
+    third = _one(renamed, yaml_body=body.replace("${API_TOKEN}", "${OTHER_TOKEN}"))
+    assert third != first
+
+
+def test_editing_one_sync_does_not_move_another(tmp_path: Path) -> None:
+    second = _SYNC_YAML.replace("users_to_api", "orders_to_api").replace(
+        "ref('users')", "ref('orders')"
+    )
+    _project(
+        tmp_path,
+        {"a.yml": _SYNC_YAML, "b.yml": second},
+        {"users.sql": "SELECT 1", "orders.sql": "SELECT 2"},
+    )
+    before = sync_fingerprints(tmp_path)
+    (tmp_path / "syncs" / "a.yml").write_text(_SYNC_YAML + "description: edited\n")
+    after = sync_fingerprints(tmp_path)
+
+    assert after["users_to_api"] != before["users_to_api"]
+    assert after["orders_to_api"] == before["orders_to_api"]
+
+
+# --- shape -------------------------------------------------------------------
+
+
+def test_missing_model_file_is_tolerated(tmp_path: Path) -> None:
+    """``ref()`` may point at a dbt model or a bare table, with no local .sql."""
+    _project(tmp_path, {"a.yml": _SYNC_YAML}, {})
+    prints = sync_fingerprints(tmp_path)
+    assert prints["users_to_api"]
+
+
+def test_no_syncs_dir_returns_empty(tmp_path: Path) -> None:
+    (tmp_path / "drt_project.yml").write_text("name: demo\nprofile: default\n")
+    assert sync_fingerprints(tmp_path) == {}
+
+
+def test_undefined_env_var_elsewhere_does_not_hide_the_sync(tmp_path: Path) -> None:
+    """A sync referencing an unset env var must still appear in the map.
+
+    Regression for a real bug: expanding the whole document to find ``name:``
+    meant one undefined ``${VAR}`` anywhere in the file dropped the sync
+    entirely, so ``state:modified`` silently would not select it. A PR adding a
+    sync whose secret is not provisioned yet is precisely what CI should be
+    looking at.
+    """
+    body = _SYNC_YAML.replace(
+        "  url: https://example.com/users\n",
+        "  url: https://example.com/users\n  auth:\n    type: bearer\n"
+        "    token: ${DEFINITELY_NOT_SET_ANYWHERE}\n",
+    )
+    _project(tmp_path, {"a.yml": body}, {"users.sql": "SELECT 1"})
+    assert "users_to_api" in sync_fingerprints(tmp_path)

--- a/tests/unit/test_fingerprint.py
+++ b/tests/unit/test_fingerprint.py
@@ -212,3 +212,74 @@ def test_undefined_env_var_elsewhere_does_not_hide_the_sync(tmp_path: Path) -> N
     )
     _project(tmp_path, {"a.yml": body}, {"users.sql": "SELECT 1"})
     assert "users_to_api" in sync_fingerprints(tmp_path)
+
+
+# --- degenerate inputs -------------------------------------------------------
+#
+# Every branch below decides whether a sync is *visible* to state:modified.
+# An invisible sync is a sync CI silently does not run, so these paths deserve
+# tests more than the happy path does.
+
+
+def test_inline_sql_model_is_supported(tmp_path: Path) -> None:
+    """``model:`` may be raw SQL rather than ``ref()`` — a normal usage, not an edge.
+
+    There is no .sql file to read in that case; the SQL is already inside the
+    yaml bytes being hashed, so editing it still moves the fingerprint.
+    """
+    body = _SYNC_YAML.replace("model: ref('users')", "model: SELECT id FROM users")
+    before = _one(tmp_path, yaml_body=body)
+
+    other_body = body.replace("SELECT id FROM users", "SELECT id, email FROM users")
+    (tmp_path / "syncs" / "a.yml").write_text(other_body)
+    assert sync_fingerprints(tmp_path)["users_to_api"] != before
+
+
+def test_malformed_yaml_does_not_poison_the_other_syncs(tmp_path: Path) -> None:
+    """One broken file must not make the whole project invisible.
+
+    ``drt validate`` is where a broken sync gets reported; a selector that blew
+    up on an unrelated malformed file would be worse than one that skips it.
+    """
+    _project(
+        tmp_path,
+        {"a.yml": _SYNC_YAML, "broken.yml": "name: [unclosed\n  : :\n"},
+        {"users.sql": "SELECT 1"},
+    )
+    prints = sync_fingerprints(tmp_path)
+    assert "users_to_api" in prints
+
+
+def test_non_mapping_yaml_is_skipped(tmp_path: Path) -> None:
+    _project(tmp_path, {"a.yml": _SYNC_YAML, "list.yml": "- just\n- a list\n"}, {})
+    assert list(sync_fingerprints(tmp_path)) == ["users_to_api"]
+
+
+def test_sync_without_a_name_is_skipped(tmp_path: Path) -> None:
+    _project(tmp_path, {"a.yml": _SYNC_YAML, "anon.yml": "model: ref('x')\n"}, {})
+    assert list(sync_fingerprints(tmp_path)) == ["users_to_api"]
+
+
+def test_missing_or_non_string_model_is_tolerated(tmp_path: Path) -> None:
+    body = _SYNC_YAML.replace("model: ref('users')\n", "")
+    _project(tmp_path, {"a.yml": body}, {})
+    assert sync_fingerprints(tmp_path)["users_to_api"]
+
+    listy = _SYNC_YAML.replace("model: ref('users')", "model:\n  - not\n  - a string")
+    (tmp_path / "syncs" / "a.yml").write_text(listy)
+    assert sync_fingerprints(tmp_path)["users_to_api"]
+
+
+def test_unresolvable_name_falls_back_to_the_literal(tmp_path: Path) -> None:
+    """The name's own expansion failing must not delete the sync either.
+
+    Distinct from the undefined-var-elsewhere case above: there the name
+    resolves fine and the failure is in another field. Here expansion of the
+    name itself fails, and the literal is kept so the sync stays visible rather
+    than vanishing from the map.
+    """
+    body = _SYNC_YAML.replace("name: users_to_api", "name: ${NOT_SET_NAME_VAR}")
+    _project(tmp_path, {"a.yml": body}, {"users.sql": "SELECT 1"})
+    prints = sync_fingerprints(tmp_path)
+    assert len(prints) == 1
+    assert next(iter(prints.values()))


### PR DESCRIPTION
First piece of #772 — the comparison unit CI needs in order to answer *"which syncs did this PR change?"*. No selector or CLI flag yet; this is the fingerprint alone, so it can be argued with on its own.

## What it hashes

The sync file **as written on disk** — before `${VAR}` substitution and `var()` rendering — plus the raw bytes of the `syncs/models/<name>.sql` a `ref()` points at.

```python
sync_fingerprints(project_dir) -> dict[str, str]   # resolved sync name -> digest
```

## Why not hash the resolved config

An earlier draft did, and it forced the question *"which destination fields are secret?"*. Reusing `config/secrets.py`'s name-suffix heuristic for that would have been a correctness bug — run against every destination config it flags:

```
SnowflakeDestinationConfig: ['upsert_key']
AirtableDestinationConfig:  ['access_token', 'primary_key']
JiraDestinationConfig:      ['project_key']
```

`upsert_key` is a column list, Airtable's `primary_key` is the field passed to `performUpsert.fieldsToMergeOn`, Jira's `project_key` is the `ENG` in `ENG-123`. Redacting `upsert_key` would mean **changing a sync's upsert key does not change its fingerprint** — write semantics change completely and CI does not select it.

Hashing the file **removes the question instead of answering it carefully**, and matches what comparable tools do: dbt keeps credentials in `profiles.yml` outside the project, which is why [`manifest.json` is documented as safe to share as a CI artifact](https://docs.getdbt.com/reference/artifacts/dbt-artifacts); Hightouch Git Sync and Census Git-backed Models keep them in the vendor workspace, referenced by id. **None of them classify secret fields — they are built so the question cannot arise.**

The accepted cost is dbt's documented blind spot: an env var or `var()` *value* change is invisible ([state comparison caveats](https://docs.getdbt.com/reference/node-selection/state-comparison-caveats)). In exchange, a baseline generated in one environment compares meaningfully against another, since file bytes do not depend on the environment.

## Two traps this deliberately avoids, each with a regression test

**The watermark must not reach the hash.** `engine/resolver.py`'s `resolve_model_ref` takes `last_cursor_value` and substitutes the **current watermark** into the SQL it returns. Fingerprinting that would move the hash after every incremental run — `state:modified` would select every sync, forever. So this reads `.sql` files off disk and never calls the resolver. Pinned by a test that writes `state.json` + `watermarks.json` and asserts the fingerprint holds.

**An undefined env var must not hide a sync.** Expanding the whole document to find `name:` meant one unresolvable `${VAR}` *anywhere* in the file dropped the sync out of the map — so a PR adding a sync whose secret is not provisioned yet would silently not be selected, which is exactly the PR CI should be looking at. Name expansion is now isolated to the name value. Found by strengthening the secret test rather than by review.

## Behaviour pinned on purpose

A **comment-only edit marks the sync modified**. That is what raw-byte hashing means and what dbt does with file checksums; being conservative costs one extra dry-run, the opposite is a silent miss. There is a test asserting it, so changing it later has to be deliberate.

## Not covered (documented, not silently missing)

A change to `drt_project.yml` (project `vars`, profile) affects every sync but no sync file. This is a per-sync-file change detector, not a whole-project one — same split dbt makes.

## Verification

- 11 new tests, including cross-process stability under two different `PYTHONHASHSEED` values (a same-process re-call would pass even if the implementation leaned on `hash()`)
- Full suite **2914 passed, 21 skipped**; `ruff` and `mypy` clean

Also renames `parser._expand_sync_vars` → `expand_sync_vars` (two internal call sites), symmetric with the already-public `expand_env_vars`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)