### PR TITLE
dwh-smoke: explicitly start the Databricks warehouse before connecting

### DIFF
--- a/.github/workflows/dwh-smoke.yml
+++ b/.github/workflows/dwh-smoke.yml
@@ -115,6 +115,45 @@ jobs:
       - name: Install drt-core[dev,duckdb,databricks]
         if: steps.creds.outputs.has_creds == 'true'
         run: uv pip install --system -e ".[dev,duckdb,databricks]"
+      # The smoke warehouse auto-stops after idle time, and the databricks-sql-
+      # connector's implicit auto-start-on-connect proved unreliable against it
+      # (observed 2026-08-27: repeated `BAD_REQUEST: Cannot create the resource,
+      # please try again later` at session-open, three attempts over ~10h, while
+      # a manual Start from the Databricks UI succeeded immediately and let the
+      # very next run pass). Start it explicitly via the REST API and wait for
+      # RUNNING before handing off to pytest, rather than relying on the SQL
+      # client to trigger and outlast a cold start on its own.
+      - name: Start Databricks SQL warehouse and wait until running
+        if: steps.creds.outputs.has_creds == 'true'
+        run: |
+          set -euo pipefail
+          warehouse_id="${DRT_SMOKE_DATABRICKS_HTTP_PATH##*/}"
+          api="https://${DRT_SMOKE_DATABRICKS_HOST}/api/2.0/sql/warehouses/${warehouse_id}"
+          auth=(-H "Authorization: Bearer ${DRT_SMOKE_DATABRICKS_TOKEN}")
+
+          state=$(curl -sf "${auth[@]}" "$api" | jq -r '.state')
+          echo "Warehouse ${warehouse_id} current state: ${state}"
+
+          if [ "$state" != "RUNNING" ]; then
+            echo "Starting warehouse..."
+            curl -sf -X POST "${auth[@]}" "${api}/start" >/dev/null
+
+            deadline=$((SECONDS + 300))
+            while [ "$SECONDS" -lt "$deadline" ]; do
+              state=$(curl -sf "${auth[@]}" "$api" | jq -r '.state')
+              echo "  state=${state} (${SECONDS}s elapsed)"
+              if [ "$state" = "RUNNING" ]; then
+                break
+              fi
+              sleep 10
+            done
+
+            if [ "$state" != "RUNNING" ]; then
+              echo "::error::Warehouse did not reach RUNNING within 300s (last state: ${state})"
+              exit 1
+            fi
+          fi
+          echo "Warehouse is running."
       - name: Run Databricks smoke
         if: steps.creds.outputs.has_creds == 'true'
         run: pytest -m dwh_smoke tests/integration/dwh/test_databricks_smoke.py -v

--- a/.github/workflows/dwh-smoke.yml
+++ b/.github/workflows/dwh-smoke.yml
@@ -98,8 +98,15 @@ jobs:
       - name: Check credentials
         id: creds
         run: |
-          if [ -z "$DRT_SMOKE_DATABRICKS_HOST" ]; then
-            echo "No Databricks smoke secrets configured — skipping (no-op)."
+          # HOST alone used to be enough to gate the whole job, but the
+          # warehouse-start step below also needs HTTP_PATH (for the
+          # warehouse ID) and TOKEN (for the REST API call) -- a partially
+          # configured secret set (a real, intentionally supported state per
+          # this workflow's own "activates per-warehouse as secrets are
+          # added" design) must still no-op rather than call the API with an
+          # empty warehouse ID or token (Codex review, #1015).
+          if [ -z "$DRT_SMOKE_DATABRICKS_HOST" ] || [ -z "$DRT_SMOKE_DATABRICKS_HTTP_PATH" ] || [ -z "$DRT_SMOKE_DATABRICKS_TOKEN" ]; then
+            echo "No (or incomplete) Databricks smoke secrets configured — skipping (no-op)."
             echo "has_creds=false" >> "$GITHUB_OUTPUT"
           else
             echo "has_creds=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dwh-smoke.yml
