### PR TITLE
chore: release prep — drt-core v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## drt-core
 
-## [Unreleased]
+## [0.9.1] - 2026-08-18
+
+**Patch release for [#986](https://github.com/drt-hub/drt/issues/986) — tracked mirror on least-privilege MySQL users, plus the state-diff privilege reduction on Snowflake, and three other fixes accumulated since v0.9.0.**
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "drt-core"
-version = "0.9.0"
+version = "0.9.1"
 description = "Reverse ETL for the code-first data stack"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Version bump + CHANGELOG for the v0.9.1 patch release. Converts `[Unreleased]` (5 fixes accumulated since v0.9.0, including #987's fix for #986) into `[0.9.1] - 2026-08-18`.

Contains no code changes — `pyproject.toml` version bump and `CHANGELOG.md` heading only.

## What's in this release

- #986: tracked mirror's no-DDL contract on MySQL (fully restored) and Snowflake's state-diff step (privilege reduced, not full no-DDL — see #988)
- #965: provider URIs silently failing on 12 connectors
- #976: `run_drt_sync()` never persisted state on Airflow/Prefect
- #978: dry runs incorrectly persisting state
- #982: `run_drt_sync()` ignoring `history.enabled: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)