### PR TITLE
feat(engine): first-class run_id + sync_run_id correlation (#762, part 1)

### DIFF
--- a/drt/_identifiers.py
+++ b/drt/_identifiers.py
@@ -1,0 +1,33 @@
+"""Run identifiers — first-class correlation IDs for one execution (#762).
+
+Two distinct scopes share this one generator:
+
+* **invocation `run_id`** — one per ``drt run`` / ``drt test`` process. The
+  CLI generates it once (``drt/cli/commands/run.py``) and threads it through
+  every sync in that invocation, so all of them can be correlated back to
+  "the run that happened at 03:40 UTC".
+* **``sync_run_id``** — one per *sync execution*, generated inside
+  :func:`drt.engine.sync.run_sync` itself so every caller gets one, including
+  library callers that never pass an invocation ``run_id`` at all.
+
+Neither is the query-tagging ``run_id`` in :mod:`drt.config.query_tags` —
+that one is scoped narrowly to "distinguish this query from the last one this
+sync ran" for cost-attribution SQL comments, predates this module, and stays
+separate on purpose (see its own docstring).
+
+Plain ``uuid4`` rather than ``uuid7``: sortability isn't a real requirement
+for any of the six correlation surfaces this threads through (history, DLQ,
+alerts, OTel, ``--output json``, structured logs all key by ``sync_name`` +
+timestamp already), and ``uuid.uuid7`` isn't in the stdlib on any Python drt
+still supports (3.10-3.13) — pulling in a dependency to sort IDs nobody sorts
+would be exactly the "heavy dependency in core" CLAUDE.md rules out.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+
+def new_run_id() -> str:
+    """A fresh globally-unique identifier for one run or one sync execution."""
+    return str(uuid.uuid4())

--- a/drt/alerts/dispatcher.py
+++ b/drt/alerts/dispatcher.py
@@ -36,6 +36,8 @@ def build_context(
         "rows_processed": result.success + result.failed,
         "duration_s": duration_s,
         "started_at": started_at,
+        "run_id": result.run_id,
+        "sync_run_id": result.sync_run_id,
     }
 
 
@@ -71,6 +73,8 @@ def build_degraded_context(
         "rows_processed": result.success + result.failed,
         "duration_s": duration_s,
         "started_at": started_at,
+        "run_id": result.run_id,
+        "sync_run_id": result.sync_run_id,
     }
 
 

--- a/drt/cli/commands/build.py
+++ b/drt/cli/commands/build.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import typer
 
+from drt._identifiers import new_run_id
 from drt.cli._app import app
 from drt.cli._selection import SelectionError, complete_selector, select_syncs
 from drt.cli.output import console, print_error
@@ -121,6 +122,7 @@ def build(
         quiet=quiet,
         log_json=False,
         cursor_value=None,
+        run_id=new_run_id(),
     )
 
     entries: list[dict[str, object]] = []

--- a/drt/cli/commands/run.py
+++ b/drt/cli/commands/run.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
     from drt.state.manager import StateManager
 
 
+from drt._identifiers import new_run_id
 from drt.cli._app import app
 from drt.cli._helpers import (
     exit_code_for_signal as _exit_code_for_signal,
@@ -120,6 +121,13 @@ class _RunContext:
     # Query tagging (#768) — drt_project.yml's query_tagging: block, passed
     # straight through to run_sync().
     query_tagging: QueryTaggingConfig | None = None
+    # Invocation-level correlation id (#762) — one per `drt run` process,
+    # generated once by run() and threaded through every sync it executes.
+    # Always a real value in production; the "" default only exists because
+    # a dataclass field can't be required once a preceding field (above) has
+    # a default — every real construction site sets it explicitly.
+    # See drt._identifiers.
+    run_id: str = ""
 
 
 def _build_observer(sync: SyncConfig, ctx: _RunContext, wm_storage: Any) -> Any:
@@ -196,6 +204,7 @@ def _run_one(
                 extract_limit=ctx.extract_limit,
                 vars=ctx.vars,
                 query_tagging=ctx.query_tagging,
+                run_id=ctx.run_id,
             )
         except Exception as e:
             from drt.cli.errors import format_error, render_to_console
@@ -216,6 +225,12 @@ def _run_one(
                 "error_type": fe.error_type,
                 "error_stage": fe.stage.value,
                 "error_suggestion": fe.suggestion,
+                # run_id (#762): known at the CLI regardless of what happened
+                # inside run_sync(). sync_run_id has no home here — run_sync
+                # raised instead of returning a SyncResult to read it from —
+                # but the history entry and failure alert it wrote before
+                # re-raising still carry the correct one.
+                "run_id": ctx.run_id,
             }
             if ctx.log_json:
                 logging.error(
@@ -227,6 +242,7 @@ def _run_one(
                         "status": "failed",
                         "error_stage": fe.stage.value,
                         "error_type": fe.error_type,
+                        "run_id": ctx.run_id,
                     },
                 )
             if not ctx.json_mode:
@@ -248,6 +264,8 @@ def _run_one(
             "rows_skipped": result.skipped,
             "duration_seconds": elapsed,
             "dry_run": ctx.dry_run,
+            "run_id": ctx.run_id,
+            "sync_run_id": result.sync_run_id,
         }
         # match_policy no-match skips (#757) — a breakdown of rows_skipped, only
         # emitted when present so healthy runs keep a lean entry.
@@ -269,6 +287,8 @@ def _run_one(
                     "rows": result.success,
                     "duration_ms": round(elapsed * 1000),
                     "status": status_str,
+                    "run_id": ctx.run_id,
+                    "sync_run_id": result.sync_run_id,
                 },
             )
         if not ctx.json_mode and not ctx.quiet:
@@ -771,6 +791,7 @@ def run(
         extract_limit=limit,
         vars=project_vars,
         query_tagging=project.query_tagging,
+        run_id=new_run_id(),
     )
 
     # Execute syncs — parallel if threads > 1, sequential otherwise
@@ -854,6 +875,7 @@ def run(
         print(
             json.dumps(
                 {
+                    "run_id": ctx.run_id,
                     "syncs": json_results,
                     "succeeded": succeeded,
                     "failed": failed,

--- a/drt/config/query_tags.py
+++ b/drt/config/query_tags.py
@@ -30,8 +30,12 @@ _COMMENT_UNSAFE = re.compile(r"\*/|[\r\n]")
 def new_run_id() -> str:
     """A short identifier for one sync's single execution.
 
-    Not the engine-wide ``run_id`` + metadata-columns concept tracked by
-    #762 (unimplemented, targeted after this issue) — this is scoped
+    Not the engine-wide ``run_id`` / ``sync_run_id`` concept #762 shipped
+    (``drt._identifiers.new_run_id``) — kept separate on purpose rather than
+    reconciled, even though both are now generated once per ``run_sync()``
+    call. That first-class id is a full UUID4 string, unconstrained; this one
+    feeds SQL comments and BigQuery job labels, which carry hard length/charset
+    budgets this format was chosen to fit without truncation math. Scoped
     narrowly to "distinguish this query from the last one this sync ran",
     which is all cost attribution needs. Lowercase hex only, so it never
     needs the BigQuery label normalization below.

--- a/drt/destinations/base.py
+++ b/drt/destinations/base.py
@@ -49,6 +49,13 @@ class SyncResult:
     # Record-level diff (#413) — populated by run_sync when dry_run + diff
     # are both requested. Always None outside that path.
     diff: DiffResult | None = None
+    # Correlation IDs (#762). sync_run_id is always set by run_sync() — every
+    # execution gets one, including library callers that pass no run_id at
+    # all. run_id is the invocation-level id the CLI generates once per
+    # `drt run` process and threads through every sync in it; None for a
+    # library caller that never supplied one. See drt._identifiers.
+    run_id: str | None = None
+    sync_run_id: str | None = None
 
     @property
     def total(self) -> int:

--- a/drt/engine/sync.py
+++ b/drt/engine/sync.py
@@ -16,6 +16,7 @@ from itertools import islice
 from pathlib import Path
 from typing import Any, Literal
 
+from drt._identifiers import new_run_id as new_correlation_id
 from drt.config.base import QueryTaggingConfig
 from drt.config.credentials import ProfileConfig
 from drt.config.duration import parse_duration
@@ -245,6 +246,7 @@ def run_sync(
     extract_limit: int | None = None,
     vars: dict[str, Any] | None = None,
     query_tagging: QueryTaggingConfig | None = None,
+    run_id: str | None = None,
 ) -> SyncResult:
     """Run a single sync: extract from source, load to destination.
 
@@ -278,15 +280,25 @@ def run_sync(
             Library callers compose with ``CompositeObserver``; the CLI
             sets up ``LoggingObserver`` + ``StatePersistingObserver`` by
             default (see ``drt.cli.main._run_one``).
+        run_id: Invocation-level correlation id (#762) — one ``drt run``
+            process's identifier, threaded through every sync it executes.
+            ``None`` for library callers that don't track one; this sync's
+            own ``sync_run_id`` (always generated, regardless of ``run_id``)
+            is what ties its own history/DLQ/alert/span records together
+            either way. See ``drt._identifiers``.
 
     Returns:
-        Aggregated SyncResult across all batches.
+        Aggregated SyncResult across all batches, with ``run_id`` and
+        ``sync_run_id`` stamped on it.
     """
     if observer is None:
         observer = NullObserver()
+    sync_run_id = new_correlation_id()
     started_at = datetime.now(timezone.utc).isoformat()
     t0 = time.perf_counter()
     total_result = SyncResult()
+    total_result.run_id = run_id
+    total_result.sync_run_id = sync_run_id
     raised: BaseException | None = None
     tracer = get_tracer()
 
@@ -311,6 +323,9 @@ def run_sync(
             run_span.set_attribute("destination.type", sync.destination.type)
             run_span.set_attribute("sync.mode", sync.sync.mode)
             run_span.set_attribute("batch_size", sync.sync.batch_size)
+            run_span.set_attribute("sync.run_id", sync_run_id)
+            if run_id is not None:
+                run_span.set_attribute("run.id", run_id)
             try:
                 result = _run_sync_body(
                     sync=sync,
@@ -389,6 +404,8 @@ def run_sync(
                         records_failed=total_result.failed,
                         errors=error_strs,
                         cursor_value_used=getattr(total_result, "cursor_value_used", None),
+                        run_id=run_id,
+                        sync_run_id=sync_run_id,
                     )
                 )
                 history_manager.prune(sync.name, history_retention_days)
@@ -655,6 +672,7 @@ def _run_sync_body(
                             error_message=err.error_message,
                             http_status=err.http_status,
                             timestamp=err.timestamp,
+                            sync_run_id=total_result.sync_run_id,
                         )
                         for err in result.row_errors
                         if 0 <= err.batch_index < len(record_batch)

--- a/drt/state/dlq.py
+++ b/drt/state/dlq.py
@@ -41,6 +41,10 @@ class DeadLetter:
     http_status: int | None = None
     timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
     attempts: int = 1
+    # Correlation ID (#762) — which sync execution produced this dead letter.
+    # See drt._identifiers. None on entries written before this field existed;
+    # the JSONL reader tolerates the missing key via the dataclass default.
+    sync_run_id: str | None = None
 
 
 @runtime_checkable

--- a/drt/state/history.py
+++ b/drt/state/history.py
@@ -41,6 +41,11 @@ class HistoryEntry:
     errors: list[str] = field(default_factory=list)  # truncated to first 5
     cursor_value_used: str | None = None  # for incremental syncs
     dry_run: bool = False  # always False on disk; reserved for future use
+    # Correlation IDs (#762) — see drt._identifiers. Both None on entries
+    # written before this field existed; the JSONL reader tolerates the
+    # missing key via the dataclass default, so no migration is needed.
+    run_id: str | None = None
+    sync_run_id: str | None = None
 
 
 @runtime_checkable

--- a/tests/unit/test_alerts.py
+++ b/tests/unit/test_alerts.py
@@ -42,6 +42,21 @@ class TestBuildContext:
         )
         assert "connection refused" in ctx["error"]
 
+    def test_context_carries_correlation_ids_from_result(self) -> None:
+        """#762: no separate params — read straight off the SyncResult that's
+        already threaded through, since run_sync stamps both onto it."""
+        result = SyncResult(success=1, failed=0, run_id="cli-1", sync_run_id="sync-1")
+        ctx = build_context(sync_name="s", result=result, duration_s=1.0, started_at="t")
+        assert ctx["run_id"] == "cli-1"
+        assert ctx["sync_run_id"] == "sync-1"
+
+    def test_context_correlation_ids_default_to_none(self) -> None:
+        ctx = build_context(
+            sync_name="s", result=SyncResult(success=1, failed=0), duration_s=1.0, started_at="t"
+        )
+        assert ctx["run_id"] is None
+        assert ctx["sync_run_id"] is None
+
 
 class TestSlackSender:
     @patch("urllib.request.urlopen")
@@ -213,6 +228,21 @@ class TestDispatchTargets:
             "row_errors_pct",
             "dlq_depth",
         ]
