### PR TITLE
feat(test): wire sync unit tests into the CLI and MCP (#780, part 2)

### DIFF
--- a/drt/cli/commands/test.py
+++ b/drt/cli/commands/test.py
@@ -123,6 +123,95 @@ def _store_or_clear_failure_sample(
     return path, len(masked_rows)
 
 
+def execute_unit_tests_for_sync(
+    sync: SyncConfig, *, json_mode: bool, quiet: bool = False
+) -> tuple[_SyncTestResult, bool]:
+    """Run one sync's ``unit_tests:`` and return ``(result_dict, had_failures)``.
+
+    Deliberately separate from :func:`execute_tests_for_sync` rather than a
+    branch inside it: unit tests (#780) never touch a destination — no
+    connection, no ``dry_run`` distinction, no ``severity: warn`` tier, none
+    of the machinery that function exists for. Sharing a function would mean
+    threading a growing set of "well, not for unit tests" exceptions through
+    it instead of two functions that each do one thing.
+    """
+    from drt.engine.unit_test_runner import UnitTestLookupsUnsupportedError, run_unit_test
+
+    show = not json_mode and not quiet
+    if show:
+        print_test_header(sync.name)
+
+    sync_results: _SyncTestResult = {"sync": sync.name, "tests": []}
+    had_failures = False
+
+    try:
+        for test_def in sync.unit_tests:
+            result = run_unit_test(sync, test_def)
+            message = "ok" if result.passed else "; ".join(result.mismatches)
+            if show:
+                print_test_result(test_def.name, result.passed, message)
+            sync_results["tests"].append(
+                {
+                    "name": test_def.name,
+                    "passed": result.passed,
+                    "mismatches": result.mismatches,
+                }
+            )
+            if not result.passed:
+                had_failures = True
+    except UnitTestLookupsUnsupportedError as e:
+        # One config-shape problem, the same for every fixture on this sync —
+        # surfaced once rather than once per unit_tests entry.
+        if show:
+            print_test_result(sync.name, False, str(e))
+        sync_results["tests"].append({"name": sync.name, "passed": False, "error": str(e)})
+        had_failures = True
+
+    return sync_results, had_failures
+
+
+def _run_unit_tests(syncs: Sequence[SyncConfig], *, json_mode: bool, fail_fast: bool) -> None:
+    """``drt test --unit``'s body — separate from the main ``sync.tests:`` loop
+    in :func:`test_syncs` for the same reason :func:`execute_unit_tests_for_sync`
+    is separate from :func:`execute_tests_for_sync`: no destination, no
+    ``dry_run``, no ``severity`` tier, no ``--store-failures``.
+    """
+    syncs_with_unit_tests = [s for s in syncs if s.unit_tests]
+    if not syncs_with_unit_tests:
+        if not json_mode:
+            console.print("[dim]No unit_tests defined in any sync.[/dim]")
+        else:
+            print(json.dumps({"status": "no_tests", "results": []}))
+        return
+
+    results: list[_SyncTestResult] = []
+    had_failures = False
+
+    for i, sync in enumerate(syncs_with_unit_tests):
+        sync_results, sync_failed = execute_unit_tests_for_sync(sync, json_mode=json_mode)
+        results.append(sync_results)
+        if sync_failed:
+            had_failures = True
+
+        if fail_fast and had_failures:
+            remaining = syncs_with_unit_tests[i + 1 :]
+            for skipped_sync in remaining:
+                results.append(
+                    {"sync": skipped_sync.name, "tests": [], "skipped": True, "reason": "fail_fast"}
+                )
+            if remaining and not json_mode:
+                console.print(
+                    f"[yellow]--fail-fast: skipped {len(remaining)} sync(s) "
+                    "after the first failure.[/yellow]"
+                )
+            break
+
+    if json_mode:
+        print(json.dumps({"status": "failed" if had_failures else "passed", "results": results}))
+    if had_failures:
+        raise typer.Exit(1)
+
+
 def execute_tests_for_sync(
     sync: SyncConfig,
     *,
@@ -350,16 +439,31 @@ def test_syncs(
         min=1,
         help="Max rows written per failed test when --store-failures is set.",
     ),
+    unit: bool = typer.Option(
+        False,
+        "--unit",
+        help=(
+            "Run sync.unit_tests instead of sync.tests: fixture rows through "
+            "the transform pipeline, zero credentials, zero network. "
+            "Mutually exclusive with --dry-run and --store-failures, which "
+            "are destination-connected concepts unit tests don't have."
+        ),
+    ),
 ) -> None:
     """Run post-sync validation tests.
 
     With --dry-run, shows what tests would be executed without actually
-    connecting to the destination or running queries.
+    connecting to the destination or running queries. With --unit, runs
+    sync.unit_tests instead — see that flag's help.
     """
     from drt.config.parser import load_syncs
 
     json_mode = output == "json"
     results: list[_SyncTestResult] = []
+
+    if unit and (dry_run or store_failures):
+        print_error("--unit cannot be combined with --dry-run or --store-failures.")
+        raise typer.Exit(2)
 
     syncs = load_syncs(Path("."))
     if not syncs:
@@ -377,6 +481,10 @@ def test_syncs(
     if not syncs:
         print_error("Selection matched no syncs (after --exclude).")
         raise typer.Exit(1)
+
+    if unit:
+        _run_unit_tests(syncs, json_mode=json_mode, fail_fast=fail_fast)
+        return
 
     syncs_with_tests = [s for s in syncs if s.tests]
     if not syncs_with_tests:

--- a/drt/mcp/server.py
+++ b/drt/mcp/server.py
@@ -144,7 +144,7 @@ def create_server(project_dir: Path | None = None) -> Any:
     # -----------------------------------------------------------------------
 
     @mcp.tool()
-    def drt_run_test(sync_name: str | None = None) -> dict[str, Any]:
+    def drt_run_test(sync_name: str | None = None, unit: bool = False) -> dict[str, Any]:
         """Run post-sync validation tests for one or all syncs.
 
         Mirrors the `drt test` CLI: for each sync with `tests:` defined,
@@ -154,19 +154,30 @@ def create_server(project_dir: Path | None = None) -> Any:
         Args:
             sync_name: Restrict to one sync. If omitted, runs tests for
                 every sync that has tests defined.
+            unit: Run `sync.unit_tests` instead of `sync.tests` (#780) —
+                fixture rows through the transform pipeline, zero
+                credentials, zero network. No destination is touched, so a
+                sync with `destination.lookups` configured reports a failed
+                test rather than running (no fake lookup table yet).
 
         Returns:
             Dict with `status` ("passed" | "failed" | "no_tests" | "no_syncs"),
-            and `results` — a list of per-sync result objects, each with:
-                - `sync`: sync name
-                - `tests`: list of {name, passed, value, severity} or
-                  {name, passed: false, error, severity} — severity is
-                  "warn" | "error" (#779); a "warn" failure is reported here
-                  but never flips the top-level `status` to "failed"
-                - `skipped` (optional): true when destination type isn't queryable
-                - `reason` (optional): why the sync was skipped
+            and `results` — a list of per-sync result objects.
+
+            When `unit` is false, each `tests` entry is
+            {name, passed, value, severity} or
+            {name, passed: false, error, severity} — severity is
+            "warn" | "error" (#779); a "warn" failure is reported here
+            but never flips the top-level `status` to "failed". A sync may
+            also carry `skipped` + `reason` when its destination type isn't
+            queryable.
+
+            When `unit` is true, each `tests` entry is instead
+            {name, passed, mismatches} — `mismatches` is a list of
+            human-readable strings, empty when `passed` is true. There is no
+            `severity` tier and no `skipped` state for unit tests.
         """
-        return _run_test(ctx, sync_name)
+        return _run_test(ctx, sync_name, unit=unit)
 
     # -----------------------------------------------------------------------
     # drt_get_status

--- a/drt/mcp/tools/run_test.py
+++ b/drt/mcp/tools/run_test.py
@@ -10,10 +10,54 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from drt.cli.commands.test import _SyncTestResult
+    from drt.config.models import SyncConfig
     from drt.mcp._context import McpContext
 
 
-def run_test(ctx: McpContext, sync_name: str | None = None) -> dict[str, Any]:
+def _run_unit_tests(syncs: list[SyncConfig]) -> dict[str, Any]:
+    """``unit=True`` path — sync.unit_tests (#780), no destination touched.
+
+    Separate from the ``sync.tests:`` loop below for the same reason
+    ``drt test --unit`` keeps its own function: no destination connection,
+    no ``severity`` tier, none of that loop's machinery applies. Delegates
+    to :func:`drt.engine.unit_test_runner.run_unit_test` — the same engine
+    function the CLI calls, so the two surfaces can't drift on what a unit
+    test result means, only on how it's presented.
+    """
+    from drt.engine.unit_test_runner import UnitTestLookupsUnsupportedError, run_unit_test
+
+    syncs_with_unit_tests = [s for s in syncs if s.unit_tests]
+    if not syncs_with_unit_tests:
+        return {"status": "no_tests", "results": []}
+
+    had_failures = False
+    results: list[dict[str, Any]] = []
+
+    for sync in syncs_with_unit_tests:
+        sync_result: dict[str, Any] = {"sync": sync.name, "tests": []}
+        try:
+            for test_def in sync.unit_tests:
+                result = run_unit_test(sync, test_def)
+                sync_result["tests"].append(
+                    {
+                        "name": test_def.name,
+                        "passed": result.passed,
+                        "mismatches": result.mismatches,
+                    }
+                )
+                if not result.passed:
+                    had_failures = True
+        except UnitTestLookupsUnsupportedError as e:
+            sync_result["tests"].append({"name": sync.name, "passed": False, "error": str(e)})
+            had_failures = True
+        results.append(sync_result)
+
+    return {"status": "failed" if had_failures else "passed", "results": results}
+
+
+def run_test(
+    ctx: McpContext, sync_name: str | None = None, unit: bool = False
+) -> dict[str, Any]:
     # #851: the per-test loop (connect, build query, execute, check,
     # severity, error handling) lives in exactly one place —
     # `execute_tests_for_sync`, which `drt test` and `drt build` already
@@ -29,6 +73,9 @@ def run_test(ctx: McpContext, sync_name: str | None = None) -> dict[str, Any]:
         syncs = [s for s in syncs if s.name == sync_name]
         if not syncs:
             return {"error": f"No sync named '{sync_name}' found."}
+
+    if unit:
+        return _run_unit_tests(syncs)
 
     syncs_with_tests = [s for s in syncs if s.tests]
     if not syncs_with_tests:

--- a/tests/unit/test_cli_test_unit.py
+++ b/tests/unit/test_cli_test_unit.py
@@ -1,0 +1,251 @@
+"""Tests for `drt test --unit` (#780, CLI wiring)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from drt.cli.main import app
+
+runner = CliRunner()
+
+
+def _write_sync(tmp_path: Path, data: dict, name: str = "sync") -> None:
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir(exist_ok=True)
+    with (syncs_dir / f"{name}.yml").open("w") as f:
+        yaml.dump(data, f)
+
+
+def _rest_sync(**overrides: object) -> dict:
+    base = {
+        "name": "s",
+        "model": "SELECT 1",
+        "destination": {"type": "rest_api", "url": "http://example.com"},
+    }
+    base.update(overrides)
+    return base
+
+
+class TestNoUnitTests:
+    def test_no_syncs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["test", "--unit"])
+        assert "No syncs found" in result.output
+        assert result.exit_code == 0
+
+    def test_no_unit_tests_defined(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        _write_sync(tmp_path, _rest_sync(tests=[{"row_count": {"min": 1}}]))
+        result = runner.invoke(app, ["test", "--unit"])
+        assert "No unit_tests defined" in result.output
+        assert result.exit_code == 0
+
+    def test_no_unit_tests_defined_json_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _write_sync(tmp_path, _rest_sync())
+        result = runner.invoke(app, ["test", "--unit", "--output", "json"])
+        assert json.loads(result.output) == {"status": "no_tests", "results": []}
+        assert result.exit_code == 0
+
+    def test_ignores_syncs_without_unit_tests_but_runs_the_rest(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """sync.tests: alone must not make a sync eligible for --unit."""
+        monkeypatch.chdir(tmp_path)
+        _write_sync(
+            tmp_path, _rest_sync(name="quality_only", tests=[{"row_count": {"min": 1}}]),
+            name="a",
+        )
+        _write_sync(
+            tmp_path,
+            _rest_sync(
+                name="has_unit",
+                unit_tests=[{"name": "t", "given": [{"id": 1}], "expect": [{"id": 1}]}],
+            ),
+            name="b",
+        )
+        result = runner.invoke(app, ["test", "--unit", "--output", "json"])
+        payload = json.loads(result.output)
+        assert [r["sync"] for r in payload["results"]] == ["has_unit"]
+
+
+class TestPassAndFail:
+    def test_a_passing_unit_test(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        _write_sync(
+            tmp_path,
+            _rest_sync(
+                sync={"field_mappings": {"first": "given_name"}},
+                unit_tests=[
+                    {
+                        "name": "renames",
+                        "given": [{"id": 1, "first": "Alice"}],
+                        "expect": [{"id": 1, "given_name": "Alice"}],
+                    }
+                ],
+            ),
+        )
+        result = runner.invoke(app, ["test", "--unit"])
+        assert result.exit_code == 0
+        assert "✓" in result.output
+        assert "renames" in result.output
+
+    def test_a_failing_unit_test_exits_nonzero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _write_sync(
+            tmp_path,
+            _rest_sync(
+                unit_tests=[
+                    {"name": "wrong", "given": [{"id": 1}], "expect": [{"id": 999}]}
+                ]
+            ),
+        )
+        result = runner.invoke(app, ["test", "--unit"])
+        assert result.exit_code == 1
+        assert "✗" in result.output
+        assert "wrong" in result.output
+
+    def test_json_output_shape(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        _write_sync(
+            tmp_path,
+            _rest_sync(
+                unit_tests=[
+                    {"name": "ok", "given": [{"id": 1}], "expect": [{"id": 1}]},
+                    {"name": "bad", "given": [{"id": 1}], "expect": [{"id": 2}]},
+                ]
+            ),
+        )
+        result = runner.invoke(app, ["test", "--unit", "--output", "json"])
+        payload = json.loads(result.output)
+        assert payload["status"] == "failed"
+        [sync_result] = payload["results"]
+        assert sync_result["sync"] == "s"
+        by_name = {t["name"]: t for t in sync_result["tests"]}
+        assert by_name["ok"]["passed"] is True
+        assert by_name["ok"]["mismatches"] == []
+        assert by_name["bad"]["passed"] is False
+        assert by_name["bad"]["mismatches"]
+
+
+class TestLookupsRejected:
+    def test_reports_as_a_failure_not_a_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _write_sync(
+            tmp_path,
+            {
+                "name": "s",
+                "model": "SELECT 1",
+                "destination": {
+                    "type": "postgres",
+                    "host_env": "H",
+                    "dbname_env": "D",
+                    "user_env": "U",
+                    "password_env": "P",
+                    "table": "t",
+                    "upsert_key": ["id"],
+                    "lookups": {
+                        "account_id": {
+                            "table": "accounts",
+                            "match": {"email": "email"},
+                            "select": "id",
+                        }
+                    },
+                },
+                "unit_tests": [{"name": "t", "given": [{"id": 1}], "expect": [{"id": 1}]}],
+            },
+        )
+        result = runner.invoke(app, ["test", "--unit"])
+        assert result.exit_code == 1
+        assert "lookups" in result.output
+
+
+class TestMutualExclusivity:
+    @pytest.mark.parametrize("flag", ["--dry-run", "--store-failures"])
+    def test_rejected_with_dry_run_or_store_failures(
+        self, flag: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _write_sync(tmp_path, _rest_sync())
+        result = runner.invoke(app, ["test", "--unit", flag])
+        assert result.exit_code == 2
+        assert "--unit" in result.output
+
+
+class TestFailFast:
+    def test_stops_after_first_failing_sync(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        for name, expect_id in [("a", 999), ("b", 1), ("c", 1)]:
+            _write_sync(
+                tmp_path,
+                _rest_sync(
+                    name=name,
+                    unit_tests=[
+                        {"name": "t", "given": [{"id": 1}], "expect": [{"id": expect_id}]}
+                    ],
+                ),
+                name=name,
+            )
+        result = runner.invoke(app, ["test", "--unit", "--fail-fast", "--output", "json"])
+        payload = json.loads(result.output)
+        statuses = {r["sync"]: r.get("skipped", False) for r in payload["results"]}
+        assert statuses["a"] is False  # ran, failed
+        # b and c: exactly one order is deterministic (syncs load alphabetically
+        # by filename), so both remaining are skipped after "a" fails.
+        assert statuses["b"] is True
+        assert statuses["c"] is True
+
+    def test_prints_a_skip_notice_in_text_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        for name, expect_id in [("a", 999), ("b", 1)]:
+            _write_sync(
+                tmp_path,
+                _rest_sync(
+                    name=name,
+                    unit_tests=[
+                        {"name": "t", "given": [{"id": 1}], "expect": [{"id": expect_id}]}
+                    ],
+                ),
+                name=name,
+            )
+        result = runner.invoke(app, ["test", "--unit", "--fail-fast"])
+        assert "--fail-fast: skipped 1 sync(s)" in result.output
+
+
+class TestSelectAndExclude:
+    def test_select_narrows_to_one_sync(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _write_sync(
+            tmp_path,
+            _rest_sync(
+                name="a", unit_tests=[{"name": "t", "given": [{"id": 1}], "expect": [{"id": 1}]}]
+            ),
+            name="a",
+        )
+        _write_sync(
+            tmp_path,
+            _rest_sync(
+                name="b", unit_tests=[{"name": "t", "given": [{"id": 1}], "expect": [{"id": 1}]}]
+            ),
+            name="b",
+        )
+        result = runner.invoke(app, ["test", "--unit", "--select", "a", "--output", "json"])
+        payload = json.loads(result.output)
+        assert [r["sync"] for r in payload["results"]] == ["a"]

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -396,6 +396,129 @@ async def test_run_test_does_not_store_failure_samples(
 
 
 # ---------------------------------------------------------------------------
+# drt_run_test — unit=True (#780)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_test_unit_no_unit_tests_defined(server: FastMCP) -> None:
+    """The default fixture sync has no unit_tests: block. sync.tests: alone
+    (a different sync than this fixture, checked below) must not count."""
+    result = await call(server, "drt_run_test", unit=True)
+    assert result == {"status": "no_tests", "results": []}
+
+
+@pytest.mark.asyncio
+async def test_run_test_unit_ignores_syncs_with_only_quality_tests(tmp_path: Path) -> None:
+    (tmp_path / "drt_project.yml").write_text("name: test\nprofile: default\n")
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    (syncs_dir / "notify.yml").write_text(
+        "name: notify\n"
+        "model: ref('users')\n"
+        "destination:\n"
+        "  type: rest_api\n"
+        "  url: https://example.com/hook\n"
+        "tests:\n"
+        "  - row_count: { min: 1 }\n"
+    )
+    srv = create_server(tmp_path)
+    result = await call(srv, "drt_run_test", unit=True)
+    assert result == {"status": "no_tests", "results": []}
+
+
+@pytest.mark.asyncio
+async def test_run_test_unit_pass_and_fail(tmp_path: Path) -> None:
+    (tmp_path / "drt_project.yml").write_text("name: test\nprofile: default\n")
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    (syncs_dir / "notify.yml").write_text(
+        "name: notify\n"
+        "model: ref('users')\n"
+        "destination:\n"
+        "  type: rest_api\n"
+        "  url: https://example.com/hook\n"
+        "sync:\n"
+        "  field_mappings: { first: given_name }\n"
+        "unit_tests:\n"
+        "  - name: renames\n"
+        "    given: [{ id: 1, first: Alice }]\n"
+        "    expect: [{ id: 1, given_name: Alice }]\n"
+        "  - name: wrong\n"
+        "    given: [{ id: 1 }]\n"
+        "    expect: [{ id: 999 }]\n"
+    )
+    srv = create_server(tmp_path)
+    result = await call(srv, "drt_run_test", unit=True)
+
+    assert result["status"] == "failed"
+    [sync_result] = result["results"]
+    by_name = {t["name"]: t for t in sync_result["tests"]}
+    assert by_name["renames"]["passed"] is True
+    assert by_name["renames"]["mismatches"] == []
+    assert by_name["wrong"]["passed"] is False
+    assert by_name["wrong"]["mismatches"]
+
+
+@pytest.mark.asyncio
+async def test_run_test_unit_lookups_reported_as_failure(tmp_path: Path) -> None:
+    """No fake lookup table yet (#780's own stated scope) — a sync with
+    destination.lookups fails the unit test rather than silently running
+    without the lookup step."""
+    (tmp_path / "drt_project.yml").write_text("name: test\nprofile: default\n")
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    (syncs_dir / "orders.yml").write_text(
+        "name: orders\n"
+        "model: ref('orders')\n"
+        "destination:\n"
+        "  type: postgres\n"
+        "  host_env: H\n"
+        "  dbname_env: D\n"
+        "  user_env: U\n"
+        "  password_env: P\n"
+        "  table: orders\n"
+        "  upsert_key: [id]\n"
+        "  lookups:\n"
+        "    account_id: { table: accounts, match: { email: email }, select: id }\n"
+        "unit_tests:\n"
+        "  - name: cannot_run\n"
+        "    given: [{ id: 1 }]\n"
+        "    expect: [{ id: 1 }]\n"
+    )
+    srv = create_server(tmp_path)
+    result = await call(srv, "drt_run_test", unit=True)
+
+    assert result["status"] == "failed"
+    test_entry = result["results"][0]["tests"][0]
+    assert test_entry["passed"] is False
+    assert "lookups" in test_entry["error"]
+
+
+@pytest.mark.asyncio
+async def test_run_test_unit_sync_name_filters_first(tmp_path: Path) -> None:
+    """unit=True composes with sync_name the same way the tests: path does."""
+    (tmp_path / "drt_project.yml").write_text("name: test\nprofile: default\n")
+    syncs_dir = tmp_path / "syncs"
+    syncs_dir.mkdir()
+    for name in ("a", "b"):
+        (syncs_dir / f"{name}.yml").write_text(
+            f"name: {name}\n"
+            "model: ref('t')\n"
+            "destination:\n"
+            "  type: rest_api\n"
+            "  url: https://example.com\n"
+            "unit_tests:\n"
+            "  - name: t\n"
+            "    given: [{ id: 1 }]\n"
+            "    expect: [{ id: 1 }]\n"
+        )
+    srv = create_server(tmp_path)
+    result = await call(srv, "drt_run_test", sync_name="a", unit=True)
+    assert [r["sync"] for r in result["results"]] == ["a"]
+
+
+# ---------------------------------------------------------------------------
 # drt_get_status
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Part 2 of #780 — stacked on #918 (the runner). `unit_tests:` was implemented but unreachable outside a library call; this makes it usable from the CLI and MCP.

```bash
drt test --unit                              # text
drt test --unit --output json                # json
drt test --unit --select users_to_hubspot    # composes with the usual selection flags
drt test --unit --fail-fast
```

Plus MCP `drt_run_test(sync_name=None, unit=False)`.

## One function each, not a branch in the existing loop

Both the CLI and MCP paths get their own execution function (`execute_unit_tests_for_sync` / `_run_unit_tests`) rather than a branch inside the existing `sync.tests:` loop. That loop's machinery — destination connection, `dry_run`, `severity: warn`, `--store-failures` — doesn't apply to a mode that never touches a destination by design, and threading a growing set of "well, not for unit tests" exceptions through one function seemed worse than two functions that each do one thing.

Both delegate to the same `drt.engine.unit_test_runner.run_unit_test` that #918 shipped, so the CLI and MCP surfaces can't drift on what a unit test result *means* — only on how it's presented. This mirrors the split already in the codebase between `execute_tests_for_sync` (CLI) and MCP's own independent loop for `sync.tests:`.

## Two things kept deliberately narrow

- **`--unit` rejects `--dry-run` and `--store-failures`** (exit 2) — both are destination-connected concepts unit tests structurally don't have, so silently ignoring them felt worse than a clear error.
- **`drt build` is untouched.** Its whole point is "run + test against a real destination in one pass" — the opposite of what a unit test promises (zero credentials, zero network). Extending it didn't make sense to attempt.

## JSON shape

Mirrors the existing envelope (`{"status", "results": [{"sync", "tests": [...]}]}`), but each test entry is `{name, passed, mismatches}` rather than `{name, passed, value/error, severity}` — there's no severity tier for unit tests, so reusing the exact shape would mean fields that are always absent rather than a shape that says what it actually means.

## Verification

Full suite **2961 passed / 22 skipped**. `drt/cli/commands/test.py` and `drt/mcp/tools/run_test.py` at **97%** each, measured per-module (not `codecov/patch`); every remaining miss in both is a pre-existing branch in the `sync.tests:` path this PR doesn't touch, cross-checked by line number. `ruff` + `mypy` clean. `scripts/check_drift.sh` reports no new drift — `--unit` maps to `unit` by name alone, no rename declaration needed (unlike `--diff` → `compute_diff`).

Manually smoke-tested end to end before writing formal tests: passing/failing unit tests, `--output json`, the lookups-rejection message, and the mutual-exclusivity guard, all through the real `drt` console script.

## Not in this PR

- Docs (`docs/llm/API_REFERENCE.md`, a guide) + `/drt-create-sync` skill update — natural follow-up now the surface is settled, same pattern as #913→#915.
