### PR TITLE
fix(config): TTL on secret provider cache so drt serve picks up rotation (#929)

### DIFF
--- a/drt/config/secret_providers/base.py
+++ b/drt/config/secret_providers/base.py
@@ -11,6 +11,8 @@ level, matching the existing ``s3``/``bigquery`` destination pattern).
 from __future__ import annotations
 
 import json
+import os
+import time
 from dataclasses import dataclass
 from typing import Any, Protocol
 from urllib.parse import urlparse
@@ -113,19 +115,22 @@ class SecretProvider(Protocol):
 
 _registry: dict[str, SecretProvider] = {}
 
-# Process-lifetime cache, keyed by the full URI. A run commonly resolves the
-# same credential more than once (validation pass, connection test, the real
-# connection), and unlike an env var or secrets.toml lookup, a provider fetch
-# is a network call — so unlike those two steps, this one is worth not
-# repeating.
-#
-# Unbounded for the process's life: fine for a `drt run` invocation (exits in
-# seconds to minutes), but `drt serve` is a long-lived process that re-enters
-# this path on every triggered sync — a secret resolved once is held until
-# the server restarts, with no TTL and no re-fetch on rotation. Known gap,
-# not yet addressed — tracked as #929 — rather than assuming rotation is
-# picked up here.
-_value_cache: dict[str, str] = {}
+# Cache provider values by full URI for 300 seconds by default. A run commonly
+# resolves the same credential more than once (validation pass, connection
+# test, the real connection), and unlike an env var or secrets.toml lookup, a
+# provider fetch is a network call. The TTL lets long-lived `drt serve`
+# processes pick up secret rotation without repeating that call on every sync.
+# Set DRT_SECRET_CACHE_TTL_SECONDS to another duration, or to a non-positive
+# value to disable caching. It is read at lookup time so runtime environment
+# changes take effect without restarting the process.
+_value_cache: dict[str, tuple[str, float]] = {}
+
+_DEFAULT_CACHE_TTL_SECONDS = 300.0
+_CACHE_TTL_ENV_VAR = "DRT_SECRET_CACHE_TTL_SECONDS"
+
+
+def _cache_ttl_seconds() -> float:
+    return float(os.environ.get(_CACHE_TTL_ENV_VAR, _DEFAULT_CACHE_TTL_SECONDS))
 
 
 def register(scheme: str, provider: SecretProvider) -> None:
@@ -152,9 +157,21 @@ def resolve_provider_uri(uri: str) -> str | None:
     provider = _registry.get(scheme)
     if provider is None:
         return None
-    if uri not in _value_cache:
-        _value_cache[uri] = provider.fetch(parse_secret_uri(uri))
-    return _value_cache[uri]
+
+    ttl = _cache_ttl_seconds()
+    if ttl <= 0:
+        _value_cache.pop(uri, None)
+        return provider.fetch(parse_secret_uri(uri))
+
+    cached = _value_cache.get(uri)
+    if cached is not None:
+        value, fetched_at = cached
+        if time.monotonic() - fetched_at <= ttl:
+            return value
+
+    value = provider.fetch(parse_secret_uri(uri))
+    _value_cache[uri] = (value, time.monotonic())
+    return value
 
 
 def clear_cache() -> None:

--- a/drt/config/secret_providers/base.py
+++ b/drt/config/secret_providers/base.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 import time
 from dataclasses import dataclass
 from typing import Any, Protocol
@@ -124,6 +125,7 @@ _registry: dict[str, SecretProvider] = {}
 # value to disable caching. It is read at lookup time so runtime environment
 # changes take effect without restarting the process.
 _value_cache: dict[str, tuple[str, float]] = {}
+_value_cache_lock = threading.Lock()
 
 _DEFAULT_CACHE_TTL_SECONDS = 300.0
 _CACHE_TTL_ENV_VAR = "DRT_SECRET_CACHE_TTL_SECONDS"
@@ -169,9 +171,16 @@ def resolve_provider_uri(uri: str) -> str | None:
         if time.monotonic() - fetched_at <= ttl:
             return value
 
-    value = provider.fetch(parse_secret_uri(uri))
-    _value_cache[uri] = (value, time.monotonic())
-    return value
+    with _value_cache_lock:
+        cached = _value_cache.get(uri)
+        if cached is not None:
+            value, fetched_at = cached
+            if time.monotonic() - fetched_at <= ttl:
+                return value
+
+        value = provider.fetch(parse_secret_uri(uri))
+        _value_cache[uri] = (value, time.monotonic())
+        return value
 
 
 def clear_cache() -> None:

--- a/drt/config/secret_providers/vault.py
+++ b/drt/config/secret_providers/vault.py
@@ -62,11 +62,11 @@ class VaultProvider:
         # construction and never refreshes it, and Vault service tokens are
         # conventionally short-TTL — a cached client under a long-lived
         # process (`drt serve`) would go from "may resolve a rotated
-        # secret's stale value" (#929, already a known gap one layer up, in
-        # base._value_cache) to "every fetch fails outright" once the token
-        # expires, which is worse and specific to this leg. Construction
-        # itself is cheap (no network call — it just wraps connection
-        # params), so paying it every call is simpler than adding
+        # secret's stale value for up to DRT_SECRET_CACHE_TTL_SECONDS"
+        # (base._value_cache's TTL, #929) to "every fetch fails outright"
+        # once the token expires, which is worse and specific to this leg.
+        # Construction itself is cheap (no network call — it just wraps
+        # connection params), so paying it every call is simpler than adding
         # token-renewal handling here.
         try:
             import hvac  # type: ignore[import-untyped]