+
+    def test_build_degraded_context_carries_correlation_ids(self) -> None:
+        from drt.alerts.conditions import TrippedCondition
+        from drt.alerts.dispatcher import build_degraded_context
+        from drt.destinations.base import SyncResult
+
+        ctx = build_degraded_context(
+            sync_name="s",
+            result=SyncResult(success=1, failed=0, run_id="cli-2", sync_run_id="sync-2"),
+            duration_s=1.0,
+            started_at="t",
+            tripped=[TrippedCondition("dlq_depth", "gt", 0.0, 5.0)],
+        )
+        assert ctx["run_id"] == "cli-2"
+        assert ctx["sync_run_id"] == "sync-2"
 
 
 class TestOnDegradedCliSeam:

--- a/tests/unit/test_cli_build.py
+++ b/tests/unit/test_cli_build.py
@@ -126,6 +126,19 @@ def test_build_runs_syncs_and_their_tests(project: Path, patched_runtime: dict[s
     assert payload["succeeded"] == 2
 
 
+def test_build_json_entries_share_a_real_invocation_run_id(
+    project: Path, patched_runtime: dict[str, Any]
+) -> None:
+    import uuid
+
+    result = runner.invoke(app, ["build", "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    run_ids = {entry["run_id"] for entry in json.loads(result.output)["syncs"]}
+    assert len(run_ids) == 1
+    uuid.UUID(run_ids.pop())
+
+
 def test_build_failing_test_marks_sync_failed(
     project: Path, patched_runtime: dict[str, Any]
 ) -> None:

--- a/tests/unit/test_cli_build.py
+++ b/tests/unit/test_cli_build.py
@@ -65,6 +65,8 @@ class _FakeResult:
         self.limit_applied: int | None = None
         self.duration_seconds = 0.01
         self.interrupted = False
+        self.run_id: str | None = None
+        self.sync_run_id: str | None = "fake-sync-run-id"
 
 
 @pytest.fixture

--- a/tests/unit/test_cli_diff.py
+++ b/tests/unit/test_cli_diff.py
@@ -75,6 +75,8 @@ def test_diff_with_dry_run_runs(
         limit_applied: int | None = None
         duration_seconds = 0.01
         interrupted = False
+        run_id: str | None = None
+        sync_run_id: str | None = "fake-sync-run-id"
         diff: Any = diff_mod.DiffResult(
             sample=[{"id": 1, "name": "Alice"}],
             total_source_rows=1,
@@ -135,6 +137,8 @@ def test_diff_json_mode_embeds_diff(
         limit_applied: int | None = None
         duration_seconds = 0.01
         interrupted = False
+        run_id: str | None = None
+        sync_run_id: str | None = "fake-sync-run-id"
         diff: Any = sample_diff
 
     def fake_run_sync(*_args: Any, **_kwargs: Any) -> _FakeResult:

--- a/tests/unit/test_cli_graceful_shutdown.py
+++ b/tests/unit/test_cli_graceful_shutdown.py
@@ -64,6 +64,8 @@ class _FakeResult:
     limit_applied: int | None = None
     duration_seconds: float | None = 0.01
     interrupted = False
+    run_id: str | None = None
+    sync_run_id: str | None = "fake-sync-run-id"
 
 
 def _patch_runtime(monkeypatch: pytest.MonkeyPatch, fake_run_sync: Any) -> None:

--- a/tests/unit/test_cli_run_parallel.py
+++ b/tests/unit/test_cli_run_parallel.py
@@ -109,6 +109,8 @@ class _FakeResult:
         self.cursor_value_used: str | None = None
         self.watermark_lag: str | None = None
         self.limit_applied: int | None = None
+        self.run_id: str | None = None
+        self.sync_run_id: str | None = "fake-sync-run-id"
 
 
 @pytest.fixture
@@ -393,6 +395,23 @@ def test_without_fail_fast_all_syncs_still_run(
     assert set(patched_engine["calls"]) == {"sync_a", "sync_b", "sync_c"}
     payload = json.loads(result.output)
     assert payload["skipped"] == 0
+
+
+def test_output_json_envelope_carries_an_invocation_run_id(
+    project: Path, patched_engine: dict[str, Any]
+) -> None:
+    """#762: run() generates one run_id per process (unmocked here — only
+    run_sync and destination/source resolution are patched) and every sync's
+    entry in the envelope echoes the same value back."""
+    import uuid
+
+    result = runner.invoke(app, ["run", "--output", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    run_id = payload["run_id"]
+    uuid.UUID(run_id)  # a real UUID, not a placeholder
+    assert {e["run_id"] for e in payload["syncs"]} == {run_id}
 
 
 def test_fail_fast_with_threads_accounts_for_every_sync(

--- a/tests/unit/test_cli_run_telemetry.py
+++ b/tests/unit/test_cli_run_telemetry.py
@@ -50,7 +50,7 @@ def _fake_profile() -> Any:
     return profile
 
 
-def _fake_ctx(*, dry_run: bool = False) -> _RunContext:
+def _fake_ctx(*, dry_run: bool = False, run_id: str = "") -> _RunContext:
     return _RunContext(
         source=MagicMock(),
         state_mgr=MagicMock(),
@@ -62,6 +62,7 @@ def _fake_ctx(*, dry_run: bool = False) -> _RunContext:
         quiet=True,
         log_json=False,
         cursor_value=None,
+        run_id=run_id,
     )
 
 
@@ -241,6 +242,56 @@ def test_run_one_entry_includes_watermark_metadata(
     _name, entry, _err = _run_one(_fake_sync(), _ctx(), _fake_profile())
     assert entry["watermark_source"] == "default_value"
     assert entry["cursor_value_used"] == "2026-01-01"
+
+
+def test_run_one_entry_includes_correlation_ids_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+    captured_calls: list[dict[str, Any]],
+) -> None:
+    """#762: ctx.run_id (invocation-level) and result.sync_run_id (per-sync)
+    both surface in the entry dict --output json reads."""
+    _wire_run_sync(
+        monkeypatch,
+        lambda *_a, **_k: SyncResult(
+            rows_extracted=1, success=1, failed=0, sync_run_id="sync-abc"
+        ),
+    )
+    _name, entry, _err = _run_one(_fake_sync(), _ctx(run_id="cli-xyz"), _fake_profile())
+    assert entry["run_id"] == "cli-xyz"
+    assert entry["sync_run_id"] == "sync-abc"
+
+
+def test_run_one_passes_ctx_run_id_into_run_sync(
+    monkeypatch: pytest.MonkeyPatch,
+    captured_calls: list[dict[str, Any]],
+) -> None:
+    """The invocation id has to actually reach run_sync, not just the entry dict."""
+    received: dict[str, Any] = {}
+
+    def fake_run_sync(*_a: Any, **kwargs: Any) -> SyncResult:
+        received["run_id"] = kwargs.get("run_id")
+        return SyncResult(rows_extracted=1, success=1, failed=0)
+
+    _wire_run_sync(monkeypatch, fake_run_sync)
+    _run_one(_fake_sync(), _ctx(run_id="cli-xyz"), _fake_profile())
+    assert received["run_id"] == "cli-xyz"
+
+
+def test_run_one_entry_includes_run_id_on_error(
+    monkeypatch: pytest.MonkeyPatch,
+    captured_calls: list[dict[str, Any]],
+) -> None:
+    """The error path has no SyncResult to read sync_run_id from — run_id is
+    still known at the CLI regardless, so it's still in the entry dict."""
+
+    def boom(*_a: Any, **_k: Any) -> SyncResult:
+        raise RuntimeError("kaboom")
+
+    _wire_run_sync(monkeypatch, boom)
+    _name, entry, err = _run_one(_fake_sync(), _ctx(run_id="cli-xyz"), _fake_profile())
+    assert err is True
+    assert entry["run_id"] == "cli-xyz"
+    assert "sync_run_id" not in entry
 
 
 def test_run_one_rich_output_success(

--- a/tests/unit/test_dlq_store.py
+++ b/tests/unit/test_dlq_store.py
@@ -138,3 +138,44 @@ def test_dlq_backend_protocol_covers_local_public_api() -> None:
     from drt.state.dlq import LocalDlqStore
 
     assert public_methods(LocalDlqStore) == _DLQ_BACKEND_METHODS
+
+
+# --- Correlation ID (#762) ----------------------------------------------------
+
+
+def test_sync_run_id_defaults_to_none() -> None:
+    assert _dl(1).sync_run_id is None
+
+
+def test_sync_run_id_round_trips_through_append_and_read(tmp_path: Path) -> None:
+    store = DlqStore(tmp_path)
+    entry = DeadLetter(
+        record={"id": 1}, error_message="boom", http_status=500, sync_run_id="sync-1"
+    )
+    store.append("s", [entry])
+
+    [loaded] = store.read("s")
+    assert loaded.sync_run_id == "sync-1"
+
+
+def test_a_pre_762_jsonl_line_still_loads(tmp_path: Path) -> None:
+    """`read()` unpacks each line via DeadLetter(**data); a line written
+    before this field existed has no sync_run_id key at all, and must still
+    load — via the dataclass default, not a migration."""
+    import json
+
+    store = DlqStore(tmp_path)
+    path = tmp_path / ".drt" / "dlq" / "s.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    old_format = {
+        "record": {"id": 1},
+        "error_message": "boom",
+        "http_status": 500,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "attempts": 1,
+        # no sync_run_id key at all
+    }
+    path.write_text(json.dumps(old_format) + "\n")
+
+    [loaded] = store.read("s")
+    assert loaded.sync_run_id is None

--- a/tests/unit/test_dry_run_summary.py
+++ b/tests/unit/test_dry_run_summary.py
@@ -62,6 +62,8 @@ def test_run_dry_run_summary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
             self.cursor_value_used = None
             self.watermark_lag = None
             self.limit_applied = None
+            self.run_id = None
+            self.sync_run_id = "fake-sync-run-id"
 
     def mock_run_sync(*args, **kwargs):
         return FakeResult()

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -1393,3 +1394,157 @@ def test_extract_limit_never_advances_watermark(tmp_path: Path) -> None:
     assert state is not None
     # The sampled run must not eat the skipped rows' cursor progress.
     assert state.last_cursor_value is None
+
+
+# ---------------------------------------------------------------------------
+# run_id / sync_run_id correlation (#762)
+# ---------------------------------------------------------------------------
+
+
+class TestRunIdCorrelation:
+    """sync_run_id is always generated; run_id only when a caller supplies one.
+
+    Both ride on the single `total_result` object `_run_sync_body` mutates in
+    place (engine/sync.py's own docstring: "so the outer finally-block can
+    read partial results when an exception propagates") — stamped once, right
+    after construction, before anything that could observe or persist it.
+    """
+
+    def test_sync_run_id_is_always_generated(self, tmp_path: Path) -> None:
+        result = run_sync(
+            _make_sync(), FakeSource([{"id": 1}]), FakeDestination(), _make_profile(), tmp_path
+        )
+        assert result.sync_run_id
+        uuid.UUID(result.sync_run_id)  # a real UUID, not a placeholder string
+
+    def test_sync_run_id_is_fresh_per_call(self, tmp_path: Path) -> None:
+        sync, source, dest, profile = (
+            _make_sync(),
+            FakeSource([{"id": 1}]),
+            FakeDestination(),
+            _make_profile(),
+        )
+        first = run_sync(sync, source, dest, profile, tmp_path)
+        second = run_sync(sync, FakeSource([{"id": 1}]), FakeDestination(), profile, tmp_path)
+        assert first.sync_run_id != second.sync_run_id
+
+    def test_run_id_defaults_to_none_and_passes_through_when_given(self, tmp_path: Path) -> None:
+        no_id = run_sync(
+            _make_sync(), FakeSource([{"id": 1}]), FakeDestination(), _make_profile(), tmp_path
+        )
+        assert no_id.run_id is None
+
+        with_id = run_sync(
+            _make_sync(),
+            FakeSource([{"id": 1}]),
+            FakeDestination(),
+            _make_profile(),
+            tmp_path,
+            run_id="cli-invocation-42",
+        )
+        assert with_id.run_id == "cli-invocation-42"
+
+    def test_history_entry_carries_both_ids(self, tmp_path: Path) -> None:
+        from drt.state.history import HistoryManager
+
+        history_mgr = HistoryManager(tmp_path)
+        result = run_sync(
+            _make_sync(),
+            FakeSource([{"id": 1}]),
+            FakeDestination(),
+            _make_profile(),
+            tmp_path,
+            history_manager=history_mgr,
+            run_id="cli-invocation-1",
+        )
+
+        entries = history_mgr.read(sync_name="test_sync")
+        assert len(entries) == 1
+        assert entries[0].run_id == "cli-invocation-1"
+        assert entries[0].sync_run_id == result.sync_run_id
+
+    def test_history_entry_carries_ids_even_on_a_raised_exception(self, tmp_path: Path) -> None:
+        """The history write happens in the finally-block, before re-raise."""
+        from drt.state.history import HistoryManager
+
+        history_mgr = HistoryManager(tmp_path)
+        dest = _AlertingDestination(raise_exc=RuntimeError("boom"))
+        sync = _make_sync_with_alerts()
+
+        with pytest.raises(RuntimeError):
+            run_sync(
+                sync,
+                FakeSource([{"id": 1}]),
+                dest,
+                _make_profile(),
+                tmp_path,
+                history_manager=history_mgr,
+                run_id="cli-invocation-2",
+            )
+
+        entries = history_mgr.read(sync_name=sync.name)
+        assert len(entries) == 1
+        assert entries[0].run_id == "cli-invocation-2"
+        assert entries[0].sync_run_id  # generated even though the sync failed
+
+    def test_dead_letter_carries_sync_run_id(self, tmp_path: Path) -> None:
+        from drt.destinations.row_errors import RowError
+        from drt.engine.observer import DlqObserver
+        from drt.state.dlq import DlqStore
+
+        class _RowErrorDestination:
+            """Fails one row with a pinpointed RowError — FakeDestination
+            only ever populates `failed`/`errors`, never `row_errors`, so the
+            DLQ's dead-letter path (which reads `row_errors`) never fires
+            against it."""
+
+            def load(
+                self, records: list[dict], config: DestinationConfig, sync_options: SyncOptions
+            ) -> SyncResult:
+                result = SyncResult()
+                result.success = len(records) - 1
+                result.failed = 1
+                result.row_errors = [
+                    RowError(
+                        batch_index=0,
+                        record_preview="{}",
+                        http_status=None,
+                        error_message="boom",
+                    )
+                ]
+                return result
+
+        dlq_store = DlqStore(tmp_path)
+        observer = DlqObserver(dlq_store, max_records=100)
+        sync = _make_sync(batch_size=10, on_error="skip")
+
+        result = run_sync(
+            sync,
+            FakeSource([{"id": 1}]),
+            _RowErrorDestination(),
+            _make_profile(),
+            tmp_path,
+            observer=observer,
+        )
+
+        dead_letters = dlq_store.read(sync.name)
+        assert len(dead_letters) == 1
+        assert dead_letters[0].sync_run_id == result.sync_run_id
+
+    @patch("drt.alerts.dispatch_alerts")
+    def test_failure_alert_context_carries_both_ids(
+        self, mock_dispatch: MagicMock, tmp_path: Path
+    ) -> None:
+        result = SyncResult()
+        result.success = 1
+        result.failed = 2
+        result.errors = ["downstream 500"]
+        dest = _AlertingDestination(result=result)
+        sync = _make_sync_with_alerts()
+
+        run_sync(sync, FakeSource([{"id": 1}]), dest, _make_profile(), tmp_path, run_id="cli-77")
+
+        args, kwargs = mock_dispatch.call_args
+        context = args[2] if len(args) > 2 else kwargs.get("context")
+        assert context["run_id"] == "cli-77"
+        assert context["sync_run_id"]  # generated, and not the placeholder ""

--- a/tests/unit/test_engine_tracing.py
+++ b/tests/unit/test_engine_tracing.py
@@ -144,7 +144,11 @@ def test_run_span_attributes_and_ok_status(rec_tracer: _RecTracer, tmp_path: Pat
     )
 
     run = rec_tracer.one("drt.sync.run")
-    assert run.attributes == {
+    # sync.run_id (#762) is a fresh UUID per call — asserted separately below,
+    # in test_run_span_carries_correlation_ids.
+    attrs = dict(run.attributes)
+    attrs.pop("sync.run_id")
+    assert attrs == {
         "sync.name": "test_sync",
         "source.type": "bigquery",
         "destination.type": "rest_api",
@@ -154,6 +158,44 @@ def test_run_span_attributes_and_ok_status(rec_tracer: _RecTracer, tmp_path: Pat
     assert run.status == "OK"
     assert run.exceptions == []
     assert run.ended is True
+
+
+def test_run_span_carries_correlation_ids(rec_tracer: _RecTracer, tmp_path: Path) -> None:
+    """#762: sync.run_id is always set; run.id only when a caller supplies one."""
+    result = run_sync(
+        _make_sync(batch_size=10),
+        FakeSource([{"id": 1}]),
+        FakeDestination(),
+        _make_profile(),
+        tmp_path,
+        observer=None,
+        run_id="invocation-abc",
+    )
+
+    run = rec_tracer.one("drt.sync.run")
+    assert run.attributes["sync.run_id"] == result.sync_run_id
+    assert result.sync_run_id  # non-empty — every execution gets one
+    assert run.attributes["run.id"] == "invocation-abc"
+    assert result.run_id == "invocation-abc"
+
+
+def test_run_span_omits_run_id_attribute_when_none(
+    rec_tracer: _RecTracer, tmp_path: Path
+) -> None:
+    """No invocation run_id was supplied — the span carries no run.id attribute
+    at all (not a null/empty one), so a backend query for `run.id EXISTS`
+    cleanly separates CLI-driven runs from library calls that never set one."""
+    run_sync(
+        _make_sync(batch_size=10),
+        FakeSource([{"id": 1}]),
+        FakeDestination(),
+        _make_profile(),
+        tmp_path,
+        observer=None,
+    )
+
+    run = rec_tracer.one("drt.sync.run")
+    assert "run.id" not in run.attributes
 
 
 def test_extract_span_records_rows_extracted(rec_tracer: _RecTracer, tmp_path: Path) -> None:

--- a/tests/unit/test_history.py
+++ b/tests/unit/test_history.py
@@ -312,3 +312,58 @@ def test_history_store_protocol_covers_local_public_api() -> None:
     from drt.state.history import LocalHistoryManager
 
     assert public_methods(LocalHistoryManager) == _HISTORY_STORE_METHODS
+
+
+# --- Correlation IDs (#762) ---------------------------------------------------
+
+
+class TestHistoryEntryCorrelationIds:
+    def test_default_to_none(self) -> None:
+        entry = _entry()
+        assert entry.run_id is None
+        assert entry.sync_run_id is None
+
+    def test_round_trip_through_append_and_read(self, tmp_path: Path) -> None:
+        mgr = HistoryManager(tmp_path)
+        entry = HistoryEntry(
+            sync_name="s",
+            started_at="2026-05-01T00:00:00+00:00",
+            completed_at="2026-05-01T00:00:01+00:00",
+            duration_seconds=1.0,
+            status="success",
+            records_synced=1,
+            records_failed=0,
+            run_id="cli-1",
+            sync_run_id="sync-1",
+        )
+        mgr.append(entry)
+
+        [loaded] = mgr.read(sync_name="s")
+        assert loaded.run_id == "cli-1"
+        assert loaded.sync_run_id == "sync-1"
+
+    def test_a_pre_762_jsonl_line_still_loads(self, tmp_path: Path) -> None:
+        """The reader unpacks each line via HistoryEntry(**data); a line
+        written before these fields existed has neither key at all, and must
+        still load — via the dataclass defaults, not a migration."""
+        mgr = HistoryManager(tmp_path)
+        path = tmp_path / ".drt" / "history" / "s.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        old_format = {
+            "sync_name": "s",
+            "started_at": "2026-01-01T00:00:00+00:00",
+            "completed_at": "2026-01-01T00:00:01+00:00",
+            "duration_seconds": 1.0,
+            "status": "success",
+            "records_synced": 1,
+            "records_failed": 0,
+            "errors": [],
+            "cursor_value_used": None,
+            "dry_run": False,
+            # no run_id / sync_run_id key at all
+        }
+        path.write_text(json.dumps(old_format) + "\n")
+
+        [loaded] = mgr.read(sync_name="s")
+        assert loaded.run_id is None
+        assert loaded.sync_run_id is None

--- a/tests/unit/test_identifiers.py
+++ b/tests/unit/test_identifiers.py
@@ -1,0 +1,18 @@
+"""Unit tests for the run-id generator (#762)."""
+
+from __future__ import annotations
+
+import uuid
+
+from drt._identifiers import new_run_id
+
+
+def test_returns_a_valid_uuid4_string() -> None:
+    value = new_run_id()
+    parsed = uuid.UUID(value)
+    assert parsed.version == 4
+    assert str(parsed) == value
+
+
+def test_successive_calls_are_unique() -> None:
+    assert len({new_run_id() for _ in range(100)}) == 100


### PR DESCRIPTION
Part 1 of #762's two-part proposal — **"run_id plumbing" only**. Part 2 (opt-in `metadata_columns` written into destination rows) is explicitly out of scope: the issue's own "Milestone fit" note defers it to ride with the managed-tables work (#760), and pulling it in now would touch every SQL destination file — all four of which currently have open, unmerged PRs (#904–#907, the #890 stack). This PR touches none of them, on purpose.

## What ships

Two identifiers, both from a new `drt._identifiers.new_run_id()`:

| id | scope | generated where |
|---|---|---|
| `run_id` | one per `drt run` process | `run()`, once — threaded through every sync it executes |
| `sync_run_id` | one per *sync execution* | inside `run_sync()` itself, so every caller gets one — including library callers that never pass `run_id` at all |

Threaded through the six surfaces the issue names: `SyncResult`, `HistoryEntry`, `DeadLetter`, `--output json`, OTel span attributes, and failure/degraded alert context.

## The design choice that kept this small: no `SyncObserver` Protocol change

`_run_sync_body` mutates one `total_result: SyncResult` object in place — its own docstring says why: *"so the outer finally-block can read partial results when an exception propagates."* I stamp both ids onto that object immediately after construction, before anything can observe it. Since `on_sync_completed(sync_name, result, ...)` already hands every observer that same object, and `build_context(result=..., ...)` already receives it too, **every downstream consumer picks the ids up for free** — no Protocol signature change, no touching `NullObserver`/`LoggingObserver`/`StatePersistingObserver`/`CompositeObserver`/`DlqObserver`, no hunting down third-party observer implementations.

## Two decisions I made rather than deferred back to the issue

**Not reconciled with `query_tags.new_run_id()`** (#768's per-query cost-attribution id), even though both now run once per `run_sync()` call. That one is lowercase hex, 12 chars — sized to fit SQL comments and BigQuery job labels without truncation math. Forcing a full UUID4 through the same path risks corrupting exactly the budget it exists to respect, across three warehouses I'd have had to re-verify (BigQuery label 63-char total, Snowflake `QUERY_TAG` length, Databricks `query_tags` kwarg). The existing docstring already flagged this reconciliation as deferred until #762 shipped — I'm recording that it was considered and declined, not missed.

**Plain `uuid.uuid4()`, not `uuid7`** as the issue proposes. Sortability isn't a real requirement for any of the six surfaces above — all six already key by `sync_name` + timestamp. `uuid.uuid7` isn't in the stdlib on any Python drt still supports (3.10–3.13); pulling in a dependency to sort ids nobody sorts is the "heavy dependency in core" CLAUDE.md rules out.

## One real gap, documented rather than solved

When `run_sync()` raises before ever returning a `SyncResult` (a hard crash), the CLI's `--output json` error-path entry has no object to read `sync_run_id` from — so that one entry carries `run_id` only. The history entry and failure alert written inside `run_sync()`'s own `finally` block *before* the re-raise still got the correct `sync_run_id` (verified by `test_history_entry_carries_ids_even_on_a_raised_exception`); only the CLI's own JSON surface misses it for that one failure mode. Smuggling the id out via the exception object felt like solving a corner case nobody asked for — flagging it here instead in case reviewers disagree.

## Verification

Full suite **2952 passed / 22 skipped**. New/touched modules at 96%+ coverage measured **per-module** (not `codecov/patch` — a new module's own test file inflates that denominator): `drt/_identifiers.py`, `destinations/base.py`, `state/dlq.py` at 100%; `engine/sync.py`, `alerts/dispatcher.py`, `state/history.py`, `cli/commands/run.py` at 93–98%, every miss cross-checked by line number against a pre-existing, unrelated branch. `ruff` + `mypy` clean. `scripts/check_drift.sh` reports no new drift (no new user-facing flag). Two backward-compatibility tests pin that a JSONL line written before these fields existed (`HistoryEntry`, `DeadLetter`) still loads via the dataclass default — both readers unpack via `Type(**json.loads(line))`.

Five hand-rolled `SyncResult`-shaped test doubles needed the two new attributes (`test_cli_build.py`, `test_cli_diff.py` ×2, `test_cli_graceful_shutdown.py`, `test_cli_run_parallel.py`, `test_dry_run_summary.py`) — following the codebase's own established convention rather than inventing one (`test_cli_run_parallel.py`'s `_FakeResult` docstring already says why: *"keeping the fake in lockstep with the real shape is cheaper than monkey-patching each attribute per test"*).

## Not in this PR

- `metadata_columns` (#762 part 2) — rides with #760.
- `target/run_results.json` (#778) — explicitly "cheap once run_id lands"; a natural next PR now that it has.
- Docs (`docs/llm/API_REFERENCE.md`, a guide) — following the pattern from #913/#914/#915, docs land as a focused follow-up once the surface is settled.
