### PR TITLE
fix(scripts): check_drift.sh's echo|grep pattern races under pipefail (SIGPIPE)

### DIFF
--- a/scripts/check_drift.sh
+++ b/scripts/check_drift.sh
@@ -140,8 +140,8 @@ readme_dest_section=$(awk '/^### Destinations/,/^## /' README.md)
 for dest in $destinations; do
     term="$(fuzzy_term "$dest")"
     alias="$(display_alias "$dest")"
-    if ! echo "$readme_dest_section" | grep -qi -- "$term"; then
-        if [ -z "$alias" ] || ! echo "$readme_dest_section" | grep -qi -- "$alias"; then
+    if ! grep -qi -- "$term" <<< "$readme_dest_section"; then
+        if [ -z "$alias" ] || ! grep -qi -- "$alias" <<< "$readme_dest_section"; then
             report "dest-readme" "$dest" "no row in README.md Destinations table"
         fi
     fi
@@ -153,7 +153,7 @@ done
 readme_src_section=$(awk '/^### Sources/,/^### Destinations/' README.md)
 for src in $sources; do
     term="$(fuzzy_term "$src")"
-    if ! echo "$readme_src_section" | grep -qi -- "$term"; then
+    if ! grep -qi -- "$term" <<< "$readme_src_section"; then
         report "src-readme" "$src" "no row in README.md Sources table"
     fi
 done
@@ -172,7 +172,7 @@ done
 # ---------------------------------------------------------------------------
 docstring=$(head -30 "$MCP_SERVER")
 for tool in $mcp_tools; do
-    if ! echo "$docstring" | grep -q "$tool"; then
+    if ! grep -q "$tool" <<< "$docstring"; then
         report "mcp-docstring" "$tool" "not listed in drt/mcp/server.py module docstring"
     fi
 done


### PR DESCRIPTION
## Summary

`scripts/check_drift.sh` was reporting drift for essentially every destination, source, and MCP tool — 58 items on a clean run — even though the actual docs/README/docstring content is correct and complete. Root-caused while doing the post-release follow-up for #986/v0.9.1.

## Root cause

Four checks used `echo "$var" | grep -qi -- "$term"` to search a variable's content. Under `set -o pipefail` (set at the top of the script):

- `grep -q` exits as soon as it finds a match, closing its read end of the pipe.
- If `echo` hasn't finished writing all its content yet (the variable is bigger than the pipe buffer), the closed pipe sends `echo` a `SIGPIPE`.
- `echo`'s resulting non-zero exit status becomes the *pipeline's* reported exit status under `pipefail` — even though `grep` already found the match and exited 0.

This is timing-dependent, not deterministic: it reproduced consistently on macOS locally (`make check-drift` → 58 false positives), but the last several CI runs on the Ubuntu runner happened not to trigger it — which is why it went unnoticed. It's a real race, though, and could start failing on CI at any time as content grows or runner timing shifts.

## Fix

Replaced the four `echo "$var" | grep ...` sites with `grep ... <<< "$var"` here-strings, which feed the same content without an independently-scheduled writer process for `grep` to `SIGPIPE`.

The other checks (`dest-doc`, `dest-skill`/`src-skill` via `mentions()`, `mcp-inventory`) were never affected — they `grep` files directly, no pipe involved.

## Test plan

- [x] `make check-drift` before: `58 new drift item(s)`. After: `0 new drift item(s), 0 baselined gap(s)`.
- [x] Sanity check the fix doesn't just silence everything: temporarily removed a real README row (BigQuery from the Destinations table) and confirmed the check still correctly reports `DRIFT dest-readme:bigquery`, then restored it.
- [x] Confirmed via CI logs that recent `drift-check.yml` runs on Ubuntu happened not to hit the race (reported `0 new drift item(s)` even pre-fix) — so this PR doesn't change CI's current green status, it removes a latent flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)