### PR TITLE
fix(state): cross-process file locking for local DLQ/state/history stores

### DIFF
--- a/drt/state/_file_lock.py
+++ b/drt/state/_file_lock.py
@@ -1,0 +1,109 @@
+"""Cross-process file locking for the local (non-object-store) state backend (#963).
+
+``LocalDlqStore`` / ``LocalStateManager`` / ``LocalHistoryManager`` each guard
+their read-modify-write cycle with a ``threading.Lock``, which only
+serialises threads sharing one process. Two separate ``drt`` CLI invocations
+(``drt run`` and ``drt retry``/``drt status`` are always separate OS
+processes, never threads) racing the same file is last-writer-wins with no
+way to detect it (#955, #962). :func:`cross_process_lock` wraps the same
+critical section in an OS-level advisory lock (``fcntl.flock`` on POSIX,
+``msvcrt.locking`` on Windows), so a second process blocks until the first
+one finishes instead of racing it.
+
+This is a real mutex, not the object-store tier's optimistic
+generation/ETag retry (:mod:`drt.state._objectstore`): a local file has no
+version token to precondition a write against, so callers get exclusion
+instead of conflict detection. Advisory OS locks are held by the kernel
+against the open file description, not the file's content, so a crashed
+holder releases the lock automatically when its process exits: there is no
+stale-lock file to clean up the way a plain "lock file exists" convention
+would need.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+DEFAULT_TIMEOUT_SECONDS = 30.0
+_POLL_INTERVAL_SECONDS = 0.05
+
+
+class FileLockTimeout(TimeoutError):
+    """Could not acquire the cross-process file lock within the timeout.
+
+    No other ``drt`` process is expected to hold a state/DLQ/history lock
+    for more than a handful of read-modify-write cycles. A caller stuck
+    this long is either genuinely deadlocked behind another process (killed
+    mid-hold on a platform where that doesn't release the lock, or a real
+    hang), or advisory locking isn't actually supported on this filesystem.
+    Both are conditions to surface, not to wait out silently.
+    """
+
+
+if sys.platform == "win32":
+    import msvcrt
+
+    def _try_lock(fd: int) -> bool:
+        try:
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+
+    def _unlock(fd: int) -> None:
+        os.lseek(fd, 0, 0)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+
+else:
+    import fcntl
+
+    def _try_lock(fd: int) -> bool:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except OSError:
+            return False
+
+    def _unlock(fd: int) -> None:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+@contextmanager
+def cross_process_lock(
+    lock_path: Path, *, timeout: float = DEFAULT_TIMEOUT_SECONDS
+) -> Iterator[None]:
+    """Hold an exclusive OS-level lock on ``lock_path`` for the block's duration.
+
+    ``lock_path`` is a dedicated lock file, created if missing and never
+    removed (deleting it after use would let a concurrent locker acquire a
+    lock on a since-recreated inode while this process still holds the
+    original one, defeating the exclusion). Callers pick a lock path scoped
+    to the resource they're protecting (e.g. ``state.json.lock`` for the
+    whole state file, ``<sync>.jsonl.lock`` per DLQ/history file) so
+    unrelated resources never contend on the same lock.
+
+    Raises:
+        FileLockTimeout: see the exception's docstring.
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        deadline = time.monotonic() + timeout
+        while not _try_lock(fd):
+            if time.monotonic() >= deadline:
+                raise FileLockTimeout(
+                    f"could not acquire lock on {lock_path} within {timeout}s "
+                    "(another drt process is likely holding it)"
+                )
+            time.sleep(_POLL_INTERVAL_SECONDS)
+        try:
+            yield
+        finally:
+            _unlock(fd)
+    finally:
+        os.close(fd)

