### PR TITLE
docs: state read-only-source access as an explicit drt differentiator

### DIFF
--- a/docs/guides/comparison.md
+++ b/docs/guides/comparison.md
@@ -43,6 +43,7 @@ All three are open-source, CLI-first, YAML-configured, and MCP-enabled. Together
 - You work with **AI coding tools** (Claude, Cursor) and want your reverse ETL layer to be accessible via MCP
 - You need **10-30 destinations** rather than 200+ — and the ones you need are covered
 - You prefer to **own your data pipeline** end-to-end
+- You want to grant **read-only access to your source warehouse** — drt's supported incremental strategy (cursor-based, reading a column like `updated_at`) never needs to write into the source. Nothing in your source warehouse is drt-managed, drt-created, or drt-owned.
 
 **drt is not the right fit when:**
 
@@ -50,6 +51,32 @@ All three are open-source, CLI-first, YAML-configured, and MCP-enabled. Together
 - You need a **managed, no-ops solution** — drt requires you to host and maintain the pipeline
 - Your team is **non-technical** and prefers a GUI over YAML/CLI
 - You need **built-in scheduling and monitoring** — drt relies on external orchestrators (Dagster, Airflow, cron)
+
+---
+
+## Read-only source access, by design
+
+Reverse ETL tools generally need read access to the warehouse. Some also
+write into it — a staging table (or a whole managed schema) to track which
+rows they've already synced, so re-runs can diff efficiently instead of
+re-scanning everything. That write access is a real trust decision, and
+it isn't always reversible: Hightouch's high-performance "Lightning" sync
+engine requires warehouse write and, per Hightouch's own documentation,
+cannot be switched back to their read-only "Basic" engine once enabled.
+Segment Reverse ETL requires a managed `_segment_reverse_etl` schema with
+read and write for the same reason. (Not every vendor documents this
+publicly — we only state what we could verify.)
+
+drt's cursor-based incremental sync (`mode: incremental` +
+`cursor_field`) never requires write access to the source — it's the
+permanent, first-class strategy, not a stripped-down fallback waiting to
+be superseded. drt's design deliberately leaves room for a
+warehouse-write-requiring strategy later, as an *opt-in, separately-scoped*
+addition for teams that want it — not a replacement, and not scheduled
+work today. Whenever it lands, switching between the two will stay a
+config change, not a one-way door. See
+[ADR 0005](../adr/0005-state-location-and-write-grants.md) for the full
+reasoning.
 
 ---
 

--- a/docs/guides/comparison.md
+++ b/docs/guides/comparison.md
@@ -43,7 +43,7 @@ All three are open-source, CLI-first, YAML-configured, and MCP-enabled. Together
 - You work with **AI coding tools** (Claude, Cursor) and want your reverse ETL layer to be accessible via MCP
 - You need **10-30 destinations** rather than 200+ — and the ones you need are covered
 - You prefer to **own your data pipeline** end-to-end
-- You want to grant **read-only access to your source warehouse** — drt's supported incremental strategy (cursor-based, reading a column like `updated_at`) never needs to write into the source. Nothing in your source warehouse is drt-managed, drt-created, or drt-owned.
+- You want to grant **read-only access to your source warehouse** — drt's supported incremental strategy (cursor-based, reading a column like `updated_at`) never needs to write into the source *to read from it*. (One opt-in exception: `sync.watermark.storage: bigquery` — see below.)
 
 **drt is not the right fit when:**
 
@@ -68,15 +68,25 @@ read and write for the same reason. (Not every vendor documents this
 publicly — we only state what we could verify.)
 
 drt's cursor-based incremental sync (`mode: incremental` +
-`cursor_field`) never requires write access to the source — it's the
-permanent, first-class strategy, not a stripped-down fallback waiting to
-be superseded. drt's design deliberately leaves room for a
-warehouse-write-requiring strategy later, as an *opt-in, separately-scoped*
-addition for teams that want it — not a replacement, and not scheduled
-work today. Whenever it lands, switching between the two will stay a
-config change, not a one-way door. See
+`cursor_field`) never requires write access to the source to *read* from
+it — it's the permanent, first-class strategy, not a stripped-down
+fallback waiting to be superseded. drt's design deliberately leaves room
+for a warehouse-write-requiring strategy later, as an *opt-in,
+separately-scoped* addition for teams that want it — not a replacement,
+and not scheduled work today. Whenever it lands, switching between the
+two will stay a config change, not a one-way door. See
 [ADR 0005](../adr/0005-state-location-and-write-grants.md) for the full
 reasoning.
+
+**One existing, unrelated exception worth naming honestly:** the older,
+separately-configured `sync.watermark.storage: bigquery` option (an
+alternative to the default local/GCS/S3 watermark storage, unrelated to
+this ADR) creates and writes a small `_drt_watermarks` tracking table.
+That write only touches your *source* warehouse if you point
+`watermark.project`/`watermark.dataset` at the same project/dataset your
+source reads from — a choice you make, not drt's default. Use `local`,
+`gcs`, or `s3` watermark storage (or a separate BigQuery
+project/dataset) to keep the source warehouse completely untouched.
 
 ---
 


### PR DESCRIPTION
Part of #922.

## Summary

#922 exists to protect two ADR 0005 design commitments as tiered features land: (1) cursor-based incremental staying drt's permanent, first-class, read-only-source strategy — not a legacy fallback #755's diff-based incremental supersedes — and (2) tier changes staying reversible config changes, never a one-way door.

Checking both against what's actually shipped:

- **Reversibility (#756)**: already verified true and documented. `docs/guides/remote-state.md` (landed with #756) is explicit that switching `state.backend` is a config change plus an optional, clearly-documented `gsutil rsync`/`aws s3 sync` step — never a vendor-control-plane lock-in. Nothing to fix here.
- **Cursor-based incremental's first-class status**: true in the code, but **stated nowhere public** — not in the README, not in `docs/guides/comparison.md`. It only existed as an internal ADR decision. This PR fixes that gap.

#755/#760/#920 (the other three features #922 was meant to watch) are all currently unscheduled with zero PRs in flight and zero community engagement (reactions/comments) — there's nothing else for #922 to actively check right now.

## What changed

`docs/guides/comparison.md`:
- New bullet under "When to choose drt": read-only source access as a reason to pick drt.
- New "Read-only source access, by design" section explaining the trust trade-off reverse ETL tools generally make, with concrete competitor examples — but **only where I could verify them**: Hightouch's Lightning/Basic split (its own docs, already cited in ADR 0005) and Segment's managed `_segment_reverse_etl` schema (same). I explicitly did not repeat #755's old Census claim, which ADR 0005 itself already flags as **unverified** (`docs.getcensus.com` now redirects to Fivetran's Activations docs post-acquisition) — searched again for this PR and still couldn't confirm it, so it stays out rather than risk a misleading comparison claim.
- Links to [ADR 0005](../adr/0005-state-location-and-write-grants.md) for readers who want the full reasoning.

Docs-only, no code/test impact.