### PR TITLE
feat(cli): state:modified / state:new selector methods (#772, 2 of 4)

### DIFF
--- a/drt/cli/_selection.py
+++ b/drt/cli/_selection.py
@@ -5,12 +5,16 @@ Selector grammar (per token):
 - ``*`` / ``all``            — every sync (explicit sentinel, back-compat)
 - ``tag:<pattern>``          — syncs with a tag matching the pattern
 - ``destination:<pattern>``  — syncs whose destination ``type`` matches
+- ``state:modified`` / ``state:new`` — syncs changed or added since a baseline
 - anything else              — the sync name (glob patterns supported)
 
 Patterns use ``fnmatch`` semantics (``*``, ``?``, ``[seq]``), so exact names
 keep working unchanged. Repeated ``--select`` values union; ``--exclude``
 subtracts with the same grammar. Definition order is preserved and results
 are deduplicated.
+
+State selectors require the caller to supply a pre-computed baseline diff;
+using one without a baseline is an error.
 
 ``source:`` is deliberately **not** a method: syncs share the project
 profile (one source per run), so there is nothing per-sync to select on.
@@ -25,9 +29,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from drt.cli._state_selection import StateDiff
     from drt.config.models import SyncConfig
 
-_METHODS = ("tag", "destination")
+_METHODS = ("tag", "destination", "state")
+_STATE_SELECTORS = ("state:modified", "state:new")
 
 
 class SelectionError(ValueError):
@@ -39,7 +45,7 @@ def is_glob(token: str) -> bool:
     return any(ch in token for ch in "*?[")
 
 
-def matches(sync: SyncConfig, token: str) -> bool:
+def matches(sync: SyncConfig, token: str, *, state_diff: StateDiff | None = None) -> bool:
     """Does one selector token match one sync?"""
     if token in ("*", "all"):
         return True
@@ -49,6 +55,19 @@ def matches(sync: SyncConfig, token: str) -> bool:
     if token.startswith("destination:"):
         pattern = token[len("destination:") :]
         return fnmatchcase(sync.destination.type, pattern)
+    if token.startswith("state:"):
+        if token not in _STATE_SELECTORS:
+            raise SelectionError(
+                f"Unknown state selector '{token}'. Available state selectors: "
+                + ", ".join(_STATE_SELECTORS)
+                + "."
+            )
+        if state_diff is None:
+            raise SelectionError(
+                f"Selector '{token}' requires a baseline manifest to compare against."
+            )
+        names = state_diff.new if token == "state:new" else state_diff.modified
+        return sync.name in names
     if ":" in token:
         method = token.split(":", 1)[0]
         raise SelectionError(
@@ -64,6 +83,10 @@ def _no_match_message(token: str) -> str:
         return f"No syncs with tag '{token[len('tag:'):]}' found."
     if token.startswith("destination:"):
         return f"No syncs with destination '{token[len('destination:'):]}' found."
+    if token == "state:modified":
+        return "No modified syncs found relative to the baseline manifest."
+    if token == "state:new":
+        return "No new syncs found relative to the baseline manifest."
     if is_glob(token):
         return f"No syncs matching '{token}' found."
     return f"No sync named '{token}' found."
@@ -73,6 +96,8 @@ def select_syncs(
     syncs: Sequence[SyncConfig],
     select: Sequence[str] | None,
     exclude: Sequence[str] | None = None,
+    *,
+    state_diff: StateDiff | None = None,
 ) -> list[SyncConfig]:
     """Resolve ``--select`` / ``--exclude`` tokens against the sync list.
 
@@ -84,7 +109,7 @@ def select_syncs(
     if select:
         matched_names: set[str] = set()
         for token in select:
-            hits = [s for s in syncs if matches(s, token)]
+            hits = [s for s in syncs if matches(s, token, state_diff=state_diff)]
             if not hits:
                 raise SelectionError(_no_match_message(token))
             matched_names.update(s.name for s in hits)
@@ -93,16 +118,17 @@ def select_syncs(
         selected = list(syncs)
 
     for token in exclude or ():
-        selected = [s for s in selected if not matches(s, token)]
+        selected = [s for s in selected if not matches(s, token, state_diff=state_diff)]
     return selected
 
 
 def complete_selector(incomplete: str) -> list[str]:
     """Best-effort shell completion for --select/--exclude values.
 
-    Loads the project's syncs from the current directory; any failure
-    (not in a project, YAML error) silently completes nothing — completion
-    must never crash the shell.
+    Loads the project's syncs from the current directory; any failure (such as
+    a YAML error) silently completes nothing — completion must never crash the
+    shell. Literal state selectors remain available when the project has no
+    sync definitions because they do not depend on project contents.
     """
     try:
         from drt.config.parser import load_syncs
@@ -113,4 +139,5 @@ def complete_selector(incomplete: str) -> list[str]:
     values: list[str] = [s.name for s in syncs]
     values += sorted({f"tag:{t}" for s in syncs for t in getattr(s, "tags", [])})
     values += sorted({f"destination:{s.destination.type}" for s in syncs})
+    values += list(_STATE_SELECTORS)
     return [v for v in values if v.startswith(incomplete)]

--- a/drt/cli/_state_selection.py
+++ b/drt/cli/_state_selection.py
@@ -1,0 +1,81 @@
+"""Baseline manifest comparison for ``state:`` sync selectors (#772)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from drt.cli._selection import SelectionError
+from drt.config.fingerprint import sync_fingerprints
+from drt.docs.manifest import Manifest
+
+if TYPE_CHECKING:
+    from drt.config.models import SyncConfig
+
+logger = logging.getLogger(__name__)
+
+# The manifest schema version config_hash was introduced at (ADR 0006, #772).
+# Deliberately NOT drt.docs.manifest.SCHEMA_VERSION: that constant moves
+# forward for any future additive change, but a baseline only needs to be at
+# least this old version to be comparable — pinning to the live SCHEMA_VERSION
+# would start rejecting perfectly good v3 baselines the day schema v4 ships
+# for something unrelated to config_hash.
+_MIN_SCHEMA_VERSION_WITH_CONFIG_HASH = 3
+
+
+@dataclass(frozen=True)
+class StateDiff:
+    """Current sync names added or changed relative to a baseline manifest."""
+
+    new: frozenset[str]
+    modified: frozenset[str]
+
+
+def load_state_diff(
+    baseline_path: Path, current_syncs: Sequence[SyncConfig], project_dir: Path
+) -> StateDiff:
+    """Load one baseline manifest and compare it with the current sync tree."""
+    current_names = frozenset(sync.name for sync in current_syncs)
+    try:
+        data: Any = json.loads(baseline_path.read_text(encoding="utf-8"))
+        manifest = Manifest.from_dict(data)
+    except Exception as exc:  # noqa: BLE001 — a missing/bad first baseline is normal
+        logger.warning(
+            "Could not load baseline manifest %s (%s); treating every current sync as new.",
+            baseline_path,
+            exc,
+        )
+        return StateDiff(new=current_names, modified=current_names)
+
+    if manifest.schema_version < _MIN_SCHEMA_VERSION_WITH_CONFIG_HASH:
+        raise SelectionError(
+            f"Baseline manifest schema version {manifest.schema_version} predates config_hash "
+            f"support (added in schema version {_MIN_SCHEMA_VERSION_WITH_CONFIG_HASH}); "
+            "regenerate the baseline with a current drt version."
+        )
+
+    baseline_hashes = {sync.name: sync.config_hash for sync in manifest.syncs}
+    current_hashes = sync_fingerprints(project_dir)
+    new: set[str] = set()
+    modified: set[str] = set()
+
+    # Iterate only current syncs. A baseline-only name represents a deleted sync,
+    # which cannot be selected because there is no current definition left to run.
+    for name in current_names:
+        if name not in baseline_hashes:
+            new.add(name)
+            modified.add(name)
+            continue
+
+        baseline_hash = baseline_hashes[name]
+        current_hash = current_hashes.get(name)
+        # Missing hashes are uncertainty, never evidence of equality: selecting
+        # an extra sync is safer than silently skipping a possibly changed one.
+        if baseline_hash is None or current_hash is None or baseline_hash != current_hash:
+            modified.add(name)
+
+    return StateDiff(new=frozenset(new), modified=frozenset(modified))

--- a/drt/cli/_state_selection.py
+++ b/drt/cli/_state_selection.py
@@ -51,6 +51,20 @@ def load_state_diff(
         )
         return StateDiff(new=current_names, modified=current_names)
 
+    # Manifest.from_dict() is a plain dataclass loader with no type
+    # validation -- a hand-edited or corrupted baseline can carry a
+    # non-numeric schema_version (a string, null) that would otherwise raise
+    # a raw, uncaught TypeError from the comparison below. Treat that the
+    # same as any other malformed baseline rather than crashing.
+    if not isinstance(manifest.schema_version, int):
+        logger.warning(
+            "Baseline manifest %s has a malformed schema_version (%r); "
+            "treating every current sync as new.",
+            baseline_path,
+            manifest.schema_version,
+        )
+        return StateDiff(new=current_names, modified=current_names)
+
     if manifest.schema_version < _MIN_SCHEMA_VERSION_WITH_CONFIG_HASH:
         raise SelectionError(
             f"Baseline manifest schema version {manifest.schema_version} predates config_hash "

--- a/tests/unit/test_cli_selection.py
+++ b/tests/unit/test_cli_selection.py
@@ -1,8 +1,9 @@
 """Tests for the shared selection resolver (#771).
 
 Grammar: bare name (glob-capable), tag:<pattern>, destination:<type>,
-"*"/"all"; repeated --select unions, --exclude subtracts, definition order
-is preserved, and a select token matching nothing is an error.
+state:modified/state:new, "*"/"all"; repeated --select unions, --exclude
+subtracts, definition order is preserved, and a select token matching nothing
+is an error.
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ from drt.cli._selection import (
     matches,
     select_syncs,
 )
+from drt.cli._state_selection import StateDiff
 from drt.config.models import SyncConfig
 
 
@@ -73,14 +75,45 @@ def test_destination_selector(syncs: list[SyncConfig]) -> None:
     ]
 
 
+def test_state_selectors(syncs: list[SyncConfig]) -> None:
+    state_diff = StateDiff(
+        new=frozenset({"events_to_rest"}),
+        modified=frozenset({"users_backfill", "events_to_rest"}),
+    )
+
+    assert [
+        s.name for s in select_syncs(syncs, ["state:new"], state_diff=state_diff)
+    ] == ["events_to_rest"]
+    assert [
+        s.name for s in select_syncs(syncs, ["state:modified"], state_diff=state_diff)
+    ] == ["users_backfill", "events_to_rest"]
+
+
 def test_star_and_all_sentinels(syncs: list[SyncConfig]) -> None:
     assert select_syncs(syncs, ["*"]) == syncs
     assert select_syncs(syncs, ["all"]) == syncs
 
 
 def test_unknown_method_errors(syncs: list[SyncConfig]) -> None:
-    with pytest.raises(SelectionError, match="Unknown selector method 'source:'"):
+    with pytest.raises(SelectionError, match="Unknown selector method 'source:'") as exc_info:
         select_syncs(syncs, ["source:bigquery"])
+    assert "state:" in str(exc_info.value)
+
+
+def test_unknown_state_selector_has_distinct_error(syncs: list[SyncConfig]) -> None:
+    with pytest.raises(SelectionError, match="Unknown state selector 'state:unmodified'") as exc:
+        select_syncs(syncs, ["state:unmodified"])
+    assert "state:modified" in str(exc.value)
+    assert "state:new" in str(exc.value)
+    assert "Unknown selector method" not in str(exc.value)
+
+
+@pytest.mark.parametrize("token", ["state:modified", "state:new"])
+def test_state_selector_without_diff_requires_baseline(
+    syncs: list[SyncConfig], token: str
+) -> None:
+    with pytest.raises(SelectionError, match="requires a baseline manifest"):
+        select_syncs(syncs, [token])
 
 
 # ---------------------------------------------------------------------------
@@ -115,6 +148,15 @@ def test_exclude_can_empty_the_selection(syncs: list[SyncConfig]) -> None:
     assert select_syncs(syncs, ["tag:ads"], exclude=["*"]) == []
 
 
+def test_state_selector_is_forwarded_to_exclude(syncs: list[SyncConfig]) -> None:
+    state_diff = StateDiff(
+        new=frozenset(),
+        modified=frozenset({"users_to_hubspot", "events_to_rest"}),
+    )
+    selected = select_syncs(syncs, None, exclude=["state:modified"], state_diff=state_diff)
+    assert [s.name for s in selected] == ["users_backfill"]
+
+
 # ---------------------------------------------------------------------------
 # no-match errors (message compatibility with the pre-#771 CLI)
 # ---------------------------------------------------------------------------
@@ -140,6 +182,19 @@ def test_no_match_destination_message(syncs: list[SyncConfig]) -> None:
         select_syncs(syncs, ["destination:slack"])
 
 
+@pytest.mark.parametrize(
+    ("token", "message"),
+    [
+        ("state:modified", "No modified syncs found relative to the baseline manifest."),
+        ("state:new", "No new syncs found relative to the baseline manifest."),
+    ],
+)
+def test_no_match_state_message(syncs: list[SyncConfig], token: str, message: str) -> None:
+    empty = StateDiff(new=frozenset(), modified=frozenset())
+    with pytest.raises(SelectionError, match=message):
+        select_syncs(syncs, [token], state_diff=empty)
+
+
 # ---------------------------------------------------------------------------
 # matches() direct + completion
 # ---------------------------------------------------------------------------
@@ -152,10 +207,28 @@ def test_matches_direct(syncs: list[SyncConfig]) -> None:
     assert not matches(syncs[2], "destination:hubspot")
 
 
-def test_complete_selector_outside_project_returns_empty(
+def test_matches_state_direct(syncs: list[SyncConfig]) -> None:
+    state_diff = StateDiff(
+        new=frozenset({"events_to_rest"}),
+        modified=frozenset({"users_to_hubspot", "events_to_rest"}),
+    )
+    assert matches(syncs[2], "state:new", state_diff=state_diff)
+    assert not matches(syncs[0], "state:new", state_diff=state_diff)
+    assert matches(syncs[0], "state:modified", state_diff=state_diff)
+
+
+def test_complete_selector_without_syncs_still_lists_state_selectors(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.chdir(tmp_path)
+    assert complete_selector("") == ["state:modified", "state:new"]
+
+
+def test_complete_selector_load_failure_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(_path) -> None:
+        raise ValueError("bad YAML")
+
+    monkeypatch.setattr("drt.config.parser.load_syncs", fail)
     assert complete_selector("") == []
 
 
@@ -175,4 +248,7 @@ def test_complete_selector_lists_names_tags_destinations(
     assert "users_sync" in values
     assert "tag:crm" in values
     assert "destination:rest_api" in values
+    assert "state:modified" in values
+    assert "state:new" in values
     assert complete_selector("tag:") == ["tag:crm"]
+    assert complete_selector("state:") == ["state:modified", "state:new"]

--- a/tests/unit/test_state_selection.py
+++ b/tests/unit/test_state_selection.py
@@ -1,0 +1,216 @@
+"""Tests for baseline comparison backing ``state:`` selectors (#772)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from drt.cli._selection import SelectionError
+from drt.cli._state_selection import StateDiff, load_state_diff
+from drt.config.fingerprint import sync_fingerprints
+from drt.config.models import SyncConfig
+from drt.docs.manifest import SCHEMA_VERSION, Manifest, Sync
+
+# Deliberately hardcoded rather than imported from _state_selection: this
+# fixes the "config_hash exists as of schema v3" fact independently of both
+# the module under test and the live SCHEMA_VERSION constant, so a bug that
+# quietly re-coupled the version check to the moving SCHEMA_VERSION constant
+# (rejecting a perfectly good baseline once schema v4 ships for something
+# unrelated to config_hash) fails this test even if SCHEMA_VERSION itself
+# has moved past 3 by the time this runs.
+_SCHEMA_VERSION_WITH_CONFIG_HASH = 3
+
+
+def _sync(name: str) -> SyncConfig:
+    return SyncConfig.model_validate(
+        {
+            "name": name,
+            "model": "ref('source_table')",
+            "destination": {"type": "rest_api", "url": "https://example.com"},
+            "sync": {"mode": "full"},
+        }
+    )
+
+
+def _write_sync(project_dir: Path, name: str) -> None:
+    syncs_dir = project_dir / "syncs"
+    syncs_dir.mkdir(exist_ok=True)
+    (syncs_dir / f"{name}.yml").write_text(
+        f"name: {name}\n"
+        "model: ref('source_table')\n"
+        "destination: {type: rest_api, url: 'https://example.com'}\n"
+        "sync: {mode: full}\n"
+    )
+
+
+def _manifest_sync(name: str, config_hash: str | None) -> Sync:
+    return Sync(
+        name=name,
+        source="default",
+        destination="rest_api",
+        mode="full",
+        config_hash=config_hash,
+    )
+
+
+def _write_manifest(
+    path: Path, syncs: list[Sync] | None = None, *, schema_version: int = SCHEMA_VERSION
+) -> None:
+    manifest = Manifest(
+        schema_version=schema_version,
+        drt_version="0.8.4",
+        syncs=syncs or [],
+    )
+    path.write_text(json.dumps(manifest.to_dict()))
+
+
+def _assert_everything_new(diff: StateDiff, names: set[str]) -> None:
+    expected = frozenset(names)
+    assert diff.new == expected
+    assert diff.modified == expected
+
+
+def test_missing_baseline_warns_and_treats_everything_as_new(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    current = [_sync("users"), _sync("events")]
+
+    with caplog.at_level(logging.WARNING, logger="drt.cli._state_selection"):
+        diff = load_state_diff(tmp_path / "missing.json", current, tmp_path)
+
+    _assert_everything_new(diff, {"users", "events"})
+    assert "treating every current sync as new" in caplog.text
+
+
+def test_unreadable_baseline_warns_and_treats_everything_as_new(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    baseline = tmp_path / "baseline.json"
+    baseline.mkdir()
+
+    with caplog.at_level(logging.WARNING, logger="drt.cli._state_selection"):
+        diff = load_state_diff(baseline, [_sync("users")], tmp_path)
+
+    _assert_everything_new(diff, {"users"})
+    assert "Could not load baseline manifest" in caplog.text
+
+
+@pytest.mark.parametrize("contents", ["{bad json", "[]"])
+def test_unparseable_baseline_warns_and_treats_everything_as_new(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, contents: str
+) -> None:
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(contents)
+
+    with caplog.at_level(logging.WARNING, logger="drt.cli._state_selection"):
+        diff = load_state_diff(baseline, [_sync("users")], tmp_path)
+
+    _assert_everything_new(diff, {"users"})
+    assert "Could not load baseline manifest" in caplog.text
+
+
+def test_old_schema_baseline_raises_clear_selection_error(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.json"
+    _write_manifest(baseline, schema_version=2)
+
+    with pytest.raises(SelectionError, match="schema version 2") as exc_info:
+        load_state_diff(baseline, [_sync("users")], tmp_path)
+
+    assert "predates config_hash" in str(exc_info.value)
+    assert "regenerate" in str(exc_info.value)
+
+
+def test_baseline_at_or_above_config_hash_schema_version_is_accepted(tmp_path: Path) -> None:
+    """A baseline should stay valid even if drt's live SCHEMA_VERSION moves on.
+
+    Regression guard for comparing against the *live* SCHEMA_VERSION constant
+    instead of a fixed "config_hash exists as of this version" threshold — that
+    would start rejecting today's perfectly comparable v3 baselines the moment
+    schema v4 ships for anything unrelated to config_hash.
+    """
+    _write_sync(tmp_path, "users")
+    current_hash = sync_fingerprints(tmp_path)["users"]
+
+    for schema_version in (_SCHEMA_VERSION_WITH_CONFIG_HASH, _SCHEMA_VERSION_WITH_CONFIG_HASH + 5):
+        baseline = tmp_path / f"baseline-{schema_version}.json"
+        _write_manifest(
+            baseline, [_manifest_sync("users", current_hash)], schema_version=schema_version
+        )
+
+        diff = load_state_diff(baseline, [_sync("users")], tmp_path)
+
+        assert diff == StateDiff(new=frozenset(), modified=frozenset())
+
+
+def test_new_sync_is_new_and_modified(tmp_path: Path) -> None:
+    _write_sync(tmp_path, "users")
+    baseline = tmp_path / "baseline.json"
+    _write_manifest(baseline)
+
+    diff = load_state_diff(baseline, [_sync("users")], tmp_path)
+
+    assert diff.new == frozenset({"users"})
+    assert diff.modified == frozenset({"users"})
+
+
+def test_changed_hash_sync_is_modified_but_not_new(tmp_path: Path) -> None:
+    _write_sync(tmp_path, "users")
+    baseline = tmp_path / "baseline.json"
+    _write_manifest(baseline, [_manifest_sync("users", "old-hash")])
+
+    diff = load_state_diff(baseline, [_sync("users")], tmp_path)
+
+    assert diff.new == frozenset()
+    assert diff.modified == frozenset({"users"})
+
+
+def test_unchanged_sync_is_in_neither_set(tmp_path: Path) -> None:
+    _write_sync(tmp_path, "users")
+    current_hash = sync_fingerprints(tmp_path)["users"]
+    baseline = tmp_path / "baseline.json"
+    _write_manifest(baseline, [_manifest_sync("users", current_hash)])
+
+    diff = load_state_diff(baseline, [_sync("users")], tmp_path)
+
+    assert diff == StateDiff(new=frozenset(), modified=frozenset())
+
+
+def test_none_baseline_hash_is_modified_not_unchanged(tmp_path: Path) -> None:
+    _write_sync(tmp_path, "users")
+    baseline = tmp_path / "baseline.json"
+    _write_manifest(baseline, [_manifest_sync("users", None)])
+
+    diff = load_state_diff(baseline, [_sync("users")], tmp_path)
+
+    assert diff.new == frozenset()
+    assert diff.modified == frozenset({"users"})
+
+
+def test_missing_current_hash_is_modified_not_unchanged(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.json"
+    _write_manifest(baseline, [_manifest_sync("users", "known-baseline-hash")])
+
+    diff = load_state_diff(baseline, [_sync("users")], tmp_path)
+
+    assert diff.new == frozenset()
+    assert diff.modified == frozenset({"users"})
+
+
+def test_deleted_baseline_sync_is_ignored(tmp_path: Path) -> None:
+    _write_sync(tmp_path, "users")
+    current_hash = sync_fingerprints(tmp_path)["users"]
+    baseline = tmp_path / "baseline.json"
+    _write_manifest(
+        baseline,
+        [
+            _manifest_sync("users", current_hash),
+            _manifest_sync("deleted_sync", "old-hash"),
+        ],
+    )
+
+    diff = load_state_diff(baseline, [_sync("users")], tmp_path)
+
+    assert diff == StateDiff(new=frozenset(), modified=frozenset())

--- a/tests/unit/test_state_selection.py
+++ b/tests/unit/test_state_selection.py
@@ -112,6 +112,25 @@ def test_unparseable_baseline_warns_and_treats_everything_as_new(
     assert "Could not load baseline manifest" in caplog.text
 
 
+@pytest.mark.parametrize("bad_version", ['"3"', "null"])
+def test_malformed_schema_version_warns_and_treats_everything_as_new(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, bad_version: str
+) -> None:
+    """Manifest.from_dict() has no type validation, so a hand-edited or
+    corrupted baseline can carry a non-numeric schema_version. That must not
+    crash with a raw TypeError out of the < comparison."""
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        f'{{"schema_version": {bad_version}, "drt_version": "0.8.4", "syncs": []}}'
+    )
+
+    with caplog.at_level(logging.WARNING, logger="drt.cli._state_selection"):
+        diff = load_state_diff(baseline, [_sync("users")], tmp_path)
+
+    _assert_everything_new(diff, {"users"})
+    assert "malformed schema_version" in caplog.text
+
+
 def test_old_schema_baseline_raises_clear_selection_error(tmp_path: Path) -> None:
     baseline = tmp_path / "baseline.json"
     _write_manifest(baseline, schema_version=2)


### PR DESCRIPTION
## Summary

Task 3 of #772's `state:modified` selector, stacked on #950 (Task 2,
manifest v3 / `config_hash`).

- New `drt/cli/_state_selection.py`: `StateDiff(new, modified)` +
  `load_state_diff(baseline_path, current_syncs, project_dir)` — diffs the
  current tree's fingerprints against a baseline manifest's `config_hash`.
- `drt/cli/_selection.py`: `matches()`/`select_syncs()` gain an optional
  `state_diff` keyword param (default `None`), so every existing caller
  (`run`/`build`/`test`/`validate`, all via `select_syncs`) is unaffected
  until Task 4 wires the actual `--state` flag on top of this.
- `state:modified`/`state:new` added to `_METHODS`, `_no_match_message`,
  and `complete_selector`.

**Semantics** (per `docs/plans/2026-08-03-772-state-modified-selector.md`
Task 3):
- Missing/unreadable/unparseable baseline → warning, everything is new
  (the normal first-CI-run case, not an error).
- Baseline older than schema v3 (predates `config_hash`) → raises clearly.
- A sync absent from the baseline → `new` (and therefore `modified` —
  dbt's own precedent: a new sync is trivially "modified").
- A missing hash on either side (baseline `None`, or current fingerprint
  lookup miss) never reads as "unchanged" — only ever "changed". A false
  "changed" costs one extra dry-run; a false "unchanged" silently skips
  real work in CI.
- A sync present only in the baseline (deleted) is ignored — nothing to
  select or run.

## Judgment call

Codex's first pass compared the baseline's `schema_version` against the
**live** `drt.docs.manifest.SCHEMA_VERSION` constant. That's a latent bug:
the day schema bumps to v4 for anything unrelated to `config_hash`, every
still-perfectly-comparable v3 baseline would start being rejected, since
`3 < 4`. Fixed by decoupling the check into a fixed
`_MIN_SCHEMA_VERSION_WITH_CONFIG_HASH = 3` constant in
`_state_selection.py`, with a comment explaining why it must not track the
live constant, plus a regression test
(`test_baseline_at_or_above_config_hash_schema_version_is_accepted`) using
a schema version *higher* than the current live one so the test doesn't
pass by coincidence once `SCHEMA_VERSION` moves.

No CHANGELOG entry yet — `state:modified`/`state:new` aren't reachable
from the CLI until Task 4 wires `--state`, so the entry lands with that
PR (or Task 5) describing the whole usable feature at once rather than
fragmenting it across not-yet-usable plumbing PRs.

## Test plan

- [x] `pytest -q -m "not dwh_smoke and not local_sql_smoke and not object_store_smoke"` — 3203 passed, 4 skipped, 21 deselected (re-run independently)
- [x] `drt/cli/_selection.py` 100%, `drt/cli/_state_selection.py` 100%
- [x] `ruff check drt tests` / `mypy drt` — clean
- [x] Confirmed every existing `matches(`/`select_syncs(` call site
      (`run.py`, `build.py`, `test.py`, `validate.py`) compiles and behaves
      unchanged with the new optional parameter defaulted

🤖 Generated with [Claude Code](https://claude.com/claude-code)