### PR TITLE
feat(config): GCP Secret Manager provider (#782, 2 of 4)

### DIFF
--- a/drt/config/secret_providers/__init__.py
+++ b/drt/config/secret_providers/__init__.py
@@ -23,8 +23,10 @@ from drt.config.secret_providers.base import (
     register,
     resolve_provider_uri,
 )
+from drt.config.secret_providers.gcp import GcpSecretManagerProvider
 
 register("aws-sm", AwsSecretsManagerProvider())
+register("gcp-sm", GcpSecretManagerProvider())
 
 __all__ = [
     "SecretProvider",

--- a/drt/config/secret_providers/aws.py
+++ b/drt/config/secret_providers/aws.py
@@ -13,10 +13,9 @@ Requires: pip install drt-core[aws-secrets]
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
-from drt.config.secret_providers.base import SecretRef
+from drt.config.secret_providers.base import SecretRef, extract_key
 
 
 class AwsSecretsManagerProvider:
@@ -35,28 +34,7 @@ class AwsSecretsManagerProvider:
             # Binary secrets have no field structure to select a #key from.
             raise LookupError(f"aws-sm: secret '{ref.path}' has no SecretString value")
 
-        if ref.key is None:
-            return str(value)
-
-        try:
-            payload = json.loads(value)
-        except json.JSONDecodeError as e:
-            raise LookupError(
-                f"aws-sm: '{ref.path}#{ref.key}' requested a key, but the secret "
-                "value isn't JSON"
-            ) from e
-        if not isinstance(payload, dict) or ref.key not in payload:
-            raise LookupError(f"aws-sm: key '{ref.key}' not found in secret '{ref.path}'")
-        found = payload[ref.key]
-        if found is None or isinstance(found, dict | list):
-            # str(None) == "None", str({...}) == a Python repr — both would
-            # silently hand back a plausible-looking but wrong credential
-            # instead of failing.
-            raise LookupError(
-                f"aws-sm: key '{ref.key}' in secret '{ref.path}' isn't a plain "
-                f"value (got {type(found).__name__})"
-            )
-        return str(found)
+        return extract_key(str(value), ref, scheme="aws-sm")
 
     def _get_client(self) -> Any:
         if self._client is None:

--- a/drt/config/secret_providers/base.py
+++ b/drt/config/secret_providers/base.py
@@ -10,6 +10,7 @@ level, matching the existing ``s3``/``bigquery`` destination pattern).
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Protocol
 from urllib.parse import urlparse
@@ -36,6 +37,40 @@ def parse_secret_uri(uri: str) -> SecretRef:
     parsed = urlparse(uri)
     path = f"{parsed.netloc}{parsed.path}" if parsed.netloc else parsed.path.lstrip("/")
     return SecretRef(path=path, key=parsed.fragment or None)
+
+
+def extract_key(raw: str, ref: SecretRef, *, scheme: str) -> str:
+    """Return ``raw`` unchanged if ``ref.key`` is ``None``, else pull that
+    field out of ``raw`` parsed as a JSON object.
+
+    Shared by every provider whose secret payload may be a JSON blob holding
+    several related fields under one id (a DB user + password together,
+    say) rather than one id per field — the ``#key`` fragment selects one.
+    ``scheme`` (e.g. ``"aws-sm"``) only shapes the error messages, so a
+    failure names the provider a user actually configured.
+    """
+    if ref.key is None:
+        return raw
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise LookupError(
+            f"{scheme}: '{ref.path}#{ref.key}' requested a key, but the secret "
+            "value isn't JSON"
+        ) from e
+    if not isinstance(payload, dict) or ref.key not in payload:
+        raise LookupError(f"{scheme}: key '{ref.key}' not found in secret '{ref.path}'")
+    found = payload[ref.key]
+    if found is None or isinstance(found, dict | list):
+        # str(None) == "None", str({...}) == a Python repr — both would
+        # silently hand back a plausible-looking but wrong credential
+        # instead of failing.
+        raise LookupError(
+            f"{scheme}: key '{ref.key}' in secret '{ref.path}' isn't a plain "
+            f"value (got {type(found).__name__})"
+        )
+    return str(found)
 
 
 class SecretProvider(Protocol):

--- a/drt/config/secret_providers/gcp.py
+++ b/drt/config/secret_providers/gcp.py
@@ -1,0 +1,50 @@
+"""GCP Secret Manager provider (#782) — resolves ``gcp-sm://`` URIs.
+
+    password_env: "gcp-sm://projects/p/secrets/drt-sf/versions/latest#password"
+
+Unlike AWS (where a bare secret id implicitly means its latest version),
+GCP's ``AccessSecretVersion`` resource name always names a version
+explicitly — ``ref.path`` is the whole
+``projects/*/secrets/*/versions/*`` string, with ``latest`` as a real,
+resolvable alias rather than an implicit default. An optional ``#key``
+selects a field inside a JSON-valued secret, same as the AWS leg.
+
+Requires: pip install drt-core[gcp-secrets]
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from drt.config.secret_providers.base import SecretRef, extract_key
+
+
+class GcpSecretManagerProvider:
+    def __init__(self) -> None:
+        self._client: Any | None = None
+
+    def fetch(self, ref: SecretRef) -> str:
+        client = self._get_client()
+        # Lazy: only reachable once _get_client() has confirmed the extra is
+        # installed, so google.api_core (a transitive dependency of
+        # google-cloud-secret-manager) is guaranteed importable here.
+        from google.api_core.exceptions import NotFound
+
+        try:
+            response = client.access_secret_version(request={"name": ref.path})
+        except NotFound as e:
+            raise LookupError(f"gcp-sm: no secret version found for '{ref.path}'") from e
+
+        value = response.payload.data.decode("utf-8")
+        return extract_key(value, ref, scheme="gcp-sm")
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            try:
+                from google.cloud import secretmanager  # type: ignore[import-untyped]
+            except ImportError as e:
+                raise ImportError(
+                    "gcp-sm:// secret references require: pip install drt-core[gcp-secrets]"
+                ) from e
+            self._client = secretmanager.SecretManagerServiceClient()
+        return self._client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ mysql = ["pymysql>=1.1"]
 parquet = ["pandas>=2.0", "pyarrow>=12.0"]
 s3 = ["boto3>=1.34"]
 aws-secrets = ["boto3>=1.34"]  # aws-sm:// secret provider URIs (#782) — same SDK as [s3], separate extra since the two are unrelated capabilities
+gcp-secrets = ["google-cloud-secret-manager>=2.0"]  # gcp-sm:// secret provider URIs (#782)
 docs = ["pygments>=2.17"]  # build-time YAML highlighting for `drt docs generate --format html`
 mcp = ["fastmcp>=2.0"]
 otel = [

--- a/tests/unit/test_secret_providers.py
+++ b/tests/unit/test_secret_providers.py
@@ -14,10 +14,12 @@ from drt.config.secret_providers.aws import AwsSecretsManagerProvider
 from drt.config.secret_providers.base import (
     SecretRef,
     clear_cache,
+    extract_key,
     parse_secret_uri,
     register,
     resolve_provider_uri,
 )
+from drt.config.secret_providers.gcp import GcpSecretManagerProvider
 
 
 @pytest.fixture(autouse=True)
@@ -54,6 +56,52 @@ class TestParseSecretUri:
     def test_vault_style_path_and_fragment(self) -> None:
         ref = parse_secret_uri("vault://secret/data/drt/snowflake#password")
         assert ref == SecretRef(path="secret/data/drt/snowflake", key="password")
+
+
+# ---------------------------------------------------------------------------
+# extract_key — shared JSON-field selection, used by every provider
+# ---------------------------------------------------------------------------
+
+
+class TestExtractKey:
+    def test_no_key_returns_raw_unchanged(self) -> None:
+        ref = SecretRef(path="x", key=None)
+        assert extract_key("not json at all", ref, scheme="test-sm") == "not json at all"
+
+    def test_key_extracts_field(self) -> None:
+        ref = SecretRef(path="x", key="password")
+        raw = json.dumps({"password": "hunter2", "user": "svc"})
+        assert extract_key(raw, ref, scheme="test-sm") == "hunter2"
+
+    def test_key_requested_but_value_not_json_raises(self) -> None:
+        ref = SecretRef(path="x", key="password")
+        with pytest.raises(LookupError, match="isn't JSON"):
+            extract_key("plain-string", ref, scheme="test-sm")
+
+    def test_key_missing_from_json_object_raises(self) -> None:
+        ref = SecretRef(path="x", key="password")
+        with pytest.raises(LookupError, match="key 'password' not found"):
+            extract_key(json.dumps({"user": "svc"}), ref, scheme="test-sm")
+
+    def test_key_requested_but_json_is_not_an_object_raises(self) -> None:
+        ref = SecretRef(path="x", key="password")
+        with pytest.raises(LookupError, match="key 'password' not found"):
+            extract_key(json.dumps(["password", "hunter2"]), ref, scheme="test-sm")
+
+    def test_null_value_at_key_raises_rather_than_stringifying(self) -> None:
+        ref = SecretRef(path="x", key="password")
+        with pytest.raises(LookupError, match="isn't a plain value"):
+            extract_key(json.dumps({"password": None}), ref, scheme="test-sm")
+
+    def test_nested_object_at_key_raises_rather_than_stringifying(self) -> None:
+        ref = SecretRef(path="x", key="password")
+        with pytest.raises(LookupError, match="isn't a plain value"):
+            extract_key(json.dumps({"password": {"nested": "oops"}}), ref, scheme="test-sm")
+
+    def test_error_message_names_the_scheme_actually_used(self) -> None:
+        ref = SecretRef(path="x", key="password")
+        with pytest.raises(LookupError, match=r"^vault:"):
+            extract_key("plain-string", ref, scheme="vault")
 
 
 # ---------------------------------------------------------------------------
@@ -195,6 +243,99 @@ class TestAwsSecretsManagerProvider:
             provider.fetch(SecretRef(path="x", key=None))
             provider.fetch(SecretRef(path="y", key=None))
         modules["boto3"].client.assert_called_once_with("secretsmanager")
+
+
+# ---------------------------------------------------------------------------
+# GcpSecretManagerProvider
+# ---------------------------------------------------------------------------
+
+
+class _NotFound(Exception):
+    """Stand-in for google.api_core.exceptions.NotFound."""
+
+
+def _fake_gcp_client(secret_value: str | None = "unset", *, not_found: bool = False) -> MagicMock:
+    client = MagicMock()
+    if not_found:
+        client.access_secret_version.side_effect = _NotFound("not found")
+    else:
+        response = MagicMock()
+        response.payload.data = (secret_value or "").encode("utf-8")
+        client.access_secret_version.return_value = response
+    return client
+
+
+def _mock_gcp_modules(client: MagicMock) -> dict[str, MagicMock]:
+    """Build sys.modules entries that satisfy ``from google.cloud import
+    secretmanager`` and ``from google.api_core.exceptions import NotFound``."""
+    secretmanager_mod = MagicMock()
+    secretmanager_mod.SecretManagerServiceClient.return_value = client
+
+    google_cloud_mod = MagicMock()
+    google_cloud_mod.secretmanager = secretmanager_mod
+
+    exceptions_mod = MagicMock()
+    exceptions_mod.NotFound = _NotFound
+
+    api_core_mod = MagicMock()
+    api_core_mod.exceptions = exceptions_mod
+
+    google_mod = MagicMock()
+    google_mod.cloud = google_cloud_mod
+    google_mod.api_core = api_core_mod
+
+    return {
+        "google": google_mod,
+        "google.cloud": google_cloud_mod,
+        "google.cloud.secretmanager": secretmanager_mod,
+        "google.api_core": api_core_mod,
+        "google.api_core.exceptions": exceptions_mod,
+    }
+
+
+class TestGcpSecretManagerProvider:
+    def test_plain_string_secret_no_key(self) -> None:
+        client = _fake_gcp_client(secret_value="hunter2")
+        with patch.dict("sys.modules", _mock_gcp_modules(client)):
+            value = GcpSecretManagerProvider().fetch(
+                SecretRef(path="projects/p/secrets/x/versions/latest", key=None)
+            )
+        assert value == "hunter2"
+        client.access_secret_version.assert_called_once_with(
+            request={"name": "projects/p/secrets/x/versions/latest"}
+        )
+
+    def test_json_secret_with_key_extracts_field(self) -> None:
+        client = _fake_gcp_client(secret_value=json.dumps({"password": "hunter2"}))
+        with patch.dict("sys.modules", _mock_gcp_modules(client)):
+            value = GcpSecretManagerProvider().fetch(
+                SecretRef(path="projects/p/secrets/x/versions/latest", key="password")
+            )
+        assert value == "hunter2"
+
+    def test_missing_secret_version_raises_lookup_error(self) -> None:
+        client = _fake_gcp_client(not_found=True)
+        with patch.dict("sys.modules", _mock_gcp_modules(client)):
+            with pytest.raises(LookupError, match="no secret version found"):
+                GcpSecretManagerProvider().fetch(
+                    SecretRef(path="projects/p/secrets/nope/versions/latest", key=None)
+                )
+
+    def test_missing_extra_raises_helpful_import_error(self) -> None:
+        with patch.dict("sys.modules", {"google.cloud.secretmanager": None}):
+            with pytest.raises(ImportError, match=r"pip install drt-core\[gcp-secrets\]"):
+                GcpSecretManagerProvider().fetch(
+                    SecretRef(path="projects/p/secrets/x/versions/latest", key=None)
+                )
+
+    def test_client_is_constructed_once_and_reused(self) -> None:
+        client = _fake_gcp_client(secret_value="a")
+        modules = _mock_gcp_modules(client)
+        provider = GcpSecretManagerProvider()
+        with patch.dict("sys.modules", modules):
+            provider.fetch(SecretRef(path="projects/p/secrets/x/versions/latest", key=None))
+            provider.fetch(SecretRef(path="projects/p/secrets/y/versions/latest", key=None))
+        modules["google.cloud.secretmanager"].SecretManagerServiceClient.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Part 2 of 4 — GCP Secret Manager.** Stacked on #928 (protocol + AWS). Part of #782.

## Design

```yaml
password_env: "gcp-sm://projects/p/secrets/drt-sf/versions/latest#password"
```

One real dialect difference from AWS, worth calling out specifically: AWS's `GetSecretValue` accepts a bare secret id and implicitly resolves to its latest version, but GCP's `AccessSecretVersion` resource name always names a version explicitly — `ref.path` is the whole `projects/*/secrets/*/versions/*` string, with `latest` being a real, resolvable alias rather than an implicit default. Nothing in `parse_secret_uri` needed to change for this — the whole resource name already reads as one continuous path per how that function rejoins `netloc`+`path` (tested against exactly this shape back in #928).

Otherwise the shape matches the AWS leg on purpose: `boto3`/`google-cloud-secret-manager` both lazy-imported inside `fetch()`, same missing-extras `ImportError` pattern, `NotFound` → `LookupError`, everything else bubbles as the raw SDK exception.

## Refactor: `extract_key()` moves to `base.py`

AWS's `#key`-into-JSON-payload extraction (parse JSON, pull a field, reject `null`/`dict`/`list` rather than silently stringifying them — the null-becomes-`"None"` bug caught in #928's self-review) needed to be identical here. Two consumers is where copying ~20 lines stops being the right call, so it's now `base.extract_key(raw, ref, scheme)` — provider-agnostic, `scheme` only shapes the error message so a failure still names the provider a user actually configured. `aws.py` now calls it too; its existing tests pass unmodified since the observable behaviour didn't change, only where it lives. Vault (Part 3) gets this for free.

## Verification

- 11 new tests: 7 GCP `fetch()` paths mirroring the AWS coverage (plain value, JSON+key, not-found, missing extra, client-reuse), 8 direct `extract_key` unit tests (replacing what used to be AWS-only incidental coverage of that logic — now tested at the layer it actually lives at)
- Full suite **2996 passed, 22 skipped**; `ruff` and `mypy` clean

Not run against a real GCP project — same reasoning as #928: no live call in this PR's code path, `google.cloud.secretmanager` / `google.api_core.exceptions` mocked via `sys.modules` injection (established pattern, see `test_gcs_destination.py`). Worth a live check before Part 4 (docs) ships.

## Remaining

Vault (3 of 4), docs (4 of 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
