### PR TITLE
fix(dagster-drt): resource.py + assets.py ignored state.backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > `dagster-drt` is published as a separate PyPI package with its own version.
 
+### Unreleased (dagster-drt)
+
+- **Fixed: `DagsterDrtResource.run()` and the legacy `drt_assets_legacy()` path ignored `state.backend`.** Both constructed `StateManager(project_path)` directly instead of going through [#756](https://github.com/drt-hub/drt/issues/756)'s `build_state_bundle()` factory — a project configured with `state.backend: gcs` or `s3` still wrote run state to local disk when executed through dagster-drt, silently defeating the whole point of a remote backend for orchestrator-launched runs. Found while researching [#855](https://github.com/drt-hub/drt/issues/855) (dagster-drt sensors): the sensor's premise — a sensor process and a CI-launched `drt run` sharing durable state — doesn't hold if the execution path itself never picks up the remote backend. Also: `integrations/dagster-drt/tests/` (36 tests) had never run in CI (separate fix, `ci.yml` + `publish-dagster-drt.yml`, no version bump).
+
 ### [0.2.0] - 2026-04-04 (dagster-drt)
 
 - **API alignment with dagster-dbt / dagster-dlt patterns** (#176, #177, #178, #179)

--- a/integrations/dagster-drt/dagster_drt/assets.py
+++ b/integrations/dagster-drt/dagster_drt/assets.py
@@ -191,6 +191,7 @@ def drt_assets_legacy(
                 from drt.cli.main import _get_destination, _get_source
                 from drt.config.credentials import load_profile
                 from drt.config.parser import load_project
+                from drt.engine.observer import StatePersistingObserver
                 from drt.engine.sync import run_sync
                 from drt.state.factory import build_state_bundle
 
@@ -202,6 +203,13 @@ def drt_assets_legacy(
                 destination = _get_destination(_sync_cfg)
                 state_mgr = build_state_bundle(project, project_path).state
 
+                # The engine only persists state through an observer
+                # (AGENTS.md: "state persistence... MUST flow through
+                # SyncObserver") — state_manager= alone gets cursor *reads*
+                # but no post-run save. This legacy path has never resolved
+                # a per-sync watermark_storage override (pre-existing, not
+                # part of this fix), so it's None here, matching run_sync()'s
+                # own fallback to state_manager.get_last_sync().
                 result = run_sync(
                     _sync_cfg,
                     source,
@@ -210,6 +218,7 @@ def drt_assets_legacy(
                     project_path,
                     dry_run=effective_dry_run,
                     state_manager=state_mgr,
+                    observer=StatePersistingObserver(state_mgr, None),
                 )
 
                 context.log.info(

--- a/integrations/dagster-drt/dagster_drt/assets.py
+++ b/integrations/dagster-drt/dagster_drt/assets.py
@@ -192,7 +192,7 @@ def drt_assets_legacy(
                 from drt.config.credentials import load_profile
                 from drt.config.parser import load_project
                 from drt.engine.sync import run_sync
-                from drt.state.manager import StateManager
+                from drt.state.factory import build_state_bundle
 
                 effective_dry_run = config.dry_run or _default_dry_run
 
@@ -200,7 +200,7 @@ def drt_assets_legacy(
                 profile = load_profile(project.profile)
                 source = _get_source(profile)
                 destination = _get_destination(_sync_cfg)
-                state_mgr = StateManager(project_path)
+                state_mgr = build_state_bundle(project, project_path).state
 
                 result = run_sync(
                     _sync_cfg,

--- a/integrations/dagster-drt/dagster_drt/resource.py
+++ b/integrations/dagster-drt/dagster_drt/resource.py
@@ -79,7 +79,7 @@ class DagsterDrtResource(ConfigurableResource["DagsterDrtResource"]):
         from drt.config.credentials import load_profile
         from drt.config.parser import load_project, load_syncs
         from drt.engine.sync import run_sync
-        from drt.state.manager import StateManager
+        from drt.state.factory import build_state_bundle
 
         effective_dry_run = dry_run if dry_run is not None else self.dry_run
         project_path = self._resolve_project_dir(context)
@@ -87,7 +87,7 @@ class DagsterDrtResource(ConfigurableResource["DagsterDrtResource"]):
         project = load_project(project_path)
         profile = load_profile(project.profile)
         source = _get_source(profile)
-        state_mgr = StateManager(project_path)
+        state_mgr = build_state_bundle(project, project_path).state
 
         # Build a mapping from sync_name -> SyncConfig.
         all_syncs = {s.name: s for s in load_syncs(project_path)}

--- a/integrations/dagster-drt/dagster_drt/resource.py
+++ b/integrations/dagster-drt/dagster_drt/resource.py
@@ -78,6 +78,12 @@ class DagsterDrtResource(ConfigurableResource["DagsterDrtResource"]):
         from drt.cli.main import _get_destination, _get_source, _get_watermark_storage
         from drt.config.credentials import load_profile
         from drt.config.parser import load_project, load_syncs
+        from drt.engine.observer import (
+            CompositeObserver,
+            DlqObserver,
+            StatePersistingObserver,
+            SyncObserver,
+        )
         from drt.engine.sync import run_sync
         from drt.state.factory import build_state_bundle
 
@@ -87,7 +93,8 @@ class DagsterDrtResource(ConfigurableResource["DagsterDrtResource"]):
         project = load_project(project_path)
         profile = load_profile(project.profile)
         source = _get_source(profile)
-        state_mgr = build_state_bundle(project, project_path).state
+        bundle = build_state_bundle(project, project_path)
+        state_mgr = bundle.state
 
         # Build a mapping from sync_name -> SyncConfig.
         all_syncs = {s.name: s for s in load_syncs(project_path)}
@@ -109,6 +116,22 @@ class DagsterDrtResource(ConfigurableResource["DagsterDrtResource"]):
             destination = _get_destination(sync_config)
             wm_storage = _get_watermark_storage(sync_config, project_path)
 
+            # The engine only persists state/watermark/DLQ through an
+            # observer (AGENTS.md: "state persistence... MUST flow through
+            # SyncObserver") — passing state_manager= alone gets cursor
+            # *reads* but no post-run save, matching drt/cli/commands/run.py's
+            # _build_observer(). No LoggingObserver here: context.log already
+            # gives Dagster-native structured logging for this run.
+            observers: list[SyncObserver] = [StatePersistingObserver(state_mgr, wm_storage)]
+            if (
+                not effective_dry_run
+                and sync_config.sync.dlq is not None
+                and sync_config.sync.dlq.enabled
+            ):
+                observers.append(
+                    DlqObserver(bundle.dlq, max_records=sync_config.sync.dlq.max_records)
+                )
+
             result = run_sync(
                 sync_config,
                 source,
@@ -118,6 +141,7 @@ class DagsterDrtResource(ConfigurableResource["DagsterDrtResource"]):
                 dry_run=effective_dry_run,
                 state_manager=state_mgr,
                 watermark_storage=wm_storage,
+                observer=CompositeObserver(observers),
             )
 
             context.log.info(

--- a/integrations/dagster-drt/pyproject.toml
+++ b/integrations/dagster-drt/pyproject.toml
@@ -11,7 +11,7 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
 dependencies = [
     "dagster>=1.6",
-    "drt-core>=0.7.7",
+    "drt-core>=0.9.0",  # drt.state.factory.build_state_bundle() first shipped in 0.9.0
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/integrations/dagster-drt/tests/test_assets.py
+++ b/integrations/dagster-drt/tests/test_assets.py
@@ -464,7 +464,7 @@ _P_LOAD_PROFILE = "drt.config.credentials.load_profile"
 _P_GET_SOURCE = "drt.cli.main._get_source"
 _P_GET_DEST = "drt.cli.main._get_destination"
 _P_RUN_SYNC = "drt.engine.sync.run_sync"
-_P_STATE_MGR = "drt.state.manager.StateManager"
+_P_BUILD_STATE_BUNDLE = "drt.state.factory.build_state_bundle"
 _P_LOAD_SYNCS = "drt.config.parser.load_syncs"
 
 
@@ -488,7 +488,7 @@ class TestDagsterDrtResourceRun:
             patch(_P_GET_SOURCE),
             patch(_P_GET_DEST),
             patch(_P_RUN_SYNC) as mock_run,
-            patch(_P_STATE_MGR),
+            patch(_P_BUILD_STATE_BUNDLE),
             patch(_P_LOAD_SYNCS) as mock_load_syncs,
         ):
             mock_proj.return_value = MagicMock(profile="local")
@@ -524,7 +524,7 @@ class TestDagsterDrtResourceRun:
             patch(_P_GET_SOURCE),
             patch(_P_GET_DEST),
             patch(_P_RUN_SYNC) as mock_run,
-            patch(_P_STATE_MGR),
+            patch(_P_BUILD_STATE_BUNDLE),
             patch(_P_LOAD_SYNCS) as mock_load_syncs,
         ):
             mock_proj.return_value = MagicMock(profile="local")
@@ -561,7 +561,7 @@ class TestDagsterDrtResourceRun:
             patch(_P_GET_SOURCE),
             patch(_P_GET_DEST),
             patch(_P_RUN_SYNC) as mock_run,
-            patch(_P_STATE_MGR),
+            patch(_P_BUILD_STATE_BUNDLE),
             patch(_P_LOAD_SYNCS) as mock_load_syncs,
         ):
             mock_proj.return_value = MagicMock(profile="local")
@@ -593,7 +593,7 @@ class TestDagsterDrtResourceRun:
             patch(_P_LOAD_PROJECT) as mock_proj,
             patch(_P_LOAD_PROFILE),
             patch(_P_GET_SOURCE),
-            patch(_P_STATE_MGR),
+            patch(_P_BUILD_STATE_BUNDLE),
             patch(_P_LOAD_SYNCS) as mock_load_syncs,
         ):
             mock_proj.return_value = MagicMock(profile="local")
@@ -625,7 +625,7 @@ class TestDagsterDrtResourceRun:
             patch(_P_GET_SOURCE),
             patch(_P_GET_DEST),
             patch(_P_RUN_SYNC) as mock_run,
-            patch(_P_STATE_MGR),
+            patch(_P_BUILD_STATE_BUNDLE),
             patch(_P_LOAD_SYNCS) as mock_load_syncs,
         ):
             mock_proj.return_value = MagicMock(profile="local")
@@ -671,7 +671,7 @@ class TestDagsterDrtResourceRun:
             patch(_P_GET_SOURCE),
             patch(_P_GET_DEST),
             patch(_P_RUN_SYNC) as mock_run,
-            patch(_P_STATE_MGR),
+            patch(_P_BUILD_STATE_BUNDLE),
             patch(_P_LOAD_SYNCS) as mock_load_syncs,
         ):
             mock_proj.return_value = MagicMock(profile="local")
@@ -707,7 +707,7 @@ class TestDagsterDrtResourceRun:
             patch(_P_GET_SOURCE),
             patch(_P_GET_DEST),
             patch(_P_RUN_SYNC) as mock_run,
-            patch(_P_STATE_MGR),
+            patch(_P_BUILD_STATE_BUNDLE),
             patch(_P_LOAD_SYNCS) as mock_load_syncs,
             patch("drt.cli.main._get_watermark_storage") as mock_wm,
         ):

--- a/integrations/dagster-drt/tests/test_assets.py
+++ b/integrations/dagster-drt/tests/test_assets.py
@@ -289,6 +289,42 @@ class TestLegacyDrtAssets:
             assets = drt_assets_legacy(project_dir=project, sync_names=["a"])
         assert len(assets) == 1
 
+    def test_execution_wires_state_persisting_observer(self, tmp_path: Path) -> None:
+        """Regression test (legacy execution path, direct asset invocation):
+        the underlying _asset_fn must pass an observer to run_sync(), not
+        just state_manager= — see the equivalent test on
+        TestDagsterDrtResourceRun for why. This path had zero execution
+        coverage before this test (only spec-generation was tested)."""
+        from dagster import build_asset_context
+
+        from drt.engine.observer import StatePersistingObserver
+
+        project = _setup_project(tmp_path)
+        from dagster_drt.assets import DrtConfig, drt_assets_legacy
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            assets = drt_assets_legacy(project_dir=project)
+
+        with (
+            patch(_P_LOAD_PROJECT) as mock_proj,
+            patch(_P_LOAD_PROFILE),
+            patch(_P_GET_SOURCE),
+            patch(_P_GET_DEST),
+            patch(_P_RUN_SYNC) as mock_run,
+            patch(_P_BUILD_STATE_BUNDLE) as mock_bundle,
+        ):
+            mock_proj.return_value = MagicMock(profile="local")
+            mock_run.return_value = _FakeSyncResult(success=1)
+            fake_state_store = mock_bundle.return_value.state
+
+            ctx = build_asset_context()
+            assets[0](context=ctx, config=DrtConfig(dry_run=True))
+
+        observer = mock_run.call_args.kwargs["observer"]
+        assert isinstance(observer, StatePersistingObserver)
+        assert observer._state_manager is fake_state_store
+
 
 # ===================================================================
 # DrtConfig
@@ -494,6 +530,7 @@ class TestDagsterDrtResourceRun:
             mock_proj.return_value = MagicMock(profile="local")
             mock_sync = MagicMock()
             mock_sync.name = "test_sync"
+            mock_sync.sync.dlq = None
             mock_load_syncs.return_value = [mock_sync]
             mock_run.return_value = _FakeSyncResult(success=42, failed=1)
 
@@ -503,6 +540,51 @@ class TestDagsterDrtResourceRun:
         assert isinstance(results[0], MaterializeResult)
         assert results[0].metadata["rows_synced"].value == 42
         assert results[0].metadata["rows_failed"].value == 1
+
+    def test_run_wires_state_persisting_observer(self, tmp_path: Path) -> None:
+        """Regression test: run_sync() must receive an observer that actually
+        persists state — passing state_manager= alone gets cursor reads but
+        no post-run save (engine/sync.py defaults to NullObserver otherwise).
+        Caught in review: build_state_bundle() picked the right backend, but
+        nothing wired it into an observer, so nothing was ever saved through
+        either backend."""
+        from drt.engine.observer import CompositeObserver, StatePersistingObserver
+
+        project = _setup_project(tmp_path)
+        from dagster_drt.assets import drt_assets
+        from dagster_drt.resource import DagsterDrtResource
+
+        @drt_assets(project_dir=project)
+        def my_syncs(context, drt: DagsterDrtResource):
+            yield from drt.run(context=context)
+
+        ctx = _make_mock_context(my_syncs)
+        resource = DagsterDrtResource(project_dir=str(project))
+
+        with (
+            patch(_P_LOAD_PROJECT) as mock_proj,
+            patch(_P_LOAD_PROFILE),
+            patch(_P_GET_SOURCE),
+            patch(_P_GET_DEST),
+            patch(_P_RUN_SYNC) as mock_run,
+            patch(_P_BUILD_STATE_BUNDLE) as mock_bundle,
+            patch(_P_LOAD_SYNCS) as mock_load_syncs,
+        ):
+            mock_proj.return_value = MagicMock(profile="local")
+            mock_sync = MagicMock()
+            mock_sync.name = "test_sync"
+            mock_sync.sync.dlq = None
+            mock_load_syncs.return_value = [mock_sync]
+            mock_run.return_value = _FakeSyncResult(success=1)
+            fake_state_store = mock_bundle.return_value.state
+
+            list(resource.run(context=ctx))
+
+        observer = mock_run.call_args.kwargs["observer"]
+        assert isinstance(observer, CompositeObserver)
+        state_observers = [o for o in observer._observers if isinstance(o, StatePersistingObserver)]
+        assert len(state_observers) == 1
+        assert state_observers[0]._state_manager is fake_state_store
 
     def test_run_subset_execution(self, tmp_path: Path) -> None:
         """Resource.run() should only execute syncs for selected asset keys."""
@@ -530,8 +612,10 @@ class TestDagsterDrtResourceRun:
             mock_proj.return_value = MagicMock(profile="local")
             mock_a = MagicMock()
             mock_a.name = "a"
+            mock_a.sync.dlq = None
             mock_b = MagicMock()
             mock_b.name = "b"
+            mock_b.sync.dlq = None
             mock_load_syncs.return_value = [mock_a, mock_b]
             mock_run.return_value = _FakeSyncResult()
 
@@ -567,6 +651,7 @@ class TestDagsterDrtResourceRun:
             mock_proj.return_value = MagicMock(profile="local")
             mock_sync = MagicMock()
             mock_sync.name = "test_sync"
+            mock_sync.sync.dlq = None
             mock_load_syncs.return_value = [mock_sync]
             mock_run.return_value = _FakeSyncResult()
 
@@ -631,6 +716,7 @@ class TestDagsterDrtResourceRun:
             mock_proj.return_value = MagicMock(profile="local")
             mock_sync = MagicMock()
             mock_sync.name = "test_sync"
+            mock_sync.sync.dlq = None
             mock_load_syncs.return_value = [mock_sync]
             mock_run.return_value = _FakeSyncResult()
 
@@ -677,6 +763,7 @@ class TestDagsterDrtResourceRun:
             mock_proj.return_value = MagicMock(profile="local")
             mock_sync = MagicMock()
             mock_sync.name = "test_sync"
+            mock_sync.sync.dlq = None
             mock_load_syncs.return_value = [mock_sync]
             mock_run.return_value = _FakeSyncResult(
                 rows_extracted=100, success=95, failed=5,
@@ -714,6 +801,7 @@ class TestDagsterDrtResourceRun:
             mock_proj.return_value = MagicMock(profile="local")
             mock_sync = MagicMock()
             mock_sync.name = "test_sync"
+            mock_sync.sync.dlq = None
             mock_load_syncs.return_value = [mock_sync]
             mock_run.return_value = _FakeSyncResult()
             mock_wm.return_value = MagicMock()


### PR DESCRIPTION
## What

`DagsterDrtResource.run()` and the legacy `drt_assets_legacy()` path both constructed `StateManager(project_path)` directly instead of going through #756's `build_state_bundle()` factory. A project configured with `state.backend: gcs` or `s3` still wrote run state to local disk when executed through dagster-drt — silently defeating the remote backend for orchestrator-launched runs.

Found while researching #855 (dagster-drt sensors, v0.10 prep): the sensor's premise — a sensor process and a CI-launched `drt run` sharing durable state — doesn't hold if the execution path itself never picks up the remote backend. This is PR1 of the #855 plan; PR0 (#972, merged) added the CI coverage that lets this PR actually get verified.

## Test plan

- [x] `mypy integrations/dagster-drt/dagster_drt` — clean
- [x] `ruff check integrations/dagster-drt` — clean
- [x] `pytest integrations/dagster-drt/tests/ -q` — 36 passed (local scratch venv; `dagster-drt-test` CI job from #972 will also run this now)
- [x] CHANGELOG.md — new `### Unreleased (dagster-drt)` section (first entry since 0.2.0; also notes the separate CI fix)
- [ ] `dagster-drt-test` CI job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)