### PR TITLE
chore(dagster-drt): prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Fixed: `DagsterDrtResource.run()` never passed `history_manager=` to `run_sync()`** ([#980](https://github.com/drt-hub/drt/issues/980)) — a Dagster-triggered sync's execution history stayed empty regardless of `state.backend`, since `run_sync()` only appends history when `history_manager` is supplied. The identical gap the drt-core `run_drt_sync()` fix closed for Airflow/Prefect (see drt-core's `[Unreleased]` CHANGELOG entry), found while fixing that one but out of scope for it since `dagster-drt` is a separately-versioned package. Now passes `history_manager=bundle.history` and `history_retention_days=project.history.retention_days`, matching the CLI's own call site.
 
-- Requires `drt-core>=0.9.0`, `dagster>=1.10.18`
+- Requires `drt-core>=0.9.1`, `dagster>=1.10.18` — the 0.9.0 floor is unsafe for this package: its `StatePersistingObserver` advances the watermark on `DagsterDrtResource.run(dry_run=True)` previews ([#978](https://github.com/drt-hub/drt/issues/978), fixed in drt-core 0.9.1)
 
 ### [0.3.0] - 2026-04-16 (dagster-drt)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > `dagster-drt` is published as a separate PyPI package with its own version.
 
-### Unreleased (dagster-drt)
+### [0.4.0] - 2026-08-28 (dagster-drt)
 
 - **Chainable `DrtEventIterator` post-processing** ([#182](https://github.com/drt-hub/drt/issues/182)): `DagsterDrtResource.run()` now returns an iterator wrapper, matching dagster-dlt's established execution shape, so asset bodies can write `yield from drt.run(context=context).fetch_row_count()`. `fetch_row_count()` independently re-runs each resolved model against the configured **source** and attaches Dagster's standard `dagster/row_count` metadata; it deliberately does not copy `rows_extracted` or `rows_synced`, which remain the engine result from the original run and therefore are not an independent post-load check. The verification query follows the project's `query_tagging` configuration with its own fresh run id, including both the universal SQL comment and native source tags, and incremental models are rendered with the exact `cursor_value_used` by the original sync so they verify the same window. Fixing this surfaced a separate, pre-existing gap in the same code path: `DagsterDrtResource.run()`'s own `run_sync()` call never passed `project.query_tagging` at all, so a project explicitly disabling tagging (`query_tagging.enabled: false`) or setting custom `extra` tags had that config silently ignored for every sync executed through dagster-drt — the CLI's `drt run` path was unaffected, this was dagster-drt-specific. Now fixed alongside the row-count query. Source-count failures are logged and leave the original materialization intact, matching the optional post-processing contract in dagster-dlt. The same wrapper handles both event forms now emitted by the resource — `MaterializeResult` under `@drt_assets` and `AssetMaterialization` under `@op` — without separate chaining APIs.
 
@@ -24,6 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Fixed: `DagsterDrtResource.run()` and the legacy `drt_assets_legacy()` path ignored `state.backend`.** Both constructed `StateManager(project_path)` directly instead of going through [#756](https://github.com/drt-hub/drt/issues/756)'s `build_state_bundle()` factory — a project configured with `state.backend: gcs` or `s3` still wrote run state to local disk when executed through dagster-drt, silently defeating the whole point of a remote backend for orchestrator-launched runs. Found while researching [#855](https://github.com/drt-hub/drt/issues/855) (dagster-drt sensors): the sensor's premise — a sensor process and a CI-launched `drt run` sharing durable state — doesn't hold if the execution path itself never picks up the remote backend. Also: `integrations/dagster-drt/tests/` (36 tests) had never run in CI (separate fix, `ci.yml` + `publish-dagster-drt.yml`, no version bump).
 
 - **Fixed: `DagsterDrtResource.run()` never passed `history_manager=` to `run_sync()`** ([#980](https://github.com/drt-hub/drt/issues/980)) — a Dagster-triggered sync's execution history stayed empty regardless of `state.backend`, since `run_sync()` only appends history when `history_manager` is supplied. The identical gap the drt-core `run_drt_sync()` fix closed for Airflow/Prefect (see drt-core's `[Unreleased]` CHANGELOG entry), found while fixing that one but out of scope for it since `dagster-drt` is a separately-versioned package. Now passes `history_manager=bundle.history` and `history_retention_days=project.history.retention_days`, matching the CLI's own call site.
+
+- Requires `drt-core>=0.9.0`, `dagster>=1.10.18`
+
+### [0.3.0] - 2026-04-16 (dagster-drt)
+
+- **Source-volume and incremental-sync observability** ([#343](https://github.com/drt-hub/drt/issues/343)) — `DagsterDrtResource.run()` now reports `rows_extracted` and `duration_seconds` metadata, logs the extracted count, and wires watermark storage so Dagster-launched incremental syncs persist and reuse their cursor.
+- Requires `drt-core>=0.5.3`, `dagster>=1.6`
 
 ### [0.2.0] - 2026-04-04 (dagster-drt)
 

--- a/README.md
+++ b/README.md
@@ -427,7 +427,14 @@ defs = Definitions(
 )
 ```
 
-See [dagster-drt README](integrations/dagster-drt/README.md) for full API docs (Translator, Pipes support, DrtConfig dry-run, MaterializeResult).
+For event-driven activation, `build_drt_change_sensor()` watches metadata-only
+change signals from Delta Lake, Iceberg, Snowflake, or SQL Server. The same
+resource also runs explicitly selected syncs from a plain Dagster `@op`, returns
+a chainable `DrtEventIterator` for source row-count checks, and powers the
+declarative `DrtSyncComponent` for `defs.yaml` projects.
+
+See [dagster-drt README](integrations/dagster-drt/README.md) for full API docs
+(sensors, Components, `@op`, Translator, Pipes support, and dry-run config).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,8 +14,8 @@
 
 | Version | Supported |
 |---------|-----------|
+| 0.4.x   | ✅        |
 | 0.3.x   | ✅        |
-| 0.2.x   | ✅        |
 
 ## Supply-Chain Scanning
 

--- a/docs/llm/CONTEXT.md
+++ b/docs/llm/CONTEXT.md
@@ -217,6 +217,19 @@ specs = build_drt_asset_specs(project_dir=".")
 # Use specs with @multi_asset + PipesClient
 ```
 
+The v0.4 API also includes:
+
+- `build_drt_change_sensor()` for event-driven runs from metadata-only Delta
+  Lake, Iceberg, Snowflake, or SQL Server change signals. Snowflake requires
+  both `watch_table=` and an explicit `minimum_interval_seconds=`; SQL Server
+  requires `watch_table=` to validate table-level Change Tracking.
+- Plain `@op` execution through `DagsterDrtResource.run(context=...,
+  sync_names=[...])`, which emits asset materializations without requiring an
+  `@drt_assets` definition.
+- `DrtEventIterator`, returned by `run()`, with chainable
+  `.fetch_row_count()` source-side verification.
+- `DrtSyncComponent` for declarative `defs.yaml` assets and `dg scaffold defs`.
+
 ## AI Skills for Claude Code
 
 Four skills available via the Claude Code plugin marketplace:

--- a/integrations/dagster-drt/pyproject.toml
+++ b/integrations/dagster-drt/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dagster-drt"
-version = "0.3.0"
+version = "0.4.0"
 description = "Community-maintained Dagster integration for drt (data reverse tool)"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/integrations/dagster-drt/pyproject.toml
+++ b/integrations/dagster-drt/pyproject.toml
@@ -11,7 +11,7 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
 dependencies = [
     "dagster>=1.10.18",  # current defs.yaml Components API + per-project dg CLI contract
-    "drt-core>=0.9.0",  # drt.state.factory.build_state_bundle() first shipped in 0.9.0
+    "drt-core>=0.9.1",  # 0.9.0's StatePersistingObserver advanced the watermark on dry runs (#978, fixed in 0.9.1)
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
## Summary

`dagster-drt`'s last PyPI publish was v0.3.0 (2026-04-16). Since then, ~4 months of merged features and fixes accumulated on `main` without ever being versioned or released:

- `build_drt_change_sensor()` — event-driven activation (#855), Snowflake/SQL Server support (#975)
- `DrtEventIterator` chainable post-processing, `DrtSyncComponent` declarative `defs.yaml` support, `@op` execution (#182, #183, #184 / #1005)
- Fix: `DagsterDrtResource.run()` ignored `state.backend` (#973) — a project configured with `state.backend: gcs`/`s3` still wrote run state to local disk when executed through dagster-drt
- Fix: `history_manager=` never wired through (#980)

This PR is pure release housekeeping, no functional code changes:

- Bump `integrations/dagster-drt/pyproject.toml` to `0.4.0`
- `CHANGELOG.md`: rename `### Unreleased (dagster-drt)` → `### [0.4.0] - 2026-08-28 (dagster-drt)`. Also backfills a **missing 0.3.0 entry** — that release shipped #343 (rows_extracted metadata + watermark storage integration) but was never changelogged at all
- `README.md`, `docs/llm/CONTEXT.md`: brief mentions of the new sensor/`@op`/Component surface, matching each file's existing level of detail
- `SECURITY.md`: supported versions → `0.4.x` + `0.3.x` (drop `0.2.x`), matching the existing N/N-1 pattern

Verified independently (not just Codex's self-report): `dagster_drt/__init__.py`'s `__all__` already exports everything the new features expose (`DrtEventIterator`, `DrtSyncComponent`, `build_drt_change_sensor`) — no gap there. `dagster>=1.10.18` floor (not `>=1.6`) is correct — `DrtSyncComponent`'s Components API requires it, confirmed against `main`'s current pyproject.toml (a stale local branch I first checked still had `>=1.6`, which was the red herring, not the repo).

Does **not** create a git tag, push, or publish to PyPI — that's the follow-up once this merges (`git tag dagster-drt-v0.4.0 && git push origin dagster-drt-v0.4.0`, which triggers `publish-dagster-drt.yml`), plus a `--latest=false` GitHub Release per the `dagster-drt-release-check` skill so it doesn't steal "Latest" from the `drt-core` release.

## Test plan

- [x] `cd integrations/dagster-drt && pytest tests/ -q` — 70 passed
- [x] `ruff check integrations/dagster-drt` — clean
- [x] `mypy integrations/dagster-drt/dagster_drt` — clean
- [x] `ruff check drt tests && mypy drt` (repo root, to confirm no unrelated breakage) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)