+++ b/.github/workflows/dwh-smoke.yml
@@ -150,7 +150,7 @@ jobs:
           curl_retry() {
             local attempt
             for attempt in 1 2 3; do
-              if curl -sf "${auth[@]}" "$@"; then
+              if curl -sf --connect-timeout 10 --max-time 30 "${auth[@]}" "$@"; then
                 return 0
               fi
               sleep 3
@@ -174,7 +174,7 @@ jobs:
 
             deadline=$((SECONDS + 300))
             while [ "$SECONDS" -lt "$deadline" ]; do
-              if new_state=$(curl -sf "${auth[@]}" "$api" | jq -r '.state'); then
+              if new_state=$(curl -sf --connect-timeout 10 --max-time 30 "${auth[@]}" "$api" | jq -r '.state'); then
                 state="$new_state"
                 echo "  state=${state} (${SECONDS}s elapsed)"
                 if [ "$state" = "RUNNING" ]; then

--- a/.github/workflows/dwh-smoke.yml
+++ b/.github/workflows/dwh-smoke.yml
@@ -126,24 +126,55 @@ jobs:
       - name: Start Databricks SQL warehouse and wait until running
         if: steps.creds.outputs.has_creds == 'true'
         run: |
-          set -euo pipefail
+          # No `set -e`: every failure point below is handled explicitly.
+          # `curl -sf ... | jq` inside the polling loop must NOT abort the
+          # whole step on one transient 429/5xx/network blip -- that would
+          # spend none of the 300s budget the loop exists to provide (Codex
+          # review, #1015).
+          set -uo pipefail
           warehouse_id="${DRT_SMOKE_DATABRICKS_HTTP_PATH##*/}"
           api="https://${DRT_SMOKE_DATABRICKS_HOST}/api/2.0/sql/warehouses/${warehouse_id}"
           auth=(-H "Authorization: Bearer ${DRT_SMOKE_DATABRICKS_TOKEN}")
 
-          state=$(curl -sf "${auth[@]}" "$api" | jq -r '.state')
+          # A short bounded retry for the two one-shot calls below (initial
+          # status check, start request) -- separate from the polling loop's
+          # own longer-running retry budget, so neither call fails the whole
+          # job over a single bad response.
+          curl_retry() {
+            local attempt
+            for attempt in 1 2 3; do
+              if curl -sf "${auth[@]}" "$@"; then
+                return 0
+              fi
+              sleep 3
+            done
+            return 1
+          }
+
+          state=""
+          if ! state=$(curl_retry "$api" | jq -r '.state'); then
+            echo "::error::Could not reach the Databricks SQL Warehouses API to check status"
+            exit 1
+          fi
           echo "Warehouse ${warehouse_id} current state: ${state}"
 
           if [ "$state" != "RUNNING" ]; then
             echo "Starting warehouse..."
-            curl -sf -X POST "${auth[@]}" "${api}/start" >/dev/null
+            if ! curl_retry -X POST "${api}/start" >/dev/null; then
+              echo "::error::Failed to request warehouse start"
+              exit 1
+            fi
 
             deadline=$((SECONDS + 300))
             while [ "$SECONDS" -lt "$deadline" ]; do
-              state=$(curl -sf "${auth[@]}" "$api" | jq -r '.state')
-              echo "  state=${state} (${SECONDS}s elapsed)"
-              if [ "$state" = "RUNNING" ]; then
-                break
+              if new_state=$(curl -sf "${auth[@]}" "$api" | jq -r '.state'); then
+                state="$new_state"
+                echo "  state=${state} (${SECONDS}s elapsed)"
+                if [ "$state" = "RUNNING" ]; then
+                  break
+                fi
+              else
+                echo "  status check failed transiently, retrying... (${SECONDS}s elapsed)"
               fi
               sleep 10
             done

--- a/.github/workflows/dwh-smoke.yml
+++ b/.github/workflows/dwh-smoke.yml
@@ -98,14 +98,18 @@ jobs:
       - name: Check credentials
         id: creds
         run: |
-          # HOST alone used to be enough to gate the whole job, but the
-          # warehouse-start step below also needs HTTP_PATH (for the
-          # warehouse ID) and TOKEN (for the REST API call) -- a partially
-          # configured secret set (a real, intentionally supported state per
-          # this workflow's own "activates per-warehouse as secrets are
-          # added" design) must still no-op rather than call the API with an
-          # empty warehouse ID or token (Codex review, #1015).
-          if [ -z "$DRT_SMOKE_DATABRICKS_HOST" ] || [ -z "$DRT_SMOKE_DATABRICKS_HTTP_PATH" ] || [ -z "$DRT_SMOKE_DATABRICKS_TOKEN" ]; then
+          # HOST alone used to be enough to gate the whole job. Now checks all
+          # five secrets `test_databricks_smoke.py`'s own `require_env(...)`
+          # calls require: not just what the warehouse-start step below needs
+          # (HOST/HTTP_PATH/TOKEN, to avoid calling the API with an empty
+          # warehouse ID or token), but also CATALOG/SCHEMA -- otherwise a
+          # partial set missing only those two would still wake the live
+          # warehouse via the API, then have every pytest test skip anyway,
+          # burning compute for a run that validated nothing (Codex review,
+          # #1015). A partially configured secret set is a real,
+          # intentionally supported state per this workflow's own "activates
+          # per-warehouse as secrets are added" design and must fully no-op.
+          if [ -z "$DRT_SMOKE_DATABRICKS_HOST" ] || [ -z "$DRT_SMOKE_DATABRICKS_HTTP_PATH" ] || [ -z "$DRT_SMOKE_DATABRICKS_TOKEN" ] || [ -z "$DRT_SMOKE_DATABRICKS_CATALOG" ] || [ -z "$DRT_SMOKE_DATABRICKS_SCHEMA" ]; then
             echo "No (or incomplete) Databricks smoke secrets configured — skipping (no-op)."
             echo "has_creds=false" >> "$GITHUB_OUTPUT"
           else

--- a/tests/integration/dwh/README.md
+++ b/tests/integration/dwh/README.md
@@ -93,8 +93,12 @@ Databricks prerequisites (#672):
   Metastore works too — set the catalog to `hive_metastore`). All tables are
   created **Delta** (`USING DELTA`): the `replace_strategy: swap` leg relies on
   Delta `INSERT OVERWRITE` snapshot-isolation atomicity.
-- A running **SQL warehouse**; its HTTP path is `SMOKE_DATABRICKS_HTTP_PATH`.
-  The complex-type leg uses a `VARIANT` column, so the warehouse must be on a
+- A **SQL warehouse**; its HTTP path is `SMOKE_DATABRICKS_HTTP_PATH`. It does
+  not need to be left running between jobs — `dwh-smoke.yml`'s Databricks job
+  starts it via the REST API and waits for `RUNNING` before running pytest,
+  since the `databricks-sql-connector`'s implicit auto-start-on-connect proved
+  unreliable on an idle/auto-stopped warehouse (observed 2026-08-27). The
+  complex-type leg uses a `VARIANT` column, so the warehouse must be on a
   channel that supports VARIANT (current serverless/pro warehouses do).
 - Least-privilege grants for the token principal: `USE CATALOG` + `USE SCHEMA`,
   plus `CREATE TABLE` / `MODIFY` on the smoke schema — the swap leg builds and


### PR DESCRIPTION
## Summary

The smoke warehouse (Serverless Starter Warehouse) auto-stops after idle time. `databricks-sql-connector`'s implicit auto-start-on-connect proved unreliable against it — observed 2026-08-27: three attempts over ~10h all failed identically at session-open with `BAD_REQUEST: Cannot create the resource, please try again later`. Manually clicking Start in the Databricks UI succeeded immediately, and the very next scheduled run passed once the warehouse was already running.

- Adds a step to `dwh-smoke.yml`'s Databricks job that starts the warehouse via the SQL Warehouses REST API (`POST .../start`) and polls `GET .../warehouses/{id}` until `state == RUNNING` (5 minute timeout) before handing off to pytest.
- Uses the existing `SMOKE_DATABRICKS_HOST`/`HTTP_PATH`/`TOKEN` secrets — no new secrets needed. The warehouse ID is parsed from the existing `SMOKE_DATABRICKS_HTTP_PATH` secret's path.
- Updated `tests/integration/dwh/README.md`'s prerequisites note (previously said the warehouse just needs to be "running" — now the workflow ensures that itself).

[skip changelog] — CI/workflow reliability fix only, no user-facing drt-core behavior change.

## Test plan

- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`
- [x] Dry-run tested the bash logic locally against a mock `curl` for both the success path (STOPPED → STARTING → RUNNING) and the timeout-failure path — both behave correctly
- [x] Root-caused live against the actual failing workflow run: manually started the warehouse in the Databricks UI, re-ran the smoke job while it was warm, confirmed it passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)