--- a/drt/state/_file_lock.py
+++ b/drt/state/_file_lock.py
@@ -91,7 +91,9 @@ def cross_process_lock(
         FileLockTimeout: see the exception's docstring.
     """
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+    # Owner-only, matching the rest of .drt/ (credentials hardened to 0o600
+    # in #650) rather than the world-readable 0o644 CodeQL flags by default.
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
     try:
         deadline = time.monotonic() + timeout
         while not _try_lock(fd):

--- a/drt/state/dlq.py
+++ b/drt/state/dlq.py
@@ -29,6 +29,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
+from drt.state._file_lock import DEFAULT_TIMEOUT_SECONDS, cross_process_lock
+
 
 @dataclass
 class DeadLetter:
@@ -110,7 +112,8 @@ class DlqBackend(Protocol):
         ``HistoryStore.append`` — a failure is logged at WARNING and
         swallowed rather than raised, so a DLQ persistence problem never
         fails the sync whose records it's recording. ``LocalDlqStore`` does
-        not catch local I/O errors (disk full, permission denied); those
+        not catch local I/O errors (disk full, permission denied) or the
+        cross-process lock timing out (#963, ``FileLockTimeout``); those
         still propagate.
         """
         ...
@@ -143,22 +146,34 @@ class DlqBackend(Protocol):
 class LocalDlqStore:
     """Append / read / replace dead-letter entries under ``.drt/dlq/``.
 
-    One JSONL file per sync (``<sync_name>.jsonl``). All mutating methods run
-    under ``self._lock``, a **process-local** ``threading.Lock`` — it
-    serialises ``drt run --threads N`` workers within a single process, but
-    does **not** coordinate across processes: a concurrent ``drt run`` and
-    ``drt retry`` doing read-modify-write on the same file is last-writer-wins.
-    Single-writer-at-a-time is the expected operational model.
+    One JSONL file per sync (``<sync_name>.jsonl``). Every mutating method
+    (``append``/``replace``/``reconcile``) runs under two locks: ``self._lock``,
+    a process-local ``threading.Lock`` serialising ``drt run --threads N``
+    workers within one process, and a per-file OS-level lock (#963,
+    :mod:`drt.state._file_lock`), so a genuinely separate process (``drt run``
+    and ``drt retry`` are always separate processes, never threads) blocks
+    instead of racing the same read-modify-write cycle. ``read``/``depth``/
+    ``all_depths`` stay unlocked, as before: they can still observe a write
+    in flight (this closes writer-vs-writer loss, not torn reads).
     """
 
-    def __init__(self, project_dir: Path = Path(".")) -> None:
+    def __init__(
+        self,
+        project_dir: Path = Path("."),
+        *,
+        lock_timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
         self._dlq_dir = project_dir / ".drt" / "dlq"
+        self._lock_timeout = lock_timeout
         self._lock = threading.Lock()
 
     # -- path helpers -------------------------------------------------------
 
     def _path(self, sync_name: str) -> Path:
         return self._dlq_dir / f"{sync_name}.jsonl"
+
+    def _lock_path(self, sync_name: str) -> Path:
+        return self._dlq_dir / f"{sync_name}.jsonl.lock"
 
     @staticmethod
     def _count_lines(path: Path) -> int:
@@ -191,30 +206,36 @@ class LocalDlqStore:
         with self._lock:
             path = self._path(sync_name)
             path.parent.mkdir(parents=True, exist_ok=True)
-            lines = self._read_raw(path)
-            lines.extend(json.dumps(asdict(e)) for e in entries)
-            if max_records > 0 and len(lines) > max_records:
-                lines = lines[-max_records:]
-            path.write_text("\n".join(lines) + "\n")
-            return len(lines)
+            with cross_process_lock(self._lock_path(sync_name), timeout=self._lock_timeout):
+                lines = self._read_raw(path)
+                lines.extend(json.dumps(asdict(e)) for e in entries)
+                if max_records > 0 and len(lines) > max_records:
+                    lines = lines[-max_records:]
+                path.write_text("\n".join(lines) + "\n")
+                return len(lines)
 
     def replace(self, sync_name: str, entries: list[DeadLetter]) -> None:
         """Overwrite the queue with ``entries`` (empty list removes the file).
 
-        Wholesale — ``entries`` fully replaces whatever is on disk, including
+        Wholesale: ``entries`` fully replaces whatever is on disk, including
         anything a concurrent writer appended since this call's caller last
         read the queue (#955). ``drt retry`` uses ``reconcile()`` instead,
         which re-reads fresh state and touches only named entries; this
         method still backs ``clear()`` (discard everything, intentionally)
         and stays available for callers that genuinely want a full overwrite.
+        The cross-process lock (#963) only stops this write from landing
+        mid-write of a concurrent ``append``/``reconcile``. It can't stop
+        the overwrite itself from discarding entries this call never saw,
+        which is the documented, intentional "wholesale" contract above.
         """
         with self._lock:
             path = self._path(sync_name)
-            if not entries:
-                path.unlink(missing_ok=True)
-                return
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text("\n".join(json.dumps(asdict(e)) for e in entries) + "\n")
+            with cross_process_lock(self._lock_path(sync_name), timeout=self._lock_timeout):
+                if not entries:
+                    path.unlink(missing_ok=True)
+                    return
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("\n".join(json.dumps(asdict(e)) for e in entries) + "\n")
 
     def clear(self, sync_name: str) -> None:
         """Remove the queue file for ``sync_name`` if it exists.
@@ -252,44 +273,39 @@ class LocalDlqStore:
     ) -> list[DeadLetter]:
         """Remove/update entries by identity against a fresh read (#955).
 
-        See the ``DlqBackend`` Protocol docstring for the "why" — the short
+        See the ``DlqBackend`` Protocol docstring for the "why": the short
         version is this is what ``drt retry`` uses instead of ``replace()``
         so a concurrent append isn't silently overwritten.
 
-        ``self._lock`` is process-local (same caveat as the class docstring
-        above), and this class has no OS-level file lock or conditional
-        write — unlike ``ObjectStoreDlqBackend.reconcile()``, which is
-        genuinely safe against a concurrent writer because generation/ETag
-        preconditioning catches a stale write and forces a retry against
-        fresh state. Here, a separate ``drt run`` **process** appending
-        between this method's read and its write still loses that append
-        exactly as ``replace()`` did (caught in review, #962) — this class
-        was never cross-process-safe (see the docstring above) and this
-        method does not change that. What it *does* fix, on local too: the
-        legacy bug of computing a result from a stale in-memory snapshot
-        (``untouched + remaining``) rather than from a fresh read, and
-        reconciling by identity rather than position — both matter the
-        moment real file locking lands, since a wholesale-overwrite
-        operation could never be made cross-process-safe no matter how it's
-        locked. Real cross-process safety needs OS-level file locking,
-        which no local state store has today; tracked as a follow-up
-        (#963) covering ``LocalStateManager``/``LocalHistoryManager`` too,
-        not just this class.
+        Cross-process-safe as of #963: the OS-level lock this method now
+        holds (see the class docstring) means a separate ``drt run``
+        process's ``append()`` either completes fully before this method's
+        read, or waits for this method to finish before it starts. There
+        is no window left where an append lands between the read and the
+        write and gets silently discarded. Before #963, ``self._lock``
+        alone (process-local) could not prevent that; #955/#962 only fixed
+        this method's own read-then-compute-then-write logic (reconciling
+        by identity against a fresh read rather than a stale in-memory
+        snapshot), which is necessary but was not sufficient without this
+        method also serialising against a genuinely separate process.
         """
         updates = updates or {}
         remove_ids = set(remove_ids)
         with self._lock:
             path = self._path(sync_name)
-            current = self._read_entries(sync_name)
-            result = [
-                updates.get(entry.id, entry) for entry in current if entry.id not in remove_ids
-            ]
-            if not result:
-                path.unlink(missing_ok=True)
-            else:
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text("\n".join(json.dumps(asdict(e)) for e in result) + "\n")
-            return result
+            with cross_process_lock(self._lock_path(sync_name), timeout=self._lock_timeout):
+                current = self._read_entries(sync_name)
+                result = [
+                    updates.get(entry.id, entry)
+                    for entry in current
+                    if entry.id not in remove_ids
+                ]
+                if not result:
+                    path.unlink(missing_ok=True)
+                else:
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_text("\n".join(json.dumps(asdict(e)) for e in result) + "\n")
+                return result
 
     def depth(self, sync_name: str) -> int:
         """Return the number of entries queued for ``sync_name``."""

--- a/drt/state/history.py
+++ b/drt/state/history.py
@@ -5,8 +5,12 @@ The CLI exposes recent entries via ``drt status --history``; the MCP server expo
 them as ``drt_get_history`` so AI agents can query past runs.
 
 Why JSONL per-sync:
-- POSIX ``O_APPEND`` makes single-line writes atomic across ``--threads`` workers,
-  no lock file needed.
+- POSIX ``O_APPEND`` makes a single-line write atomic against *other appends*:
+  two appends can never tear or interleave, with or without a lock. That is
+  not the same as safe against ``prune()``'s wholesale rewrite (#963): a
+  prune reading the file before an append lands and replacing it after would
+  silently drop that append, so both now take the same OS-level lock
+  (:mod:`drt.state._file_lock`) rather than relying on ``O_APPEND`` alone.
 - Per-sync files keep retention prune trivial (rewrite the file once it crosses
   the cutoff) and let ``drt status --history <sync_name>`` read just one file.
 - JSONL is grep/jq friendly without a database dependency.
@@ -23,6 +27,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Protocol, runtime_checkable
+
+from drt.state._file_lock import DEFAULT_TIMEOUT_SECONDS, FileLockTimeout, cross_process_lock
 
 logger = logging.getLogger(__name__)
 
@@ -82,30 +88,59 @@ class LocalHistoryManager:
     Files live under ``<project_dir>/.drt/history/<sync_name>.jsonl``. All
     writes append a single JSON object per line. Reads return the most recent
     N entries (newest first).
+
+    Cross-process safety (#963): both ``append`` and ``prune`` take the same
+    OS-level file lock (:mod:`drt.state._file_lock`). ``append``'s own write
+    was already safe against *other appends* via POSIX ``O_APPEND``, but not
+    against ``prune``'s wholesale rewrite: an append landing between
+    prune's read and its replace would be silently dropped unless append
+    also holds the lock prune waits on. Matching ``HistoryStore``'s
+    best-effort contract, a lock timeout on either method is logged and
+    swallowed rather than raised.
     """
 
     _MAX_ERRORS_PER_ENTRY = 5
 
-    def __init__(self, project_dir: Path = Path(".")) -> None:
+    def __init__(
+        self,
+        project_dir: Path = Path("."),
+        *,
+        lock_timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
         self._dir = project_dir / ".drt" / "history"
-        self._lock = threading.Lock()  # protects prune's read-rewrite-write
+        self._lock_timeout = lock_timeout
+        self._lock = threading.Lock()  # serialises append/prune within one process
 
     def _file_for(self, sync_name: str) -> Path:
         return self._dir / f"{sync_name}.jsonl"
 
+    def _lock_path(self, sync_name: str) -> Path:
+        return self._dir / f"{sync_name}.jsonl.lock"
+
     def append(self, entry: HistoryEntry) -> None:
         """Append one entry. Best-effort — failures are logged at WARNING and
         never propagate (sync results must not depend on history persistence).
+
+        Takes the cross-process lock (#963) even though the write itself is
+        ``O_APPEND``-atomic on its own: without it, this write could still
+        land inside a concurrent ``prune()``'s read-rewrite-replace window
+        on another process and be silently discarded when that rewrite
+        completes.
         """
         try:
             self._dir.mkdir(parents=True, exist_ok=True)
             # Truncate errors to bound disk growth on long-failing syncs.
             entry.errors = entry.errors[: self._MAX_ERRORS_PER_ENTRY]
             line = json.dumps(asdict(entry), default=str)
-            # POSIX O_APPEND makes single-line writes atomic across processes.
-            with self._file_for(entry.sync_name).open("a") as f:
-                f.write(line + "\n")
+            with self._lock:
+                with cross_process_lock(
+                    self._lock_path(entry.sync_name), timeout=self._lock_timeout
+                ):
+                    with self._file_for(entry.sync_name).open("a") as f:
+                        f.write(line + "\n")
         except OSError as exc:  # disk full, permission denied, etc.
+            logger.warning("history append failed for sync=%s: %s", entry.sync_name, exc)
+        except FileLockTimeout as exc:
             logger.warning("history append failed for sync=%s: %s", entry.sync_name, exc)
 
     def read(
@@ -139,8 +174,10 @@ class LocalHistoryManager:
         """Drop entries older than ``retention_days`` for one sync.
 
         Returns the number of entries removed. No-op if the file doesn't exist.
-        Rewrites the file in place under a process-local lock so concurrent
-        workers don't lose appends in the gap between read and write.
+        Rewrites the file in place under a process-local lock plus an
+        OS-level cross-process lock (#963) so a concurrent ``append`` from a
+        genuinely separate ``drt`` process (not just another thread) isn't
+        lost in the gap between this method's read and its replace.
         """
         path = self._file_for(sync_name)
         if not path.exists():
@@ -149,31 +186,42 @@ class LocalHistoryManager:
         cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
 
         with self._lock:
-            kept: list[HistoryEntry] = []
-            removed = 0
-            for entry in _read_jsonl(path):
-                try:
-                    started = datetime.fromisoformat(entry.started_at)
-                except ValueError:
-                    # Malformed timestamp — keep so a human can inspect.
-                    kept.append(entry)
-                    continue
-                if started < cutoff:
-                    removed += 1
-                else:
-                    kept.append(entry)
+            try:
+                with cross_process_lock(self._lock_path(sync_name), timeout=self._lock_timeout):
+                    kept: list[HistoryEntry] = []
+                    removed = 0
+                    for entry in _read_jsonl(path):
+                        try:
+                            started = datetime.fromisoformat(entry.started_at)
+                        except ValueError:
+                            # Malformed timestamp: keep so a human can inspect.
+                            kept.append(entry)
+                            continue
+                        if started < cutoff:
+                            removed += 1
+                        else:
+                            kept.append(entry)
 
-            if removed == 0:
+                    if removed == 0:
+                        return 0
+
+                    # Rewrite (entries are already in the order we want,
+                    # preserved from the original file).
+                    tmp = path.with_suffix(".jsonl.tmp")
+                    with tmp.open("w") as f:
+                        for entry in kept:
+                            f.write(json.dumps(asdict(entry), default=str) + "\n")
+                    tmp.replace(path)
+                    return removed
+            except FileLockTimeout:
+                # Best-effort, like HistoryStore.append: never fail the
+                # caller over a retention housekeeping pass.
+                logger.warning(
+                    "history prune failed for sync=%s: lock timed out after %ss",
+                    sync_name,
+                    self._lock_timeout,
+                )
                 return 0
-
-            # Rewrite (entries are already in the order we want — preserved
-            # from the original file).
-            tmp = path.with_suffix(".jsonl.tmp")
-            with tmp.open("w") as f:
-                for entry in kept:
-                    f.write(json.dumps(asdict(entry), default=str) + "\n")
-            tmp.replace(path)
-            return removed
 
 
 # Back-compat alias — see the note on ``StateManager`` in state/manager.py.

--- a/drt/state/manager.py
+++ b/drt/state/manager.py
@@ -11,6 +11,11 @@ Thread safety: ``drt run --threads N`` calls ``save_sync`` concurrently
 from each worker. Every method that touches state.json runs under a
 process-local :class:`threading.Lock` so the load-modify-save cycle is
 atomic and parallel writers don't clobber each other's updates.
+
+Cross-process safety: the same load-modify-save cycle is also wrapped in an
+OS-level file lock (:mod:`drt.state._file_lock`, #963), so a genuinely
+separate ``drt`` process (``drt run`` and ``drt retry``/``drt status`` are
+always separate processes, never threads) blocks instead of racing.
 """
 
 from __future__ import annotations
@@ -21,6 +26,9 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
+
+from drt.state._file_lock import DEFAULT_TIMEOUT_SECONDS, FileLockTimeout, cross_process_lock
+from drt.state.errors import StateContentionError
 
 
 @dataclass
@@ -83,11 +91,25 @@ class LocalStateManager:
     serialises the load-modify-save cycle in :meth:`save_sync` and the
     read-only operations so a reader never observes a partially-written
     file in-memory either.
+
+    Cross-process safety (#963): :meth:`save_sync` and :meth:`reset` also
+    hold an OS-level file lock for the same critical section, so a second
+    ``drt`` process blocks instead of racing the first one's read-modify-write.
+    Exhausting the lock's timeout raises ``StateContentionError``, matching
+    ``StateStore``'s Protocol contract. ``get_last_sync``/``get_all`` stay
+    ``threading.Lock``-only since they never write.
     """
 
-    def __init__(self, project_dir: Path = Path(".")) -> None:
+    def __init__(
+        self,
+        project_dir: Path = Path("."),
+        *,
+        lock_timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
         self._state_dir = project_dir / ".drt"
         self._state_file = self._state_dir / "state.json"
+        self._lock_file = self._state_dir / "state.json.lock"
+        self._lock_timeout = lock_timeout
         self._lock = threading.Lock()
 
     def _load_all(self) -> dict[str, Any]:
@@ -126,9 +148,16 @@ class LocalStateManager:
 
     def save_sync(self, state: SyncState) -> None:
         with self._lock:
-            data = self._load_all()
-            data[state.sync_name] = asdict(state)
-            self._save_all(data)
+            try:
+                with cross_process_lock(self._lock_file, timeout=self._lock_timeout):
+                    data = self._load_all()
+                    data[state.sync_name] = asdict(state)
+                    self._save_all(data)
+            except FileLockTimeout as exc:
+                raise StateContentionError(
+                    f"state update for '{state.sync_name}' could not acquire the "
+                    f"cross-process lock within {self._lock_timeout}s"
+                ) from exc
 
     def reset(self, sync_name: str) -> bool:
         """Drop the recorded run state for ``sync_name`` (#776).
@@ -145,15 +174,22 @@ class LocalStateManager:
 
         Takes the same lock as ``save_sync``: ``drt run --threads`` writes
         state concurrently, and a read-modify-write here would otherwise race
-        a run finishing.
+        a run finishing. Also takes the same cross-process file lock (#963).
         """
         with self._lock:
-            data = self._load_all()
-            if sync_name not in data:
-                return False  # never run — nothing to clear, and no file to create
-            del data[sync_name]
-            self._save_all(data)
-            return True
+            try:
+                with cross_process_lock(self._lock_file, timeout=self._lock_timeout):
+                    data = self._load_all()
+                    if sync_name not in data:
+                        return False  # never run: nothing to clear, no file to create
+                    del data[sync_name]
+                    self._save_all(data)
+                    return True
+            except FileLockTimeout as exc:
+                raise StateContentionError(
+                    f"state reset for '{sync_name}' could not acquire the "
+                    f"cross-process lock within {self._lock_timeout}s"
+                ) from exc
 
     def now(self) -> str:
         return datetime.now(timezone.utc).isoformat()

--- a/tests/unit/test_state_cross_process_safety.py
+++ b/tests/unit/test_state_cross_process_safety.py
@@ -1,0 +1,231 @@
+"""Cross-process proof tests for the local state stores (#963).
+
+These races only exist between genuinely separate OS processes racing a
+read-modify-write on the same file. An in-process mock (a fake clock, a
+patched method) cannot reproduce them, which is exactly why #955/#962 could
+fix ``LocalDlqStore.reconcile()``'s in-memory logic but explicitly could not
+close the cross-process gap this issue (#963) targets. Every test here
+spawns real ``multiprocessing.Process`` workers against a shared ``tmp_path``
+project directory, synchronised with a ``Barrier`` so their operations
+actually overlap instead of running back-to-back.
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+from dataclasses import asdict
+from datetime import datetime, timedelta, timezone
+from multiprocessing.synchronize import Barrier
+from pathlib import Path
+
+from drt.state.dlq import DeadLetter, LocalDlqStore
+from drt.state.history import HistoryEntry, LocalHistoryManager
+from drt.state.manager import LocalStateManager, SyncState
+
+# Short so a genuine deadlock/regression fails the test in seconds, not
+# whatever the production default (30s) would otherwise wait.
+_TEST_LOCK_TIMEOUT = 10.0
+_JOIN_TIMEOUT = 15.0
+
+# Explicit "spawn" rather than the bare module-level API (which defaults to
+# "fork" on Linux): fork()ing a multi-threaded process (pytest itself runs
+# background threads) is unsafe and Python warns on it; spawn is also the
+# only choice that behaves the same on every platform this suite targets.
+_mp = multiprocessing.get_context("spawn")
+
+
+# -- LocalDlqStore --------------------------------------------------------
+
+
+def _dlq_append_worker(project_dir: str, sync_name: str, idx: int, barrier: Barrier) -> None:
+    store = LocalDlqStore(Path(project_dir), lock_timeout=_TEST_LOCK_TIMEOUT)
+    entry = DeadLetter(record={"idx": idx}, error_message=f"boom {idx}")
+    barrier.wait(timeout=_JOIN_TIMEOUT)
+    store.append(sync_name, [entry])
+
+
+def test_concurrent_appends_from_separate_processes_are_not_lost(tmp_path: Path) -> None:
+    n = 8
+    barrier = _mp.Barrier(n)
+    procs = [
+        _mp.Process(
+            target=_dlq_append_worker, args=(str(tmp_path), "s", i, barrier)
+        )
+        for i in range(n)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=_JOIN_TIMEOUT)
+        assert p.exitcode == 0
+
+    store = LocalDlqStore(tmp_path)
+    entries = store.read("s")
+    assert store.depth("s") == n
+    assert sorted(e.record["idx"] for e in entries) == list(range(n))
+
+
+def _dlq_reconcile_worker(
+    project_dir: str, sync_name: str, remove_id: str, barrier: Barrier
+) -> None:
+    store = LocalDlqStore(Path(project_dir), lock_timeout=_TEST_LOCK_TIMEOUT)
+    barrier.wait(timeout=_JOIN_TIMEOUT)
+    store.reconcile(sync_name, remove_ids={remove_id})
+
+
+def _dlq_concurrent_append_worker(
+    project_dir: str, sync_name: str, entry: DeadLetter, barrier: Barrier
+) -> None:
+    store = LocalDlqStore(Path(project_dir), lock_timeout=_TEST_LOCK_TIMEOUT)
+    barrier.wait(timeout=_JOIN_TIMEOUT)
+    store.append(sync_name, [entry])
+
+
+def test_reconcile_does_not_drop_a_concurrent_append(tmp_path: Path) -> None:
+    """The exact #955/#962 scenario: ``drt retry`` reconciling (removing one
+    replayed entry) while a genuinely separate ``drt run`` process appends a
+    new failure to the same queue. Neither operation may lose the other's.
+    """
+    store = LocalDlqStore(tmp_path)
+    seed = [DeadLetter(record={"seed": i}, error_message="pre-existing") for i in range(3)]
+    store.append("s", seed)
+    to_remove = seed[0].id
+    new_entry = DeadLetter(record={"new": True}, error_message="fresh failure")
+
+    barrier = _mp.Barrier(2)
+    p_reconcile = _mp.Process(
+        target=_dlq_reconcile_worker, args=(str(tmp_path), "s", to_remove, barrier)
+    )
+    p_append = _mp.Process(
+        target=_dlq_concurrent_append_worker, args=(str(tmp_path), "s", new_entry, barrier)
+    )
+    p_reconcile.start()
+    p_append.start()
+    p_reconcile.join(timeout=_JOIN_TIMEOUT)
+    p_append.join(timeout=_JOIN_TIMEOUT)
+    assert p_reconcile.exitcode == 0
+    assert p_append.exitcode == 0
+
+    final = store.read("s")
+    final_ids = {e.id for e in final}
+    # The removed seed entry is gone, the other two seeds survived, and the
+    # concurrent append landed: nothing silently overwritten either way.
+    assert to_remove not in final_ids
+    assert seed[1].id in final_ids
+    assert seed[2].id in final_ids
+    assert new_entry.id in final_ids
+    assert len(final) == 3  # 3 seeds - 1 removed + 1 appended
+
+
+# -- LocalStateManager ------------------------------------------------------
+
+
+def _state_save_worker(project_dir: str, sync_name: str, barrier: Barrier) -> None:
+    mgr = LocalStateManager(Path(project_dir), lock_timeout=_TEST_LOCK_TIMEOUT)
+    state = SyncState(
+        sync_name=sync_name,
+        last_run_at=mgr.now(),
+        records_synced=1,
+        status="success",
+    )
+    barrier.wait(timeout=_JOIN_TIMEOUT)
+    mgr.save_sync(state)
+
+
+def test_concurrent_save_sync_from_separate_processes_are_not_lost(tmp_path: Path) -> None:
+    n = 8
+    barrier = _mp.Barrier(n)
+    sync_names = [f"sync_{i}" for i in range(n)]
+    procs = [
+        _mp.Process(target=_state_save_worker, args=(str(tmp_path), name, barrier))
+        for name in sync_names
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=_JOIN_TIMEOUT)
+        assert p.exitcode == 0
+
+    mgr = LocalStateManager(tmp_path)
+    all_states = mgr.get_all()
+    assert set(all_states) == set(sync_names)
+
+
+# -- LocalHistoryManager -----------------------------------------------------
+
+
+def _history_append_burst_worker(
+    project_dir: str, sync_name: str, count: int, barrier: Barrier
+) -> None:
+    mgr = LocalHistoryManager(Path(project_dir), lock_timeout=_TEST_LOCK_TIMEOUT)
+    barrier.wait(timeout=_JOIN_TIMEOUT)
+    now = datetime.now(timezone.utc)
+    for i in range(count):
+        mgr.append(
+            HistoryEntry(
+                sync_name=sync_name,
+                started_at=(now + timedelta(microseconds=i)).isoformat(),
+                completed_at=(now + timedelta(microseconds=i, milliseconds=1)).isoformat(),
+                duration_seconds=0.001,
+                status="success",
+                records_synced=1,
+                records_failed=0,
+                run_id=f"run-{i}",
+            )
+        )
+
+
+def _history_prune_worker(project_dir: str, sync_name: str, barrier: Barrier) -> None:
+    mgr = LocalHistoryManager(Path(project_dir), lock_timeout=_TEST_LOCK_TIMEOUT)
+    barrier.wait(timeout=_JOIN_TIMEOUT)
+    for _ in range(5):
+        mgr.prune(sync_name, retention_days=1)
+
+
+def test_prune_does_not_drop_a_concurrent_append(tmp_path: Path) -> None:
+    """The history analogue of #955/#962: a retention ``prune()`` rewriting
+    the file while a separate process is mid-burst appending new entries
+    must not silently discard any of those appends.
+    """
+    mgr = LocalHistoryManager(tmp_path)
+    old = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    # Seed old entries directly so the first prune() has real work to do:
+    # appending them via mgr.append() would use "now", not an old timestamp.
+    history_dir = tmp_path / ".drt" / "history"
+    history_dir.mkdir(parents=True)
+    seed_lines = []
+    for i in range(3):
+        entry = HistoryEntry(
+            sync_name="s",
+            started_at=(old + timedelta(seconds=i)).isoformat(),
+            completed_at=(old + timedelta(seconds=i, milliseconds=1)).isoformat(),
+            duration_seconds=0.001,
+            status="success",
+            records_synced=1,
+            records_failed=0,
+        )
+        seed_lines.append(json.dumps(asdict(entry), default=str))
+    (history_dir / "s.jsonl").write_text("\n".join(seed_lines) + "\n")
+
+    n_appends = 40
+    barrier = _mp.Barrier(2)
+    p_append = _mp.Process(
+        target=_history_append_burst_worker, args=(str(tmp_path), "s", n_appends, barrier)
+    )
+    p_prune = _mp.Process(
+        target=_history_prune_worker, args=(str(tmp_path), "s", barrier)
+    )
+    p_append.start()
+    p_prune.start()
+    p_append.join(timeout=_JOIN_TIMEOUT)
+    p_prune.join(timeout=_JOIN_TIMEOUT)
+    assert p_append.exitcode == 0
+    assert p_prune.exitcode == 0
+
+    kept = mgr.read("s", limit=1000)
+    run_ids = {e.run_id for e in kept}
+    # All 40 fresh appends survived (none silently dropped by a racing
+    # prune), and the 3 seeded old entries were pruned away.
+    assert run_ids == {f"run-{i}" for i in range(n_appends)}
+    assert len(kept) == n_appends

--- a/tests/unit/test_state_file_lock.py
+++ b/tests/unit/test_state_file_lock.py
@@ -1,0 +1,92 @@
+"""Tests for drt.state._file_lock: the OS-level cross-process lock (#963)."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from drt.state._file_lock import FileLockTimeout, cross_process_lock
+
+
+def test_acquires_and_releases(tmp_path: Path) -> None:
+    lock_path = tmp_path / "x.lock"
+    with cross_process_lock(lock_path):
+        pass
+    # Released cleanly: a second, sequential acquire doesn't hang.
+    with cross_process_lock(lock_path):
+        pass
+
+
+def test_creates_lock_file_and_parent_dirs(tmp_path: Path) -> None:
+    lock_path = tmp_path / "nested" / "dir" / "x.lock"
+    with cross_process_lock(lock_path):
+        assert lock_path.exists()
+
+
+def test_second_holder_blocks_until_first_releases(tmp_path: Path) -> None:
+    """Two independent file descriptors on the same path, even within one
+    process, genuinely serialise under ``flock``/``msvcrt.locking``. That is
+    what lets this test prove blocking without spawning a real process.
+    """
+    lock_path = tmp_path / "x.lock"
+    first_holds = threading.Event()
+    second_acquired_at: list[float] = []
+    first_released_at: list[float] = []
+
+    def hold_then_release() -> None:
+        with cross_process_lock(lock_path):
+            first_holds.set()
+            time.sleep(0.2)
+        first_released_at.append(time.monotonic())
+
+    def wait_then_acquire() -> None:
+        first_holds.wait(timeout=2)
+        with cross_process_lock(lock_path, timeout=5):
+            second_acquired_at.append(time.monotonic())
+
+    t1 = threading.Thread(target=hold_then_release)
+    t2 = threading.Thread(target=wait_then_acquire)
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert first_released_at and second_acquired_at
+    # The second thread could only acquire at or after the first released.
+    assert second_acquired_at[0] >= first_released_at[0]
+
+
+def test_timeout_raises_when_lock_held(tmp_path: Path) -> None:
+    lock_path = tmp_path / "x.lock"
+    holder_ready = threading.Event()
+    release = threading.Event()
+
+    def hold_until_released() -> None:
+        with cross_process_lock(lock_path):
+            holder_ready.set()
+            release.wait(timeout=5)
+
+    t = threading.Thread(target=hold_until_released)
+    t.start()
+    holder_ready.wait(timeout=2)
+    try:
+        with pytest.raises(FileLockTimeout):
+            with cross_process_lock(lock_path, timeout=0.2):
+                pass  # pragma: no cover - never reached
+    finally:
+        release.set()
+        t.join(timeout=5)
+
+
+def test_lock_file_survives_and_is_reusable(tmp_path: Path) -> None:
+    """The lock file is never deleted after use (see the module docstring on
+    why): a third acquire against the same still-existing file must work.
+    """
+    lock_path = tmp_path / "x.lock"
+    for _ in range(3):
+        with cross_process_lock(lock_path):
+            pass
+    assert lock_path.exists()


### PR DESCRIPTION
Closes #963.

## Problem

`LocalDlqStore`, `LocalStateManager`, and `LocalHistoryManager` each guarded their read-modify-write cycle with a `threading.Lock`, which only serialises threads inside one process. Two genuinely separate `drt` CLI invocations (`drt run` and `drt retry`/`drt status` are always separate OS processes, never threads) racing the same file was last-writer-wins, with no way to detect it.

Flagged during review of #955/#962: `reconcile()` closed the race for the object-store backends via real generation/ETag preconditioning, but the local file backend had no equivalent primitive, so a concurrent process appending between the read and the write was still silently lost.

## Fix

Adds `drt/state/_file_lock.py`: an OS-level advisory lock (`fcntl.flock` on POSIX, `msvcrt.locking` on Windows) around a dedicated per-resource lock file, with a bounded timeout so a genuine deadlock surfaces as `FileLockTimeout` instead of hanging forever.

Wired into every read-modify-write path:
- `LocalDlqStore.append`/`replace`/`reconcile`
- `LocalStateManager.save_sync`/`reset` (raising `StateContentionError` on timeout, matching the `StateStore` Protocol's published contract from #992)
- `LocalHistoryManager.append`/`prune`

One thing that surfaced while writing the cross-process tests: `LocalHistoryManager.append` needed the lock too, not just `prune`, even though `O_APPEND` already makes its own write atomic against other appends. Without it, an append could still land between `prune`'s read and its replace and be silently discarded, since `flock` only serialises processes that both take it.

## Tests

Real `multiprocessing.Process` workers (spawn context) racing each store, since an in-process mock can't reproduce a cross-process race, per the issue's own note. Verified they actually catch the regression by temporarily stubbing the lock to a no-op: all four failed reliably, including one run that corrupted `state.json` outright. Restored the real implementation and confirmed all pass.

`make test`: 3525 passed (full suite plus the 9 new tests), 40 skipped. One pre-existing, unrelated failure locally (`test_invalid_key_fails_with_actionable_message`, missing the optional `pyrage`/encryption extra) confirmed to fail identically on unmodified `main`.
