### PR TITLE
feat(templates): render templates to values, and compile them once (#763, 1 of 3)

### DIFF
--- a/drt/templates/renderer.py
+++ b/drt/templates/renderer.py
@@ -2,6 +2,22 @@
 
 Future: replace with MiniJinja (Rust) via PyO3 for zero-dependency binary.
 Interface is intentionally simple to make the swap transparent.
+
+Two rendering entry points, differing only in what they return:
+
+* :func:`render_template` — always a ``str``. Used where the result is spliced
+  into a larger text payload (REST ``body_template``, HubSpot / Klaviyo /
+  Mixpanel / Zendesk / Linear property templates), so a string is the only
+  sensible answer.
+* :func:`render_value` — a Python value when the template is a **single
+  output node**, otherwise a ``str`` (#763). Used where the result becomes a
+  *field* in a record that a typed destination is about to write, so
+  ``{{ row.n * 1000 }}`` must reach a BIGINT column as ``5000`` and not
+  ``"5000"``.
+
+Both share one Environment per mode and cache compiled templates, because
+every caller renders **per record**: the previous code built a fresh
+``Environment`` and re-parsed the template inside the row loop.
 """
 
 from __future__ import annotations
@@ -9,11 +25,22 @@ from __future__ import annotations
 import json
 from datetime import date, datetime, time
 from decimal import Decimal
+from functools import lru_cache
+from itertools import chain, islice
 from typing import Any
 from uuid import UUID
 
-from jinja2 import BaseLoader, Environment, StrictUndefined
+from jinja2 import BaseLoader, Environment, StrictUndefined, Template, Undefined
 from jinja2.exceptions import UndefinedError
+from jinja2.nativetypes import NativeEnvironment, NativeTemplate
+
+# Compiled templates are cached by source text. Template sources come from
+# config, so the working set is bounded by project size; the cap only exists
+# so a pathological config cannot grow the cache without limit (a miss just
+# re-parses). Jinja templates are safe to render concurrently — each render
+# builds its own context — which matters because `drt run --threads N` renders
+# from several threads against one cache.
+_TEMPLATE_CACHE_SIZE = 512
 
 
 def _json_default(obj: Any) -> Any:
@@ -36,16 +63,107 @@ def tojson_safe(value: Any) -> str:
     return json.dumps(value, default=_json_default, ensure_ascii=False)
 
 
+def _single_node_concat(values: Any) -> Any:
+    """Join rendered output nodes, preserving the value of a lone node (#763).
+
+    This is the whole of the "when does a template keep its type" rule, and it
+    is deliberately expressed in terms of **output nodes** rather than the
+    rendered text:
+
+    * one node  → that node's value, untouched. ``{{ row.n }}`` yields ``5``;
+      ``{{ row.zip }}`` over ``"01"`` yields ``"01"``; a template with no
+      expression at all (``"drt-prod"``) is a single literal node and stays
+      the string it was written as.
+    * many nodes → ``str`` of each, concatenated. ``"{{ a }}-{{ b }}"`` is
+      text assembly, so text is what it produces.
+
+    Jinja's own :func:`jinja2.nativetypes.native_concat` is **not** usable
+    here: it runs ``literal_eval`` over the result, so a column holding the
+    string ``"123"`` would silently arrive at the destination as the integer
+    ``123``. That is data-dependent — the same config would behave differently
+    per row — which is exactly the failure this rule exists to avoid.
+    """
+    head = list(islice(values, 2))
+    if not head:
+        return ""
+    if len(head) == 1:
+        value = head[0]
+        if isinstance(value, Undefined):
+            # The native code generator never stringifies an output node, so
+            # StrictUndefined has nothing to trip over and an Undefined would
+            # otherwise be written into the record as-is. Force it.
+            str(value)
+        return value
+    return "".join(str(v) for v in chain(head, values))
+
+
+class _ValueTemplate(NativeTemplate):
+    """A NativeTemplate that concatenates via :func:`_single_node_concat`.
+
+    ``NativeTemplate.render`` reaches for ``self.environment_class.concat``,
+    i.e. the concat of the *declared* class rather than of the environment
+    that produced the template — so overriding ``concat`` on an Environment
+    subclass alone silently has no effect.
+    """
+
+    def render(self, *args: Any, **kwargs: Any) -> Any:
+        ctx = self.new_context(dict(*args, **kwargs))
+        try:
+            return _single_node_concat(self.root_render_func(ctx))
+        except Exception:
+            return self.environment.handle_exception()
+
+
+class _ValueEnvironment(NativeEnvironment):
+    """Native environment whose templates return values, not repr-able text."""
+
+    template_class = _ValueTemplate
+    concat = staticmethod(_single_node_concat)
+
+
+def _build_env(env: Environment) -> Environment:
+    env.filters["tojson_safe"] = tojson_safe
+    return env
+
+
+_STRING_ENV = _build_env(Environment(loader=BaseLoader(), undefined=StrictUndefined))
+_VALUE_ENV = _build_env(_ValueEnvironment(loader=BaseLoader(), undefined=StrictUndefined))
+
+
+@lru_cache(maxsize=_TEMPLATE_CACHE_SIZE)
+def _compile_string(template_str: str) -> Template:
+    return _STRING_ENV.from_string(template_str)
+
+
+@lru_cache(maxsize=_TEMPLATE_CACHE_SIZE)
+def _compile_value(template_str: str) -> Template:
+    return _VALUE_ENV.from_string(template_str)
+
+
 def render_template(template_str: str, row: dict[str, Any]) -> str:
     """Render a Jinja2 template string with a single row of data.
 
     Variables are accessed as {{ row.field_name }}.
     Raises ValueError on missing variables (strict mode).
     """
-    env = Environment(loader=BaseLoader(), undefined=StrictUndefined)
-    env.filters["tojson_safe"] = tojson_safe
     try:
-        tmpl = env.from_string(template_str)
-        return tmpl.render(row=row)
+        return _compile_string(template_str).render(row=row)
+    except UndefinedError as e:
+        raise ValueError(f"Template error: {e}") from e
+
+
+def render_value(template_str: str, row: dict[str, Any]) -> Any:
+    """Render a template to a Python value rather than to text (#763).
+
+    Same environment, filters and strictness as :func:`render_template`; the
+    only difference is that a template consisting of a **single output node**
+    returns that node's value with its type intact — see
+    :func:`_single_node_concat` for the rule and why Jinja's native concat is
+    not used.
+
+    Raises ValueError on missing variables (strict mode).
+    """
+    try:
+        return _compile_value(template_str).render(row=row)
     except UndefinedError as e:
         raise ValueError(f"Template error: {e}") from e

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -1,13 +1,14 @@
 """Tests for template renderer."""
 
 import json
+from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime, time, timezone
 from decimal import Decimal
 from uuid import UUID
 
 import pytest
 
-from drt.templates.renderer import render_template, tojson_safe
+from drt.templates.renderer import _compile_value, render_template, render_value, tojson_safe
 
 
 def test_render_simple(sample_row: dict) -> None:
@@ -70,3 +71,104 @@ def test_tojson_strict_still_fails_on_datetime() -> None:
     row = {"ts": datetime(2026, 5, 28, tzinfo=timezone.utc)}
     with pytest.raises(TypeError, match="not JSON serializable"):
         render_template("{{ row.ts | tojson }}", row)
+
+
+# --- render_value: single output node keeps its type (#763) ------------------
+
+
+class TestRenderValueKeepsType:
+    """One output node → that node's value. Anything else → a string."""
+
+    @pytest.mark.parametrize(
+        "template,expected",
+        [
+            ("{{ row.n }}", 5),
+            ("{{ row.n * 1000 }}", 5000),
+            ("{{ row.flag }}", True),
+            ("{{ row.nothing }}", None),
+            ("{{ row.amount }}", Decimal("1.50")),
+            ("{{ row.ts }}", datetime(2026, 5, 28, tzinfo=timezone.utc)),
+        ],
+    )
+    def test_lone_expression_returns_the_python_value(
+        self, template: str, expected: object
+    ) -> None:
+        row = {
+            "n": 5,
+            "flag": True,
+            "nothing": None,
+            "amount": Decimal("1.50"),
+            "ts": datetime(2026, 5, 28, tzinfo=timezone.utc),
+        }
+        result = render_value(template, row)
+        assert result == expected
+        assert type(result) is type(expected)
+
+    @pytest.mark.parametrize("raw", ["123", "01", "1_000", "True", "None", "[1, 2]"])
+    def test_a_string_column_stays_a_string(self, raw: str) -> None:
+        """The reason Jinja's own native_concat is not used.
+
+        native_concat runs `literal_eval` over the rendered result, so a column
+        holding "123" would reach the destination as the integer 123 while a
+        column holding "01" stayed a string — the same config behaving
+        differently per row, decided by the data. Every value here is
+        `literal_eval`-able (or deceptively close to it) and must survive as
+        the string it was.
+        """
+        result = render_value("{{ row.value }}", {"value": raw})
+        assert result == raw
+        assert isinstance(result, str)
+
+    @pytest.mark.parametrize(
+        "template,expected",
+        [
+            ("{{ row.a }}-{{ row.b }}", "x-y"),  # two expressions
+            ("+81{{ row.a }}", "+81x"),  # literal text plus an expression
+            ("{{ row.n }} ", "5 "),  # even one trailing space is a second node
+            ("drt-prod", "drt-prod"),  # no expression at all
+            ("01", "01"),  # ...and a literal is never literal_eval'd
+            ("", ""),  # nothing to render is the empty string, not None
+        ],
+    )
+    def test_anything_but_a_lone_node_renders_as_text(self, template: str, expected: str) -> None:
+        result = render_value(template, {"a": "x", "b": "y", "n": 5})
+        assert result == expected
+        assert isinstance(result, str)
+
+    def test_undefined_still_raises_for_a_lone_expression(self) -> None:
+        """The trap the native code generator opens up.
+
+        It never stringifies an output node, so StrictUndefined has nothing to
+        trip over: without an explicit check the Undefined object itself is
+        returned and gets written into the record. A typo'd column name has to
+        fail, not produce a mystery value.
+        """
+        with pytest.raises(ValueError, match="Template error"):
+            render_value("{{ row.missing_field }}", {"present": 1})
+
+    def test_undefined_still_raises_with_surrounding_text(self) -> None:
+        with pytest.raises(ValueError, match="Template error"):
+            render_value("prefix-{{ row.missing_field }}", {"present": 1})
+
+    def test_filters_are_available(self) -> None:
+        """Same environment as render_template — one templating story."""
+        row = {"ts": datetime(2026, 5, 28, tzinfo=timezone.utc)}
+        assert render_value("{{ row.ts | tojson_safe }}", row) == '"2026-05-28T00:00:00+00:00"'
+
+
+class TestRenderValueReuse:
+    def test_templates_are_compiled_once(self) -> None:
+        """Every caller renders per record; re-parsing per row was the cost."""
+        template = "{{ row.unique_to_this_test }}"
+        render_value(template, {"unique_to_this_test": 1})
+        before = _compile_value.cache_info().hits
+        for _ in range(5):
+            render_value(template, {"unique_to_this_test": 2})
+        assert _compile_value.cache_info().hits == before + 5
+
+    def test_concurrent_renders_do_not_share_state(self) -> None:
+        """`drt run --threads N` renders from several threads through one cache."""
+        template = "{{ row.i }}"
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(pool.map(lambda i: render_value(template, {"i": i}), range(200)))
+        assert results == list(range(200))


### PR DESCRIPTION
First of three for #763 (`computed_fields`). Self-contained: no config key and no engine wiring yet, and one of the two changes is a straight win for code already shipped.

## Compile once

`render_template` built a fresh `Environment` and re-parsed the template **on every call**, and all five of its callers — HubSpot, Klaviyo, Mixpanel, Zendesk, Linear — call it *per record*. Now: two module-level environments and an LRU cache of compiled templates. Jinja templates are safe to render concurrently (each render builds its own context), which matters because `drt run --threads N` renders through one shared cache — a test renders 200 rows across 8 threads to pin that.

## `render_value`

Returns a Python value when the template is a **single output node**, a string otherwise:

| template | result |
|---|---|
| `{{ row.n }}` | `5` |
| `{{ row.n * 1000 }}` | `5000` |
| `{{ row.flag }}` | `True` |
| `{{ row.a }}-{{ row.b }}` | `"x-y"` |
| `+81{{ row.a }}` | `"+81x"` |
| `drt-prod` | `"drt-prod"` |

`render_template` is unchanged and keeps returning `str` — its callers splice the result into a larger text payload, so a string is the only sensible answer. A *computed field* is different: it becomes a column a typed destination is about to write, and `{{ row.ts | to_ms }}` arriving as `"1754000000000"` instead of an integer is a real defect, not a formatting quibble.

**Why not Jinja's own `native_concat`.** It runs `literal_eval` over the rendered result, so a column holding the string `"123"` would arrive at the destination as the integer `123`, while `"01"` stayed a string (leading zero → `SyntaxError` → falls back to text). Same config, different behaviour per row, decided by the data. The rule here keys on the **output node count** instead, so a bare literal is never evaluated at all — `"01"` in YAML stays `"01"`.

## Two Jinja details worth flagging, both silent if missed

- `NativeTemplate.render` reaches for `self.environment_class.concat` — the concat of the **declared** class, not of the environment that produced the template. Overriding `concat` on an `Environment` subclass alone therefore does nothing at all; the template class has to be replaced too. My first prototype had exactly this bug and looked like it worked, because `native_concat` happens to give the right answer for `{{ row.n }}` — it only diverged on string columns.
- The native code generator never stringifies an output node, so `StrictUndefined` has nothing to trip over. `{{ row.typo }}` returned the `Undefined` **object**, which would have been written straight into the record. Now forced explicitly, with tests for both the lone-expression and the surrounded-by-text case.

## Verification

Full suite **2951 passed / 22 skipped**; `drt/templates/renderer.py` at **100%** line coverage (measured per-module, not via the patch status); `ruff` + `mypy` clean.

Next in the stack: the `computed_fields` config key + engine stage, then docs.
