### PR TITLE
chore: point AGENTS.md at CLAUDE.md for Codex compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ cd drt
 uv sync --extra dev --extra bigquery
 ```
 
-**Note for Windows contributors:** `AGENTS.md` is a symlink to `CLAUDE.md` (kept in sync for Codex CLI). If `git clone` checks it out as a plain text file containing just `CLAUDE.md` instead of the real file contents, your Git isn't creating real symlinks — run `git config core.symlinks true` (may also require enabling Windows Developer Mode) and re-clone.
+**Note for Windows contributors:** `AGENTS.md` is a symlink to `CLAUDE.md` (kept in sync for Codex CLI). If `git clone` checks it out as a plain text file containing just `CLAUDE.md` instead of the real file contents, your Git isn't creating real symlinks. `git config core.symlinks true` only affects the clone you set it in, so re-cloning without setting it first reproduces the same problem — either run `git config --global core.symlinks true` (may also require enabling Windows Developer Mode) *before* cloning, or set it locally in this clone and re-check out the file: `git config core.symlinks true && git rm --cached AGENTS.md && git checkout AGENTS.md`.
 
 ### Pre-commit hooks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,8 @@ cd drt
 uv sync --extra dev --extra bigquery
 ```
 
+**Note for Windows contributors:** `AGENTS.md` is a symlink to `CLAUDE.md` (kept in sync for Codex CLI). If `git clone` checks it out as a plain text file containing just `CLAUDE.md` instead of the real file contents, your Git isn't creating real symlinks — run `git config core.symlinks true` (may also require enabling Windows Developer Mode) and re-clone.
+
 ### Pre-commit hooks
 
 You can optionally use [pre-commit](https://pre-commit.com/) to run ruff and mypy before each commit. This is optional — you can also use `make lint` and `make fmt` directly.


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` as a symlink to `CLAUDE.md` so Codex CLI picks up the same agent context as Claude Code, with `CLAUDE.md` remaining the single source of truth.

## Test plan
- [x] Verified `AGENTS.md` resolves to `CLAUDE.md` content locally
- [x] Confirmed no existing `AGENTS.md` was overwritten