### PR TITLE
feat(test): sync unit tests — fixture rows in, expected payload out (#780, part 1)

### DIFF
--- a/drt/config/models.py
+++ b/drt/config/models.py
@@ -97,6 +97,7 @@ from drt.config.sync_options import (
     SyncOptions,
     SyncTest,
     UniqueTest,
+    UnitTest,
     WatermarkConfig,
     WebhookAlertConfig,
 )
@@ -175,6 +176,7 @@ __all__ = [
     "TeamsDestinationConfig",
     "TwilioDestinationConfig",
     "UniqueTest",
+    "UnitTest",
     "WatermarkConfig",
     "WebhookAlertConfig",
     "ZendeskDestinationConfig",

--- a/drt/config/sync_options.py
+++ b/drt/config/sync_options.py
@@ -6,7 +6,7 @@ the three ``destinations_*`` modules and consumed by :class:`SyncConfig`.
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
@@ -374,6 +374,30 @@ class SyncTest(BaseModel):
         return self
 
 
+class UnitTest(BaseModel):
+    """Offline transform-pipeline test — fixture rows in, expected rows out (#780).
+
+    Unlike ``SyncTest`` (which queries the *destination* after a real sync),
+    a ``UnitTest`` never touches a destination or the network: ``given`` rows
+    are run through the same ``computed_fields`` -> ``field_mappings`` ->
+    ``mask`` chain ``run_sync()`` applies in production (via
+    ``drt.engine.unit_test_runner``), and the result is compared against
+    ``expect``. dbt unit-tests analog; Census/Hightouch mapper previews.
+    """
+
+    name: str
+    # At least one row — an empty `given` would make every unit test
+    # vacuously pass, silently, the moment a fixture typo drops its only row.
+    given: list[dict[str, Any]] = Field(min_length=1)
+    # Row count must match `given` exactly (a transform that's supposed to
+    # drop/split rows is exactly the kind of change a unit test exists to
+    # catch) — but each expected row is matched by the *keys it declares*,
+    # not the full record. A sync's source columns grow over time; requiring
+    # every unit test to enumerate every column it doesn't care about would
+    # make each one a maintenance burden against unrelated schema growth.
+    expect: list[dict[str, Any]] = Field(min_length=1)
+
+
 class SlackAlertConfig(BaseModel):
     type: Literal["slack"]
     webhook_url: str | None = None
@@ -546,6 +570,9 @@ class SyncConfig(BaseModel):
     destination: DestinationConfig
     sync: SyncOptions = Field(default_factory=SyncOptions)
     tests: list[SyncTest] = Field(default_factory=list)
+    # Offline transform-pipeline tests (#780) — distinct from `tests:`, which
+    # queries the real destination after a sync has run.
+    unit_tests: list[UnitTest] = Field(default_factory=list)
     alerts: AlertsConfig | None = None
 
     @model_validator(mode="after")

--- a/drt/engine/unit_test_runner.py
+++ b/drt/engine/unit_test_runner.py
@@ -1,0 +1,158 @@
+"""Offline transform-pipeline test runner (#780).
+
+Runs a sync's ``unit_tests:`` fixtures through the *real* engine pipeline —
+``computed_fields`` -> ``field_mappings`` -> ``mask`` (and anything else
+``run_sync()`` applies) — without a network call or a credential in sight.
+
+The trick is that it needs none: :func:`drt.engine.sync.run_sync` already
+accepts any ``Source``/``Destination`` Protocol implementation, and
+``FakeSource`` (#364) plus the ``CaptureDestination`` this module adds are
+exactly that. Every stateful side effect in ``run_sync()`` — state
+persistence, watermark storage, history, DLQ — is opt-in via a parameter
+that defaults to ``None``/off, so calling it with only a source and a
+destination is already side-effect-free. No engine change was needed to
+make this possible; this module is a *consumer* of the public API, not a
+modification of it.
+
+Two things a full sync can do that a unit test deliberately can't:
+
+* **``lookups``** resolve FK values by querying the real destination
+  (``build_lookup_map``) — there is no fake for that yet (tracked as v2 in
+  #780's own scope), so a sync with ``destination.lookups`` configured is
+  rejected outright rather than silently skipping the lookup step.
+* **``alerts``** fire real Slack/webhook HTTP calls from inside
+  ``run_sync()``'s own ``finally`` block whenever a run reports a failure —
+  not observer-mediated, so passing a real ``SyncConfig`` through as-is
+  risks firing them the moment a test deliberately exercises a failure
+  path. The sync is run with ``alerts`` stripped (a shallow
+  ``model_copy(update=...)``; the caller's own config object is untouched).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from drt.config.credentials import DuckDBProfile
+from drt.config.models import DestinationConfig, SyncConfig, SyncOptions, UnitTest
+from drt.destinations.base import SyncResult
+from drt.engine.sync import run_sync
+from drt.sources.fake import FakeSource
+
+
+class UnitTestLookupsUnsupportedError(ValueError):
+    """Raised when a unit-tested sync's destination has ``lookups:`` configured.
+
+    Lookups resolve against the real destination (``build_lookup_map``), which
+    a unit test has none of. Rejected rather than silently run without them,
+    since a passing test would then be asserting against output the real sync
+    never produces.
+    """
+
+
+@dataclass
+class CaptureDestination:
+    """``Destination`` stand-in that records what it would have sent.
+
+    Accumulates across every ``load()`` call — batching must never change
+    which rows a unit test compares against, only how many calls it takes to
+    deliver them.
+    """
+
+    records: list[dict[str, Any]] = field(default_factory=list)
+
+    def load(
+        self,
+        records: list[dict[str, Any]],
+        config: DestinationConfig,
+        sync_options: SyncOptions,
+    ) -> SyncResult:
+        self.records.extend(records)
+        return SyncResult(success=len(records))
+
+
+@dataclass
+class UnitTestResult:
+    """Outcome of one :class:`UnitTest`."""
+
+    name: str
+    passed: bool
+    actual: list[dict[str, Any]]
+    # Human-readable mismatch descriptions; empty when passed. A raised
+    # exception from run_sync() (a template error, an unsupported
+    # match_policy, ...) becomes a single-entry list rather than propagating —
+    # the point of a unit test is to report a broken config safely, not to
+    # crash the `drt test --unit` invocation on the first one.
+    mismatches: list[str] = field(default_factory=list)
+
+
+def _row_matches(expected: dict[str, Any], actual: dict[str, Any]) -> bool:
+    """``expected``'s keys must be present in ``actual`` with equal values.
+
+    Subset match, not exact-record match: a sync's source columns grow over
+    time, and requiring every unit test to enumerate every column it doesn't
+    care about would make each one a maintenance burden against unrelated
+    schema growth. Row *count* is still checked exactly by the caller — a
+    transform that drops or duplicates rows is exactly what a unit test
+    exists to catch.
+    """
+    return all(key in actual and actual[key] == value for key, value in expected.items())
+
+
+def run_unit_test(
+    sync: SyncConfig, test: UnitTest, project_dir: Path = Path(".")
+) -> UnitTestResult:
+    """Run one ``UnitTest`` fixture through ``sync``'s real transform pipeline.
+
+    Raises:
+        UnitTestLookupsUnsupportedError: ``sync.destination`` has
+            ``lookups:`` configured. Not a per-test result — this is a
+            config-shape problem the same for every fixture on this sync, so
+            the caller should surface it once rather than call this in a loop
+            and get the same rejection N times.
+    """
+    if getattr(sync.destination, "lookups", None):
+        raise UnitTestLookupsUnsupportedError(
+            f"sync '{sync.name}': unit_tests do not support destination.lookups yet "
+            "(no fake lookup table — see #780). Remove lookups to unit-test this "
+            "sync, or test the lookup-resolved fields via a real --dry-run instead."
+        )
+
+    # Alerts fire real HTTP from inside run_sync()'s own finally block on any
+    # reported failure — stripped so a fixture that deliberately exercises an
+    # on_error path can't page anyone. model_copy is a shallow copy; `sync`
+    # itself (the caller's object) is never mutated.
+    test_sync = sync.model_copy(update={"alerts": None})
+
+    capture = CaptureDestination()
+    try:
+        run_sync(
+            test_sync,
+            FakeSource(rows=test.given),
+            capture,
+            DuckDBProfile(type="duckdb"),
+            project_dir,
+        )
+    except Exception as exc:  # noqa: BLE001 — reported as a failed test, not a crash
+        return UnitTestResult(
+            name=test.name,
+            passed=False,
+            actual=capture.records,
+            mismatches=[f"{type(exc).__name__}: {exc}"],
+        )
+
+    mismatches: list[str] = []
+    if len(capture.records) != len(test.expect):
+        mismatches.append(
+            f"expected {len(test.expect)} row(s), got {len(capture.records)} "
+            f"— given {len(test.given)}"
+        )
+    else:
+        for i, (expected, actual) in enumerate(zip(test.expect, capture.records)):
+            if not _row_matches(expected, actual):
+                mismatches.append(f"row {i}: expected {expected!r} to be a subset of {actual!r}")
+
+    return UnitTestResult(
+        name=test.name, passed=not mismatches, actual=capture.records, mismatches=mismatches
+    )

--- a/integrations/vscode-drt/CHANGELOG.md
+++ b/integrations/vscode-drt/CHANGELOG.md
@@ -9,6 +9,9 @@ drt-core version its bundled schemas were generated from.
 - Bundled JSON Schemas regenerated from drt-core: `syncs/*.yml` now validates a
   `sync.computed_fields` block (`{field_name: jinja_template}`) for declarative
   derived columns (drt-hub/drt#763).
+- Bundled JSON Schemas regenerated from drt-core: `syncs/*.yml` now validates a
+  `sync.unit_tests` block (`{name, given, expect}`) for offline transform-pipeline
+  tests (drt-hub/drt#780).
 
 ## [0.1.11] - Unreleased
 

--- a/integrations/vscode-drt/schemas/sync.schema.json
+++ b/integrations/vscode-drt/schemas/sync.schema.json
@@ -4547,6 +4547,40 @@
       "title": "UniqueTest",
       "type": "object"
     },
+    "UnitTest": {
+      "description": "Offline transform-pipeline test \u2014 fixture rows in, expected rows out (#780).\n\nUnlike ``SyncTest`` (which queries the *destination* after a real sync),\na ``UnitTest`` never touches a destination or the network: ``given`` rows\nare run through the same ``computed_fields`` -> ``field_mappings`` ->\n``mask`` chain ``run_sync()`` applies in production (via\n``drt.engine.unit_test_runner``), and the result is compared against\n``expect``. dbt unit-tests analog; Census/Hightouch mapper previews.",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "given": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "minItems": 1,
+          "title": "Given",
+          "type": "array"
+        },
+        "expect": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "minItems": 1,
+          "title": "Expect",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "given",
+        "expect"
+      ],
+      "title": "UnitTest",
+      "type": "object"
+    },
     "WatermarkConfig": {
       "description": "Configuration for remote watermark storage.",
       "properties": {
@@ -5022,6 +5056,13 @@
         "$ref": "#/$defs/SyncTest"
       },
       "title": "Tests",
+      "type": "array"
+    },
+    "unit_tests": {
+      "items": {
+        "$ref": "#/$defs/UnitTest"
+      },
+      "title": "Unit Tests",
       "type": "array"
     },
     "alerts": {

--- a/tests/unit/test_unit_test_runner.py
+++ b/tests/unit/test_unit_test_runner.py
@@ -1,0 +1,238 @@
+"""Unit tests for the offline transform-pipeline test runner (#780)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from drt.config.models import SyncConfig, UnitTest
+from drt.engine.unit_test_runner import (
+    CaptureDestination,
+    UnitTestLookupsUnsupportedError,
+    run_unit_test,
+)
+
+
+def _sync(**sync_overrides: Any) -> SyncConfig:
+    return SyncConfig.model_validate(
+        {
+            "name": "users_to_hubspot",
+            "model": "ref('users')",
+            "destination": {"type": "rest_api", "url": "https://example.com"},
+            "sync": {"mode": "full", **sync_overrides},
+        }
+    )
+
+
+def _postgres_sync(**destination_overrides: Any) -> SyncConfig:
+    return SyncConfig.model_validate(
+        {
+            "name": "postgres_sync",
+            "model": "ref('t')",
+            "destination": {
+                "type": "postgres",
+                "host_env": "H",
+                "dbname_env": "D",
+                "user_env": "U",
+                "password_env": "P",
+                "table": "t",
+                "upsert_key": ["id"],
+                **destination_overrides,
+            },
+        }
+    )
+
+
+class TestUnitTestConfig:
+    def test_rejects_empty_given(self) -> None:
+        """An empty `given` would make the test vacuously pass forever —
+        catch it at config load, not by writing a fixture no one reviews."""
+        with pytest.raises(ValidationError, match="given"):
+            UnitTest(name="x", given=[], expect=[{"id": 1}])
+
+    def test_rejects_empty_expect(self) -> None:
+        with pytest.raises(ValidationError, match="expect"):
+            UnitTest(name="x", given=[{"id": 1}], expect=[])
+
+    def test_unit_tests_default_to_empty_on_sync_config(self) -> None:
+        sync = _sync()
+        assert sync.unit_tests == []
+
+    def test_sync_config_accepts_a_unit_tests_block(self) -> None:
+        sync = SyncConfig.model_validate(
+            {
+                "name": "s",
+                "model": "ref('t')",
+                "destination": {"type": "rest_api", "url": "https://example.com"},
+                "unit_tests": [
+                    {"name": "t1", "given": [{"id": 1}], "expect": [{"id": 1}]},
+                ],
+            }
+        )
+        assert len(sync.unit_tests) == 1
+        assert sync.unit_tests[0].name == "t1"
+
+
+class TestGivenExpect:
+    def test_a_passing_row_through_the_real_pipeline(self) -> None:
+        """field_mappings + mask both run — this is the real production
+        pipeline, not a reimplementation of it."""
+        sync = _sync(field_mappings={"first": "given_name"}, mask={"email": "hash"})
+        test = UnitTest(
+            name="masks_and_renames",
+            given=[{"id": 1, "email": "alice@example.com", "first": "Alice", "last": "Doe"}],
+            expect=[{"id": 1, "given_name": "Alice", "last": "Doe"}],
+        )
+
+        result = run_unit_test(sync, test)
+
+        assert result.passed
+        assert result.mismatches == []
+        assert result.actual[0]["given_name"] == "Alice"
+        assert result.actual[0]["email"] != "alice@example.com"  # masked, not the raw value
+
+    def test_expect_is_a_subset_match_not_exact(self) -> None:
+        """An unrelated source column growing later must not break existing
+        unit tests — only the keys `expect` declares are checked."""
+        sync = _sync()
+        test = UnitTest(
+            name="only_checks_id",
+            given=[{"id": 1, "unrelated_new_column": "whatever"}],
+            expect=[{"id": 1}],
+        )
+
+        assert run_unit_test(sync, test).passed
+
+    def test_wrong_value_is_a_mismatch(self) -> None:
+        sync = _sync()
+        test = UnitTest(name="wrong", given=[{"id": 1}], expect=[{"id": 2}])
+
+        result = run_unit_test(sync, test)
+
+        assert not result.passed
+        assert len(result.mismatches) == 1
+        assert "row 0" in result.mismatches[0]
+
+    def test_row_count_mismatch_is_reported_not_silently_zipped(self) -> None:
+        """zip() would silently truncate to the shorter list — a dropped row
+        must surface as a failure, not vanish from the comparison."""
+        sync = _sync(on_error="skip")
+        test = UnitTest(
+            name="drops_a_row",
+            given=[{"id": 1}, {"id": 2}],
+            expect=[{"id": 1}, {"id": 2}, {"id": 3}],
+        )
+
+        result = run_unit_test(sync, test)
+
+        assert not result.passed
+        assert "expected 3 row(s), got 2" in result.mismatches[0]
+
+    def test_row_order_is_preserved_across_batches(self) -> None:
+        """batch_size=1 forces three separate load() calls — CaptureDestination
+        must still hand back rows in the order they were given."""
+        sync = _sync(batch_size=1)
+        test = UnitTest(
+            name="order",
+            given=[{"id": 1}, {"id": 2}, {"id": 3}],
+            expect=[{"id": 1}, {"id": 2}, {"id": 3}],
+        )
+
+        result = run_unit_test(sync, test)
+
+        assert result.passed
+        assert [r["id"] for r in result.actual] == [1, 2, 3]
+
+
+class TestLookupsRejected:
+    def test_a_sync_with_lookups_is_rejected(self) -> None:
+        sync = _postgres_sync(
+            lookups={
+                "account_id": {
+                    "table": "accounts",
+                    "match": {"email": "email"},
+                    "select": "id",
+                }
+            }
+        )
+        test = UnitTest(name="x", given=[{"id": 1}], expect=[{"id": 1}])
+
+        with pytest.raises(UnitTestLookupsUnsupportedError, match="lookups"):
+            run_unit_test(sync, test)
+
+    def test_a_sync_without_lookups_is_unaffected(self) -> None:
+        sync = _postgres_sync()  # no lookups key at all
+        test = UnitTest(name="x", given=[{"id": 1}], expect=[{"id": 1}])
+
+        assert run_unit_test(sync, test).passed
+
+
+class TestAlertsStripped:
+    """run_sync() fires real HTTP alerts from its own finally block on any
+    reported failure — not observer-mediated, so this can't rely on
+    dry_run or a passed-in observer to suppress it."""
+
+    def _sync_with_alerts(self) -> SyncConfig:
+        return SyncConfig.model_validate(
+            {
+                "name": "z",
+                "model": "ref('t')",
+                "destination": {"type": "rest_api", "url": "https://example.com"},
+                "sync": {"on_error": "skip"},
+                "alerts": {
+                    "on_failure": [{"type": "webhook", "url": "https://hooks.example/x"}]
+                },
+            }
+        )
+
+    def test_dispatch_alerts_is_never_called(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_dispatch = MagicMock()
+        monkeypatch.setattr("drt.alerts.dispatch_alerts", mock_dispatch)
+        sync = self._sync_with_alerts()
+
+        run_unit_test(sync, UnitTest(name="ok", given=[{"id": 1}], expect=[{"id": 1}]))
+
+        mock_dispatch.assert_not_called()
+
+    def test_the_callers_sync_config_is_not_mutated(self) -> None:
+        """model_copy(update=...) must not touch the caller's own object —
+        a shared SyncConfig loaded once for `drt test --unit` still needs
+        its real alerts config for whatever else uses it."""
+        sync = self._sync_with_alerts()
+
+        run_unit_test(sync, UnitTest(name="ok", given=[{"id": 1}], expect=[{"id": 1}]))
+
+        assert sync.alerts is not None
+        assert sync.alerts.on_failure[0].url == "https://hooks.example/x"
+
+
+class TestExceptionsBecomeFailures:
+    """The point of a unit test is to report a broken config safely — one
+    bad fixture must not crash `drt test --unit` before later tests run."""
+
+    def test_an_unsupported_match_policy_is_reported_not_raised(self) -> None:
+        """CaptureDestination doesn't implement MatchPolicyCapable, so
+        `match_policy: update_only` fails run_sync()'s fail-fast guard —
+        exactly the kind of config error a unit test should catch safely."""
+        sync = _sync(match_policy="update_only")
+        test = UnitTest(name="unsupported_match_policy", given=[{"id": 1}], expect=[{"id": 1}])
+
+        result = run_unit_test(sync, test)
+
+        assert not result.passed
+        assert len(result.mismatches) == 1
+        assert "match_policy" in result.mismatches[0]
+
+
+class TestCaptureDestination:
+    def test_accumulates_across_multiple_load_calls(self) -> None:
+        capture = CaptureDestination()
+        result1 = capture.load([{"id": 1}], MagicMock(), MagicMock())
+        result2 = capture.load([{"id": 2}, {"id": 3}], MagicMock(), MagicMock())
+
+        assert capture.records == [{"id": 1}, {"id": 2}, {"id": 3}]
+        assert result1.success == 1
+        assert result2.success == 2


### PR DESCRIPTION
Part 1 of #780 — the `unit_tests:` config shape + offline runner. CLI wiring (`drt test --unit`), MCP parity, and docs are follow-ups, same split that worked for #763/#762. This piece is independently useful (library callers, and the eventual CLI command is a thin wrapper over it).

```yaml
sync:
  unit_tests:
    - name: masks_email_and_renames
      given:
        - { id: 1, email: "alice@example.com", first: "Alice", last: "Doe" }
      expect:
        - { id: 1, given_name: "Alice" }
```

## No engine change needed

`run_sync()` already accepts any Source/Destination Protocol implementation, and every stateful side effect inside it (state persistence, watermark storage, history, DLQ) is opt-in via a parameter that defaults to `None`/off. `FakeSource` (#364, already shipped) plus the new `CaptureDestination` this PR adds are exactly a Source/Destination pair with nothing to opt into — so `run_sync(sync, FakeSource(rows=given), CaptureDestination(), ...)` runs the *real* `computed_fields → field_mappings → mask` chain with zero network calls and zero disk writes, using the public API exactly as it exists today.

This is also why this PR touches **none** of the `engine/sync.py` regions currently under an unmerged diff (#917's outer `run_sync` setup, #914's per-batch transform chain) — it's a new file that *calls* `run_sync()`, not an edit to it. That was the deciding factor over doing #762 part 2 (`metadata_columns`) next, which needs to insert into the exact region #914 already has an open diff in.

## Two side effects I found by reading `run_sync()`, not by hitting them in CI

**Lookups** resolve FK values by querying the real destination (`build_lookup_map`) — no fake exists for that yet, which #780's own scope section already calls out ("lookup mocking (v2)"). A sync with `destination.lookups` configured is rejected outright (`UnitTestLookupsUnsupportedError`) rather than silently running without the lookup step and asserting against output the real sync would never produce.

**Alerts** fire real Slack/webhook HTTP calls from inside `run_sync()`'s own `finally` block whenever a run reports a failure — a direct call, not observer-mediated (same as the history write beside it), so nothing about capturing the destination or omitting an observer stops it. A fixture that deliberately exercises `on_error: skip` to test a drop-a-row scenario would page whatever channel `alerts.on_failure` points at. Handled with `sync.model_copy(update={"alerts": None})` — a shallow copy, so the caller's own `SyncConfig` object is never mutated (pinned by a test).

## Design choices worth a second look

- **`expect` is a subset match per row, not exact-record equality.** Only the keys a test declares are checked; extra keys the real pipeline produces are ignored. A sync's source columns grow over time, and requiring every unit test to enumerate every column it doesn't care about would turn each one into a maintenance burden against unrelated schema growth. Row **count** is still checked exactly, and *before* the per-row comparison rather than via `zip()` — which would silently truncate to the shorter list and hide a dropped row.
- **A raised exception becomes a failed test, not a crashed CLI.** An unsupported `match_policy`, a template error — anything `run_sync()` can raise — is caught and turned into a one-line mismatch. The point of a unit test is to report a broken config safely; one bad fixture must not stop `drt test --unit` before later tests get a chance to run.
- **`CaptureDestination` accumulates across every `load()` call.** Batching is an implementation detail of `sync.batch_size` — it must never change which rows a test compares against, only how many calls it takes to deliver them. Pinned with a `batch_size=1` / 3-row fixture test.

## Verification

Full suite **2943 passed / 22 skipped** (this branch is `main` + this PR only — independent of #762/#763, not stacked on either). `drt/engine/unit_test_runner.py` at **100%** line coverage; `drt/config/sync_options.py` at 97%, every miss a pre-existing unrelated branch (watermark backend validation, an assert labelled unreachable) verified by line number. `ruff`, `mypy`, `check_drift.sh` all clean — no new CLI/MCP drift, since `--unit` isn't wired up yet.

## Not in this PR

- `drt test --unit` CLI flag + `drt_run_test` MCP parity — natural next PR now this exists.
- `expect_body` (rendered-payload assertion for templated destinations, e.g. REST `body_template`) — needs the *real* destination class to render its body without sending, which likely means extending the existing `--dry-run --diff` machinery rather than `CaptureDestination`. Deserves its own investigation.
- Docs + `/drt-create-sync` skill update ("LLM writes the sync and its test in one shot").
