### PR TITLE
test(destinations): live Postgres multi-schema regression test via testcontainers (closes #939)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
         # snowflake is omitted — its tests use sys.modules injection so the
         # heavy snowflake-connector-python install would only slow CI.
         # bigquery / gcs / parquet remain opt-in for the same reason.
+        # dev supplies testcontainers, so local_sql_smoke runs against the
+        # runner's Docker daemon on every PR without secrets (#939).
         run: uv pip install --system -e ".[dev,mcp,duckdb,postgres,mysql,clickhouse,sqlserver]"
 
       - name: Dependency vulnerability scan (pip-audit)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,11 @@ make lint     # ruff + mypy
 make fmt      # ruff format + fix
 ```
 
+`local_sql_smoke` covers real Postgres/MySQL dialect behaviour with ephemeral
+testcontainers and runs in the normal PR test job; it skips when Docker is not
+available. ClickHouse and other local dialects are outside this initial scope.
+Cloud-warehouse tests remain under `dwh_smoke` and require `DRT_SMOKE_*` secrets.
+
 ## Current Status
 
 - **Unreleased (on `main`, since v0.8.4)** — nothing landed yet.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ dev = [
     "ruff>=0.4,<1",
     "types-pyyaml",
     "types-PyMySQL",
+    "testcontainers[postgres]>=4.0",
 ]
 
 [project.scripts]
@@ -133,5 +134,6 @@ disallow_untyped_decorators = false
 testpaths = ["tests"]
 markers = [
     "dwh_smoke: real cloud-warehouse smoke checks (Snowflake/Databricks/BigQuery); skip without DRT_SMOKE_* secrets (#674).",
+    "local_sql_smoke: real Postgres/MySQL via testcontainers-python; skip without Docker (#939).",
 ]
 asyncio_mode = "auto"

--- a/tests/integration/local_sql/conftest.py
+++ b/tests/integration/local_sql/conftest.py
@@ -1,0 +1,18 @@
+"""Docker availability gating for local SQL dialect smoke tests (#939)."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def require_docker() -> None:
+    """Skip when Docker's Python client is absent or its daemon is unreachable."""
+    docker = pytest.importorskip("docker")
+    try:
+        client = docker.from_env()
+        try:
+            client.ping()
+        finally:
+            client.close()
+    except docker.errors.DockerException as exc:
+        pytest.skip(f"Docker is not reachable: {exc}")

--- a/tests/integration/local_sql/test_postgres_scope_probe_smoke.py
+++ b/tests/integration/local_sql/test_postgres_scope_probe_smoke.py
@@ -1,0 +1,53 @@
+"""Live Postgres regressions that a mock cursor cannot prove (#939)."""
+
+from __future__ import annotations
+
+import pytest
+
+from drt.destinations.postgres import PostgresDestination
+
+from .conftest import require_docker
+
+pytestmark = pytest.mark.local_sql_smoke
+
+psycopg2 = pytest.importorskip("psycopg2")
+testcontainers_postgres = pytest.importorskip("testcontainers.postgres")
+
+
+def test_state_scope_columns_probe_follows_search_path() -> None:
+    """The unqualified probe must inspect the table Postgres actually resolves."""
+    require_docker()
+    postgres_container = testcontainers_postgres.PostgresContainer
+
+    with postgres_container("postgres:16-alpine", driver=None) as postgres:
+        conn = psycopg2.connect(postgres.get_connection_url())
+        try:
+            with conn.cursor() as cur:
+                cur.execute("CREATE SCHEMA legacy")
+                cur.execute("CREATE SCHEMA migrated")
+                cur.execute(
+                    "CREATE TABLE legacy._drt_synced_keys ("
+                    "sync_name VARCHAR(255) NOT NULL, "
+                    "key_hash CHAR(64) NOT NULL, "
+                    "key_json TEXT NOT NULL, "
+                    "PRIMARY KEY (sync_name, key_hash))"
+                )
+                cur.execute(
+                    "CREATE TABLE migrated._drt_synced_keys "
+                    "(LIKE legacy._drt_synced_keys INCLUDING ALL)"
+                )
+                cur.execute(
+                    "ALTER TABLE migrated._drt_synced_keys "
+                    "ADD COLUMN scope_spec TEXT, ADD COLUMN scope_key TEXT"
+                )
+
+                destination = PostgresDestination()
+                raw = "_drt_synced_keys"
+
+                cur.execute("SET search_path TO legacy, migrated")
+                assert destination._state_scope_columns_exist(cur, None, raw) is False
+
+                cur.execute("SET search_path TO migrated, legacy")
+                assert destination._state_scope_columns_exist(cur, None, raw) is True
+        finally:
+            conn.close()


### PR DESCRIPTION
Closes #939.

## Why

The mock-based regression test added in #904 for `_state_scope_columns_exist` proves the SQL text/params changed shape, but can't prove the multi-schema `search_path` resolution the fix depends on is actually correct — a mock accepts any query. Flagged by a Codex adversarial review on #904's fix commit.

This has already been a real, shipped problem once: #908 (Databricks composite-key mirror DELETE, rejected by Delta but accepted by every mock) shipped in 4 releases before being caught in review, not by tests.

## What this adds

- `testcontainers[postgres]` as a dev dependency
- `local_sql_smoke` pytest marker — real Postgres via testcontainers, **runs on every PR** (not nightly-only like `dwh_smoke`, since this needs no secrets and costs nothing beyond Docker, already on `ubuntu-latest`). Skips cleanly without Docker/testcontainers.
- One test: two schemas containing `_drt_synced_keys`, only one migrated with `scope_spec`/`scope_key`, `search_path` flipped both ways, asserting `_state_scope_columns_exist` resolves the schema Postgres actually would.

## Verification

- Ran against the current fix: passes.
- Temporarily reverted `_state_scope_columns_exist` to the pre-#904 `information_schema.columns` query with no schema filter: **fails**, exactly as expected — confirms this test actually catches the bug class it exists to catch, not just that some SQL text changed.
- Full suite: `2937 passed, 4 skipped` (dwh_smoke deselected).
- `ruff` + `mypy` clean.

## Stack

Based on `perf/890-scope-aware-sql-diff` (#904) since the fix under test only exists there — this PR is additive on top, no duplicate changes to `postgres.py`.

🤖 Implemented via Codex (codex-companion), verified end-to-end by Claude — Codex's own sandbox has no Docker/network access, so it could reason about but not actually run the live container.