--- a/tests/unit/test_secret_providers.py
+++ b/tests/unit/test_secret_providers.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import threading
+import time
 from collections.abc import Iterator
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -194,6 +196,33 @@ class TestRegistry:
         monotonic.return_value = 400.1
         assert resolve_provider_uri(f"{scheme}://x") == "rotated-value"
         assert provider.fetch.call_count == 2
+
+    def test_concurrent_cache_misses_fetch_once(
+        self, _fake_provider: tuple[str, MagicMock]
+    ) -> None:
+        scheme, provider = _fake_provider
+        worker_count = 8
+        barrier = threading.Barrier(worker_count)
+        results: list[str | None] = [None] * worker_count
+
+        def slow_fetch(ref: SecretRef) -> str:
+            time.sleep(0.05)
+            return "shared-value"
+
+        def resolve(index: int) -> None:
+            barrier.wait()
+            results[index] = resolve_provider_uri(f"{scheme}://x")
+
+        provider.fetch.side_effect = slow_fetch
+        threads = [threading.Thread(target=resolve, args=(i,)) for i in range(worker_count)]
+
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert results == ["shared-value"] * worker_count
+        provider.fetch.assert_called_once_with(SecretRef(path="x", key=None))
 
     def test_non_positive_ttl_disables_caching(
         self, monkeypatch: pytest.MonkeyPatch, _fake_provider: tuple[str, MagicMock]

--- a/tests/unit/test_secret_providers.py
+++ b/tests/unit/test_secret_providers.py
@@ -26,7 +26,8 @@ from drt.config.secret_providers.vault import VaultProvider, _split_kv2_path
 
 
 @pytest.fixture(autouse=True)
-def _clear_provider_cache() -> Iterator[None]:
+def _clear_provider_cache(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.delenv("DRT_SECRET_CACHE_TTL_SECONDS", raising=False)
     clear_cache()
     yield
     clear_cache()
@@ -166,13 +167,44 @@ class TestRegistry:
         assert resolve_provider_uri(f"{scheme}://a/b#c") == "the-secret"
         provider.fetch.assert_called_once_with(SecretRef(path="a/b", key="c"))
 
-    def test_result_is_cached_across_calls(self, _fake_provider: tuple[str, MagicMock]) -> None:
+    def test_result_is_cached_before_ttl_expiry(
+        self, monkeypatch: pytest.MonkeyPatch, _fake_provider: tuple[str, MagicMock]
+    ) -> None:
         scheme, provider = _fake_provider
         provider.fetch.return_value = "cached-value"
+        monotonic = MagicMock(return_value=100.0)
+        monkeypatch.setattr(sp_base.time, "monotonic", monotonic)
+        monkeypatch.setenv("DRT_SECRET_CACHE_TTL_SECONDS", "300")
 
         assert resolve_provider_uri(f"{scheme}://x") == "cached-value"
+        monotonic.return_value = 399.0
         assert resolve_provider_uri(f"{scheme}://x") == "cached-value"
         provider.fetch.assert_called_once()
+
+    def test_result_is_refetched_after_ttl_expiry(
+        self, monkeypatch: pytest.MonkeyPatch, _fake_provider: tuple[str, MagicMock]
+    ) -> None:
+        scheme, provider = _fake_provider
+        provider.fetch.side_effect = ["initial-value", "rotated-value"]
+        monotonic = MagicMock(return_value=100.0)
+        monkeypatch.setattr(sp_base.time, "monotonic", monotonic)
+        monkeypatch.setenv("DRT_SECRET_CACHE_TTL_SECONDS", "300")
+
+        assert resolve_provider_uri(f"{scheme}://x") == "initial-value"
+        monotonic.return_value = 400.1
+        assert resolve_provider_uri(f"{scheme}://x") == "rotated-value"
+        assert provider.fetch.call_count == 2
+
+    def test_non_positive_ttl_disables_caching(
+        self, monkeypatch: pytest.MonkeyPatch, _fake_provider: tuple[str, MagicMock]
+    ) -> None:
+        scheme, provider = _fake_provider
+        provider.fetch.side_effect = ["initial-value", "rotated-value"]
+        monkeypatch.setenv("DRT_SECRET_CACHE_TTL_SECONDS", "0")
+
+        assert resolve_provider_uri(f"{scheme}://x") == "initial-value"
+        assert resolve_provider_uri(f"{scheme}://x") == "rotated-value"
+        assert provider.fetch.call_count == 2
 
     def test_different_uris_are_cached_independently(
         self, _fake_provider: tuple[str, MagicMock]


### PR DESCRIPTION
## Summary
- `_value_cache` in `drt/config/secret_providers/base.py` cached provider-resolved secrets (`aws-sm://`, `gcp-sm://`, `vault://`) for the process's full lifetime — fine for a short-lived `drt run`, but `drt serve` is a long-lived process that re-enters this path on every triggered sync, so a rotated secret was never picked up until restart. Contradicted #782's own "breaks rotation" problem statement.
- Cache entries now store `(value, fetched_at)`; a lookup past TTL refetches and overwrites the entry.
- Default TTL: 300s. Configurable via `DRT_SECRET_CACHE_TTL_SECONDS`, read lazily per lookup. Non-positive value disables caching entirely.
- Updated `vault.py`'s comment referencing the old "known gap, unbounded" framing to describe the now-bounded staleness window.

Closes #929.

**Stack:** 5th PR on the #782 stack, based on #934 (`feat/782-docs`). Merge order: #928 → #930 → #933 → #934 → this.

## Test plan
- [x] `pytest tests/unit/test_secret_providers.py -q` — 55 passed (added 2 new tests: post-TTL-expiry refetch, TTL=0 disables caching; extended the existing cache test to assert pre-expiry behavior)
- [x] `ruff check` — clean
- [x] `mypy drt/config/secret_providers/base.py` — clean