### PR TITLE
feat(config): HashiCorp Vault provider (#782, 3 of 4)

### DIFF
--- a/drt/config/secret_providers/__init__.py
+++ b/drt/config/secret_providers/__init__.py
@@ -24,9 +24,11 @@ from drt.config.secret_providers.base import (
     resolve_provider_uri,
 )
 from drt.config.secret_providers.gcp import GcpSecretManagerProvider
+from drt.config.secret_providers.vault import VaultProvider
 
 register("aws-sm", AwsSecretsManagerProvider())
 register("gcp-sm", GcpSecretManagerProvider())
+register("vault", VaultProvider())
 
 __all__ = [
     "SecretProvider",

--- a/drt/config/secret_providers/base.py
+++ b/drt/config/secret_providers/base.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol
 from urllib.parse import urlparse
 
 
@@ -39,27 +39,23 @@ def parse_secret_uri(uri: str) -> SecretRef:
     return SecretRef(path=path, key=parsed.fragment or None)
 
 
-def extract_key(raw: str, ref: SecretRef, *, scheme: str) -> str:
-    """Return ``raw`` unchanged if ``ref.key`` is ``None``, else pull that
-    field out of ``raw`` parsed as a JSON object.
+def select_field(payload: dict[str, Any], ref: SecretRef, *, scheme: str) -> str:
+    """Pull ``ref.key`` out of an already-parsed secret payload.
 
-    Shared by every provider whose secret payload may be a JSON blob holding
-    several related fields under one id (a DB user + password together,
+    Shared by every provider whose secret is (or can be) a field map holding
+    several related values under one id (a DB user + password together,
     say) rather than one id per field — the ``#key`` fragment selects one.
     ``scheme`` (e.g. ``"aws-sm"``) only shapes the error messages, so a
     failure names the provider a user actually configured.
-    """
-    if ref.key is None:
-        return raw
 
-    try:
-        payload = json.loads(raw)
-    except json.JSONDecodeError as e:
-        raise LookupError(
-            f"{scheme}: '{ref.path}#{ref.key}' requested a key, but the secret "
-            "value isn't JSON"
-        ) from e
-    if not isinstance(payload, dict) or ref.key not in payload:
+    ``ref.key`` must not be ``None`` — callers with a payload that might
+    also just *be* the scalar value (AWS, GCP: the secret string itself,
+    with no wrapping object) branch on that before parsing far enough to
+    have a ``dict`` at all; see :func:`extract_key`. Vault's payload is
+    always a field map, so it requires a key from the start rather than
+    calling this.
+    """
+    if ref.key not in payload:
         raise LookupError(f"{scheme}: key '{ref.key}' not found in secret '{ref.path}'")
     found = payload[ref.key]
     if found is None or isinstance(found, dict | list):
@@ -71,6 +67,29 @@ def extract_key(raw: str, ref: SecretRef, *, scheme: str) -> str:
             f"value (got {type(found).__name__})"
         )
     return str(found)
+
+
+def extract_key(raw: str, ref: SecretRef, *, scheme: str) -> str:
+    """Return ``raw`` unchanged if ``ref.key`` is ``None``, else parse it as
+    a JSON object and pull that field out via :func:`select_field`.
+
+    For providers (AWS, GCP) whose secret is a single string that *may*
+    additionally be a JSON blob — as opposed to Vault, whose secret is
+    always already a field map and so never needs the JSON-parsing step.
+    """
+    if ref.key is None:
+        return raw
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise LookupError(
+            f"{scheme}: '{ref.path}#{ref.key}' requested a key, but the secret "
+            "value isn't JSON"
+        ) from e
+    if not isinstance(payload, dict):
+        raise LookupError(f"{scheme}: key '{ref.key}' not found in secret '{ref.path}'")
+    return select_field(payload, ref, scheme=scheme)
 
 
 class SecretProvider(Protocol):

--- a/drt/config/secret_providers/vault.py
+++ b/drt/config/secret_providers/vault.py
@@ -1,0 +1,94 @@
+"""HashiCorp Vault provider (#782) — resolves ``vault://`` URIs.
+
+    password_env: "vault://secret/data/drt/snowflake#password"
+
+``ref.path`` mirrors Vault's own raw KV v2 HTTP path: mount point, the
+literal ``data`` segment KV v2's API inserts to distinguish a data read
+from a metadata/delete operation on the same secret, then the logical
+secret path — the same shape ``vault kv get`` / curl examples against
+Vault use, so it's what an operator configuring this already recognizes.
+hvac's own ``read_secret_version()`` wants the mount and the logical path
+passed separately, without that ``data`` segment, so it's split out here
+rather than exposed as a parsing detail on every caller.
+
+Connects via ``VAULT_ADDR`` / ``VAULT_TOKEN`` (``hvac.Client()``'s own
+defaults) — no drt-specific config, same as the AWS/GCP legs relying on
+their SDKs' ambient credential resolution. Unlike those two SDKs, the
+client is *not* cached across calls — see :meth:`VaultProvider._get_client`.
+
+A ``#key`` is required, unlike AWS/GCP: a KV v2 secret's payload is always
+a field map (there's no "the secret is just one string" case to fall back
+to), so there's no sensible value to return without naming which field.
+
+Requires: pip install drt-core[vault]
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from drt.config.secret_providers.base import SecretRef, select_field
+
+
+class VaultProvider:
+    def fetch(self, ref: SecretRef) -> str:
+        if ref.key is None:
+            raise LookupError(
+                f"vault: '{ref.path}' has no #key — a Vault KV v2 secret is a "
+                "field map, so a field must be named (e.g. '#password')"
+            )
+
+        mount_point, secret_path = _split_kv2_path(ref.path)
+        client = self._get_client()
+        # Lazy: only reachable once _get_client() has confirmed the extra is
+        # installed.
+        from hvac.exceptions import InvalidPath
+
+        try:
+            response = client.secrets.kv.v2.read_secret_version(
+                path=secret_path, mount_point=mount_point
+            )
+        except InvalidPath as e:
+            raise LookupError(f"vault: no secret found at '{ref.path}'") from e
+
+        payload = response["data"]["data"]
+        return select_field(payload, ref, scheme="vault")
+
+    def _get_client(self) -> Any:
+        # Deliberately not cached on self, unlike AwsSecretsManagerProvider
+        # and GcpSecretManagerProvider. boto3 and google-auth both refresh
+        # their own credentials internally, so a process-lifetime client is
+        # harmless there. hvac.Client() captures VAULT_TOKEN once at
+        # construction and never refreshes it, and Vault service tokens are
+        # conventionally short-TTL — a cached client under a long-lived
+        # process (`drt serve`) would go from "may resolve a rotated
+        # secret's stale value" (#929, already a known gap one layer up, in
+        # base._value_cache) to "every fetch fails outright" once the token
+        # expires, which is worse and specific to this leg. Construction
+        # itself is cheap (no network call — it just wraps connection
+        # params), so paying it every call is simpler than adding
+        # token-renewal handling here.
+        try:
+            import hvac  # type: ignore[import-untyped]
+        except ImportError as e:
+            raise ImportError(
+                "vault:// secret references require: pip install drt-core[vault]"
+            ) from e
+        return hvac.Client()
+
+
+def _split_kv2_path(path: str) -> tuple[str, str]:
+    """Split ``mount/data/secret/path`` into ``(mount, "secret/path")``.
+
+    The literal ``data`` segment is Vault's own KV v2 API convention, not
+    part of the logical secret path — present so the raw path an operator
+    already knows from ``vault kv get`` / curl works unmodified as the URI,
+    while hvac's higher-level client wants the two pieces apart.
+    """
+    parts = path.split("/")
+    if len(parts) < 3 or parts[1] != "data":
+        raise LookupError(
+            f"vault: expected 'mount/data/path', got '{path}' — the literal "
+            "'data' segment (Vault's own KV v2 API convention) is required"
+        )
+    return parts[0], "/".join(parts[2:])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ parquet = ["pandas>=2.0", "pyarrow>=12.0"]
 s3 = ["boto3>=1.34"]
 aws-secrets = ["boto3>=1.34"]  # aws-sm:// secret provider URIs (#782) — same SDK as [s3], separate extra since the two are unrelated capabilities
 gcp-secrets = ["google-cloud-secret-manager>=2.0"]  # gcp-sm:// secret provider URIs (#782)
+vault = ["hvac>=2.0"]  # vault:// secret provider URIs (#782)
 docs = ["pygments>=2.17"]  # build-time YAML highlighting for `drt docs generate --format html`
 mcp = ["fastmcp>=2.0"]
 otel = [

--- a/tests/unit/test_secret_providers.py
+++ b/tests/unit/test_secret_providers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterator
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -18,8 +19,10 @@ from drt.config.secret_providers.base import (
     parse_secret_uri,
     register,
     resolve_provider_uri,
+    select_field,
 )
 from drt.config.secret_providers.gcp import GcpSecretManagerProvider
+from drt.config.secret_providers.vault import VaultProvider, _split_kv2_path
 
 
 @pytest.fixture(autouse=True)
@@ -102,6 +105,39 @@ class TestExtractKey:
         ref = SecretRef(path="x", key="password")
         with pytest.raises(LookupError, match=r"^vault:"):
             extract_key("plain-string", ref, scheme="vault")
+
+
+# ---------------------------------------------------------------------------
+# select_field — the dict-native half extract_key delegates to; also used
+# directly by providers (Vault) whose payload never needs a JSON-parse step
+# ---------------------------------------------------------------------------
+
+
+class TestSelectField:
+    def test_extracts_field(self) -> None:
+        ref = SecretRef(path="x", key="password")
+        assert select_field({"password": "hunter2", "user": "svc"}, ref, scheme="vault") == (
+            "hunter2"
+        )
+
+    def test_missing_key_raises(self) -> None:
+        ref = SecretRef(path="x", key="password")
+        with pytest.raises(LookupError, match="key 'password' not found"):
+            select_field({"user": "svc"}, ref, scheme="vault")
+
+    def test_null_value_raises_rather_than_stringifying(self) -> None:
+        ref = SecretRef(path="x", key="password")
+        with pytest.raises(LookupError, match="isn't a plain value"):
+            select_field({"password": None}, ref, scheme="vault")
+
+    def test_nested_object_value_raises_rather_than_stringifying(self) -> None:
+        ref = SecretRef(path="x", key="password")
+        with pytest.raises(LookupError, match="isn't a plain value"):
+            select_field({"password": {"nested": "oops"}}, ref, scheme="vault")
+
+    def test_non_string_scalar_is_stringified(self) -> None:
+        ref = SecretRef(path="x", key="port")
+        assert select_field({"port": 5432}, ref, scheme="vault") == "5432"
 
 
 # ---------------------------------------------------------------------------
@@ -336,6 +372,123 @@ class TestGcpSecretManagerProvider:
             provider.fetch(SecretRef(path="projects/p/secrets/x/versions/latest", key=None))
             provider.fetch(SecretRef(path="projects/p/secrets/y/versions/latest", key=None))
         modules["google.cloud.secretmanager"].SecretManagerServiceClient.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _split_kv2_path
+# ---------------------------------------------------------------------------
+
+
+class TestSplitKv2Path:
+    def test_default_mount(self) -> None:
+        assert _split_kv2_path("secret/data/drt/snowflake") == ("secret", "drt/snowflake")
+
+    def test_custom_mount(self) -> None:
+        assert _split_kv2_path("kv2-custom/data/drt/snowflake") == (
+            "kv2-custom",
+            "drt/snowflake",
+        )
+
+    def test_deeply_nested_path(self) -> None:
+        assert _split_kv2_path("secret/data/team/service/creds") == (
+            "secret",
+            "team/service/creds",
+        )
+
+    def test_missing_data_segment_raises(self) -> None:
+        with pytest.raises(LookupError, match="'data' segment"):
+            _split_kv2_path("secret/drt/snowflake")
+
+    def test_too_short_raises(self) -> None:
+        with pytest.raises(LookupError, match="'data' segment"):
+            _split_kv2_path("secret/data")
+
+
+# ---------------------------------------------------------------------------
+# VaultProvider
+# ---------------------------------------------------------------------------
+
+
+class _InvalidPath(Exception):
+    """Stand-in for hvac.exceptions.InvalidPath."""
+
+
+def _fake_hvac_client(data: dict[str, Any] | None = None, *, not_found: bool = False) -> MagicMock:
+    client = MagicMock()
+    if not_found:
+        client.secrets.kv.v2.read_secret_version.side_effect = _InvalidPath("no handler")
+    else:
+        client.secrets.kv.v2.read_secret_version.return_value = {"data": {"data": data or {}}}
+    return client
+
+
+def _mock_hvac_modules(client: MagicMock) -> dict[str, MagicMock]:
+    """Build sys.modules entries that satisfy ``import hvac`` and
+    ``from hvac.exceptions import InvalidPath``."""
+    exceptions_mod = MagicMock()
+    exceptions_mod.InvalidPath = _InvalidPath
+
+    hvac_mod = MagicMock()
+    hvac_mod.Client.return_value = client
+    hvac_mod.exceptions = exceptions_mod
+
+    return {"hvac": hvac_mod, "hvac.exceptions": exceptions_mod}
+
+
+class TestVaultProvider:
+    def test_successful_fetch_extracts_field(self) -> None:
+        client = _fake_hvac_client(data={"password": "hunter2", "user": "svc"})
+        with patch.dict("sys.modules", _mock_hvac_modules(client)):
+            value = VaultProvider().fetch(
+                SecretRef(path="secret/data/drt/snowflake", key="password")
+            )
+        assert value == "hunter2"
+        client.secrets.kv.v2.read_secret_version.assert_called_once_with(
+            path="drt/snowflake", mount_point="secret"
+        )
+
+    def test_custom_mount_point_is_passed_through(self) -> None:
+        client = _fake_hvac_client(data={"password": "hunter2"})
+        with patch.dict("sys.modules", _mock_hvac_modules(client)):
+            VaultProvider().fetch(
+                SecretRef(path="kv2-custom/data/drt/snowflake", key="password")
+            )
+        client.secrets.kv.v2.read_secret_version.assert_called_once_with(
+            path="drt/snowflake", mount_point="kv2-custom"
+        )
+
+    def test_no_key_raises(self) -> None:
+        with pytest.raises(LookupError, match="has no #key"):
+            VaultProvider().fetch(SecretRef(path="secret/data/drt/snowflake", key=None))
+
+    def test_invalid_path_shape_raises_before_any_client_call(self) -> None:
+        with pytest.raises(LookupError, match="'data' segment"):
+            VaultProvider().fetch(SecretRef(path="secret/drt/snowflake", key="password"))
+
+    def test_not_found_raises_lookup_error(self) -> None:
+        client = _fake_hvac_client(not_found=True)
+        with patch.dict("sys.modules", _mock_hvac_modules(client)):
+            with pytest.raises(LookupError, match="no secret found"):
+                VaultProvider().fetch(
+                    SecretRef(path="secret/data/nope", key="password")
+                )
+
+    def test_missing_extra_raises_helpful_import_error(self) -> None:
+        with patch.dict("sys.modules", {"hvac": None}):
+            with pytest.raises(ImportError, match=r"pip install drt-core\[vault\]"):
+                VaultProvider().fetch(SecretRef(path="secret/data/x", key="password"))
+
+    def test_client_is_constructed_fresh_every_fetch(self) -> None:
+        """Unlike AWS/GCP: hvac.Client() doesn't refresh VAULT_TOKEN on its
+        own, so caching it would go stale under a long-lived `drt serve`
+        rather than just serving a possibly-rotated value (#929)."""
+        client = _fake_hvac_client(data={"password": "a"})
+        modules = _mock_hvac_modules(client)
+        provider = VaultProvider()
+        with patch.dict("sys.modules", modules):
+            provider.fetch(SecretRef(path="secret/data/x", key="password"))
+            provider.fetch(SecretRef(path="secret/data/y", key="password"))
+        assert modules["hvac"].Client.call_count == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Part 3 of 4 — HashiCorp Vault.** Stacked on #930 (GCP) → #928 (protocol + AWS). Part of #782.

## Design

```yaml
password_env: "vault://secret/data/drt/snowflake#password"
```

`ref.path` mirrors Vault's own raw KV v2 HTTP path — mount point, the literal `data` segment KV v2's API inserts to distinguish a data read from a metadata/delete operation on the same secret, then the logical secret path. That's the exact shape `vault kv get` / curl examples against Vault already use, so it's what an operator configuring this recognizes without translation. hvac's higher-level client wants the mount and the logical path passed separately (`read_secret_version(path=, mount_point=)`), so `_split_kv2_path()` splits it here rather than making every caller do that parsing.

**`#key` is required**, unlike AWS/GCP — a KV v2 secret's payload is always a field map (there's no "the secret is just one string" case), so there's no sensible value to return without naming which field. Fails fast with a clear message rather than guessing.

## Refactor: `extract_key` splits into `extract_key` + `select_field`

Vault's payload is already a parsed dict by the time it reaches this code (`response["data"]["data"]`) — it never needs the JSON-parsing step AWS/GCP's `extract_key` does. Rather than have Vault round-trip through `json.dumps` just to reuse a string-shaped function, `base.py` now has:
- `select_field(payload: dict, ref, scheme)` — the actual guard logic (key present? not `null`/`dict`/`list`?)
- `extract_key(raw: str, ref, scheme)` — parses `raw` as JSON, then calls `select_field`

AWS/GCP call `extract_key` (unchanged behavior — their own tests pass unmodified, confirming the split didn't move any observable behavior). Vault calls `select_field` directly.

## Verification done differently this time

Rather than resting on documentation search the way #928/#930 initially did, I installed both `hvac` and `google-cloud-secret-manager` in a throwaway venv and checked `inspect.signature()` against the real packages:

```
hvac read_secret_version: (path, version=None, mount_point='secret', raise_on_deleted_version=None)
gcp access_secret_version: (self, request: Union[AccessSecretVersionRequest, dict, None] = None, ...)
```

Both confirm what's already in the code (this PR's `path=`/`mount_point=`, and retroactively #930's `request={"name": ...}` — a plain `dict` is in the documented type union, not just something that happened to not crash a mock). `hvac.exceptions.InvalidPath` and `google.api_core.exceptions.NotFound` both exist with the expected import paths. This closes a real gap the mocked tests structurally can't: `assert_called_once_with(...)` can't catch a wrong keyword-argument name, since `MagicMock` accepts anything silently.

## ⚠️ The client is *not* cached — asymmetric with the AWS/GCP legs, deliberately

`boto3` and `google-auth` both refresh their own credentials internally, so caching those SDKs' clients for the process's lifetime (as `AwsSecretsManagerProvider`/`GcpSecretManagerProvider` do) is harmless. `hvac.Client()` captures `VAULT_TOKEN` once at construction and **never refreshes it**, and Vault service tokens are conventionally short-TTL. Caching the client here would mean a long-lived `drt serve` process eventually holds an expired token — every subsequent Vault fetch would then fail outright, which is worse than #929's "may serve a rotated-but-still-valid value" gap (that one degrades gracefully; this one wouldn't have). `hvac.Client()` construction is cheap (no network call, just wraps connection params), so a fresh client per `fetch()` call is the simple fix rather than adding token-renewal handling. Documented at length next to `_get_client()`.

## Verification

- 18 new tests: 5 `_split_kv2_path` (default/custom mount, nested paths, both malformed-path rejections), 5 `select_field` (mirroring what used to be `extract_key`-only coverage, now tested at the layer each behavior actually lives at), 8 `VaultProvider.fetch()` paths (success, custom mount, no-`#key` rejection, malformed-path rejection before any client call, not-found, missing extra, and the fresh-client-per-call behavior replacing what would otherwise have been a "cached and reused" assertion)
- Full suite **3013 passed, 22 skipped**; `ruff` and `mypy` clean

Not run against a real Vault server — no live call happens in this PR's code path; `hvac` is mocked via `sys.modules` injection (established pattern). The signature verification above closes the biggest gap that leaves, but a live check is still worth doing before Part 4 ships, batched with AWS/GCP.

## Remaining

Docs (4 of 4) — IAM/policy snippets for all three providers, plus the `sync-unit-tests`-style guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
