### PR TITLE
refactor(destinations): centralize RowError recording across 23 files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Internal — RowError recording centralized across 23 destinations** ([#722](https://github.com/drt-hub/drt/issues/722)): the `try/except → result.failed += 1 → row_errors.append(RowError(...))` idiom, duplicated roughly 100 times across the destination layer, now goes through a shared `record_row_error()` helper (`drt/destinations/row_errors.py`). Each site keeps computing its own `record_preview` (a JSON dict dump for most destinations, `str()` of an already-transformed positional bind list for a few warehouse ones) and its own `on_error` control flow (`break`/`continue`/`return`/`raise`, whichever it already used) — only the 3-line "record the failure" block moved. `postgres.py`/`mysql.py` keep their own working `BaseSqlDestination._record_row_error`, unchanged; `clickhouse.py` was deliberately left alone (an unrelated in-flight PR was actively changing its error handling) for a follow-up sweep. No behavior change.
+
 ## [0.10.0] - 2026-08-28
 
 ### Fixed

--- a/drt/destinations/airtable.py
+++ b/drt/destinations/airtable.py
@@ -39,7 +39,7 @@ from drt.config.models import AirtableDestinationConfig, DestinationConfig, Sync
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 
 _BASE_URL = "https://api.airtable.com/v0"
 _MAX_BATCH = 10  # Airtable API limit
@@ -115,14 +115,13 @@ class AirtableDestination:
         message: str,
     ) -> None:
         for index, record in chunk:
-            result.failed += 1
-            result.row_errors.append(
-                RowError(
-                    batch_index=index,
-                    record_preview=str(record)[:200],
-                    http_status=status,
-                    error_message=message,
-                )
+            record_row_error(
+                result,
+                index,
+                str(record)[:200],
+                Exception(message),
+                http_status=status,
+                error_message=message,
             )
 
     def test_connection(self, config: DestinationConfig) -> None:

--- a/drt/destinations/amplitude.py
+++ b/drt/destinations/amplitude.py
@@ -42,7 +42,7 @@ from drt.config.models import (
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 from drt.templates.renderer import render_template
 
 _AMPLITUDE_HOSTS = {
@@ -372,12 +372,11 @@ def _add_row_error(
     http_status: int | None,
     message: str,
 ) -> None:
-    result.failed += 1
-    result.row_errors.append(
-        RowError(
-            batch_index=index,
-            record_preview=json.dumps(record, default=str)[:200],
-            http_status=http_status,
-            error_message=message,
-        )
+    record_row_error(
+        result,
+        index,
+        json.dumps(record, default=str)[:200],
+        Exception(message),
+        http_status=http_status,
+        error_message=message,
     )

--- a/drt/destinations/bigquery.py
+++ b/drt/destinations/bigquery.py
@@ -31,7 +31,7 @@ from typing import Any
 from drt.config.models import BigQueryDestinationConfig, DestinationConfig, SyncOptions
 from drt.config.query_tags import normalize_bigquery_label
 from drt.destinations.base import SyncResult
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import RowError, record_row_error
 
 
 class BigQueryDestination:
@@ -81,18 +81,16 @@ class BigQueryDestination:
 
         for i, row in enumerate(records):
             if i in failed_indices:
-                result.failed += 1
                 msg = next(
                     (str(e.get("errors", e)) for e in errors if e.get("index") == i),
                     "insert failed",
                 )
-                result.row_errors.append(
-                    RowError(
-                        batch_index=i,
-                        record_preview=str(row)[:200],
-                        http_status=None,
-                        error_message=msg,
-                    )
+                record_row_error(
+                    result,
+                    i,
+                    str(row)[:200],
+                    RuntimeError(msg),
+                    error_message=msg,
                 )
             else:
                 result.success += 1

--- a/drt/destinations/databricks.py
+++ b/drt/destinations/databricks.py
@@ -55,7 +55,7 @@ from typing import Any
 from drt.config.credentials import resolve_env
 from drt.config.models import DatabricksDestinationConfig, DestinationConfig, SyncOptions
 from drt.destinations.base import SyncResult
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 from drt.destinations.sql_utils import tagged_cursor
 
 _SWAP_SUFFIX = "__drt_swap"
@@ -549,14 +549,11 @@ class DatabricksDestination:
                 if count_success:
                     result.success += 1
             except Exception as e:
-                result.failed += 1
-                result.row_errors.append(
-                    RowError(
-                        batch_index=base_index + i,
-                        record_preview=str(row)[:200],
-                        http_status=None,
-                        error_message=str(e),
-                    )
+                record_row_error(
+                    result,
+                    base_index + i,
+                    str(row)[:200],
+                    e,
                 )
                 if sync_options.on_error == "fail":
                     raise

--- a/drt/destinations/discord.py
+++ b/drt/destinations/discord.py
@@ -42,7 +42,7 @@ from drt.config.models import DestinationConfig, DiscordDestinationConfig, SyncO
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 from drt.templates.renderer import render_template
 
 
@@ -88,26 +88,22 @@ class DiscordDestination:
                     with_retry(do_post, retry_config)
                     result.success += 1
                 except httpx.HTTPStatusError as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record, default=str)[:200],
-                            http_status=e.response.status_code,
-                            error_message=e.response.text[:500],
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        json.dumps(record, default=str)[:200],
+                        e,
+                        http_status=e.response.status_code,
+                        error_message=e.response.text[:500],
                     )
                     if sync_options.on_error == "fail":
                         break
                 except Exception as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record, default=str)[:200],
-                            http_status=None,
-                            error_message=str(e),
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        json.dumps(record, default=str)[:200],
+                        e,
                     )
                     if sync_options.on_error == "fail":
                         break

--- a/drt/destinations/elasticsearch.py
+++ b/drt/destinations/elasticsearch.py
@@ -53,7 +53,7 @@ from drt.config.models import DestinationConfig, ElasticsearchDestinationConfig,
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 
 
 class ElasticsearchDestination:
@@ -206,12 +206,11 @@ def _add_row_error(
     http_status: int | None,
     message: str,
 ) -> None:
-    result.failed += 1
-    result.row_errors.append(
-        RowError(
-            batch_index=index,
-            record_preview=json.dumps(record, default=str)[:200],
-            http_status=http_status,
-            error_message=message,
-        )
+    record_row_error(
+        result,
+        index,
+        json.dumps(record, default=str)[:200],
+        Exception(message),
+        http_status=http_status,
+        error_message=message,
     )

--- a/drt/destinations/email_smtp.py
+++ b/drt/destinations/email_smtp.py
@@ -35,7 +35,7 @@ from drt.config.credentials import resolve_env
 from drt.config.models import DestinationConfig, EmailSmtpDestinationConfig, SyncOptions
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, resolve_rate_limiter
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 from drt.templates.renderer import render_template
 
 
@@ -83,26 +83,21 @@ class EmailSmtpDestination:
 
                 result.success += 1
             except smtplib.SMTPException as e:
-                result.failed += 1
-                result.row_errors.append(
-                    RowError(
-                        batch_index=i,
-                        record_preview=json.dumps(record, default=str)[:200],
-                        http_status=None,
-                        error_message=str(e)[:500],
-                    )
+                record_row_error(
+                    result,
+                    i,
+                    json.dumps(record, default=str)[:200],
+                    e,
+                    error_message=str(e)[:500],
                 )
                 if sync_options.on_error == "fail":
                     return result
             except Exception as e:
-                result.failed += 1
-                result.row_errors.append(
-                    RowError(
-                        batch_index=i,
-                        record_preview=json.dumps(record, default=str)[:200],
-                        http_status=None,
-                        error_message=str(e),
-                    )
+                record_row_error(
+                    result,
+                    i,
+                    json.dumps(record, default=str)[:200],
+                    e,
                 )
                 if sync_options.on_error == "fail":
                     return result

--- a/drt/destinations/github_actions.py
+++ b/drt/destinations/github_actions.py
@@ -45,7 +45,7 @@ from drt.config.models import (
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 from drt.templates.renderer import render_template
 
 _GITHUB_API = "https://api.github.com"
@@ -95,14 +95,12 @@ class GitHubActionsDestination:
                         rendered = render_template(config.inputs_template, record)
                         inputs = json.loads(rendered)
                     except (ValueError, json.JSONDecodeError) as e:
-                        result.failed += 1
-                        result.row_errors.append(
-                            RowError(
-                                batch_index=i,
-                                record_preview=json.dumps(record, default=str)[:200],
-                                http_status=None,
-                                error_message=f"inputs_template error: {e}",
-                            )
+                        record_row_error(
+                            result,
+                            i,
+                            json.dumps(record, default=str)[:200],
+                            e,
+                            error_message=f"inputs_template error: {e}",
                         )
                         continue
 
@@ -123,26 +121,22 @@ class GitHubActionsDestination:
                     with_retry(do_request, retry_config)
                     result.success += 1
                 except httpx.HTTPStatusError as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record, default=str)[:200],
-                            http_status=e.response.status_code,
-                            error_message=e.response.text[:500],
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        json.dumps(record, default=str)[:200],
+                        e,
+                        http_status=e.response.status_code,
+                        error_message=e.response.text[:500],
                     )
                     if sync_options.on_error == "fail":
                         break
                 except Exception as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record, default=str)[:200],
-                            http_status=None,
-                            error_message=str(e),
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        json.dumps(record, default=str)[:200],
+                        e,
                     )
                     if sync_options.on_error == "fail":
                         break

--- a/drt/destinations/google_ads.py
+++ b/drt/destinations/google_ads.py
@@ -42,7 +42,7 @@ from drt.destinations.auth import AuthHandler
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 
 _API_VERSION = "v17"
 _BASE_URL = "https://googleads.googleapis.com"
@@ -82,18 +82,16 @@ class GoogleAdsDestination:
             gclid = record.get(config.gclid_field)
             conv_time = record.get(config.conversion_time_field)
             if not gclid or not conv_time:
-                result.failed += 1
-                result.row_errors.append(
-                    RowError(
-                        batch_index=i,
-                        record_preview=json.dumps(record, default=str)[:200],
-                        http_status=None,
-                        error_message=(
-                            f"Missing required field: "
-                            f"{config.gclid_field} or "
-                            f"{config.conversion_time_field}"
-                        ),
-                    )
+                record_row_error(
+                    result,
+                    i,
+                    json.dumps(record, default=str)[:200],
+                    ValueError(),
+                    error_message=(
+                        f"Missing required field: "
+                        f"{config.gclid_field} or "
+                        f"{config.conversion_time_field}"
+                    ),
                 )
                 if sync_options.on_error == "fail":
                     break

--- a/drt/destinations/hubspot.py
+++ b/drt/destinations/hubspot.py
@@ -52,7 +52,7 @@ from drt.config.models import DestinationConfig, HubSpotDestinationConfig, SyncO
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 from drt.templates.renderer import render_template
 
 _HUBSPOT_API = "https://api.hubapi.com/crm/v3/objects"
@@ -97,14 +97,12 @@ class HubSpotDestination:
                         rendered = render_template(config.properties_template, record)
                         properties = json.loads(rendered)
                     except (ValueError, json.JSONDecodeError) as e:
-                        result.failed += 1
-                        result.row_errors.append(
-                            RowError(
-                                batch_index=i,
-                                record_preview=json.dumps(record, default=str)[:200],
-                                http_status=None,
-                                error_message=f"properties_template error: {e}",
-                            )
+                        record_row_error(
+                            result,
+                            i,
+                            json.dumps(record, default=str)[:200],
+                            e,
+                            error_message=f"properties_template error: {e}",
                         )
                         continue
                 else:
@@ -169,26 +167,22 @@ class HubSpotDestination:
                     else:
                         result.success += 1
                 except httpx.HTTPStatusError as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record, default=str)[:200],
-                            http_status=e.response.status_code,
-                            error_message=e.response.text[:500],
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        json.dumps(record, default=str)[:200],
+                        e,
+                        http_status=e.response.status_code,
+                        error_message=e.response.text[:500],
                     )
                     if sync_options.on_error == "fail":
                         break
                 except Exception as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record, default=str)[:200],
-                            http_status=None,
-                            error_message=str(e),
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        json.dumps(record, default=str)[:200],
+                        e,
                     )
                     if sync_options.on_error == "fail":
                         break

--- a/drt/destinations/intercom.py
+++ b/drt/destinations/intercom.py
@@ -42,7 +42,7 @@ from drt.config.models import (
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 from drt.templates.renderer import render_template
 
 
@@ -103,27 +103,23 @@ class IntercomDestination:
                     result.success += 1
 
                 except httpx.HTTPStatusError as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=str(record)[:200],
-                            http_status=e.response.status_code,
-                            error_message=e.response.text[:500],
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        str(record)[:200],
+                        e,
+                        http_status=e.response.status_code,
+                        error_message=e.response.text[:500],
                     )
                     if sync_options.on_error == "fail":
                         raise
 
                 except Exception as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=str(record)[:200],
-                            http_status=None,
-                            error_message=str(e),
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        str(record)[:200],
+                        e,
                     )
                     if sync_options.on_error == "fail":
                         raise

--- a/drt/destinations/jira.py
+++ b/drt/destinations/jira.py
@@ -18,8 +18,8 @@ from drt.config.models import DestinationConfig, JiraDestinationConfig, RetryCon
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
 from drt.destinations.row_errors import record_preview as _record_preview
+from drt.destinations.row_errors import record_row_error
 from drt.templates.renderer import render_template
 
 logger = logging.getLogger(__name__)
@@ -147,29 +147,25 @@ class JiraDestination:
                         logger.info("Jira issue created for row index %s", i)
                     result.success += 1
                 except httpx.HTTPStatusError as e:
-                    result.failed += 1
-                    logger.warning("Jira request failed for row %s: %s", i, e)
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=_record_preview(row),
-                            http_status=e.response.status_code,
-                            error_message=e.response.text[:500],
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        _record_preview(row),
+                        e,
+                        http_status=e.response.status_code,
+                        error_message=e.response.text[:500],
                     )
+                    logger.warning("Jira request failed for row %s: %s", i, e)
                     if sync_options.on_error == "fail":
                         break
                 except Exception as e:
-                    result.failed += 1
-                    logger.warning("Jira destination failed for row %s: %s", i, e)
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=_record_preview(row),
-                            http_status=None,
-                            error_message=str(e),
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        _record_preview(row),
+                        e,
                     )
+                    logger.warning("Jira destination failed for row %s: %s", i, e)
                     if sync_options.on_error == "fail":
                         break
         return result

--- a/drt/destinations/klaviyo.py
+++ b/drt/destinations/klaviyo.py
@@ -44,7 +44,7 @@ from drt.config.models import (
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 from drt.templates.renderer import render_template
 
 _BASE = "https://a.klaviyo.com/api"
@@ -87,26 +87,22 @@ class KlaviyoDestination:
                     self._upsert(client, config, headers, record, list_id, retry_config)
                     result.success += 1
                 except httpx.HTTPStatusError as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=index,
-                            record_preview=str(record)[:200],
-                            http_status=e.response.status_code,
-                            error_message=e.response.text[:500],
-                        )
+                    record_row_error(
+                        result,
+                        index,
+                        str(record)[:200],
+                        e,
+                        http_status=e.response.status_code,
+                        error_message=e.response.text[:500],
                     )
                     if sync_options.on_error == "fail":
                         break
                 except Exception as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=index,
-                            record_preview=str(record)[:200],
-                            http_status=None,
-                            error_message=str(e),
-                        )
+                    record_row_error(
+                        result,
+                        index,
+                        str(record)[:200],
+                        e,
                     )
                     if sync_options.on_error == "fail":
                         break

--- a/drt/destinations/linear.py
+++ b/drt/destinations/linear.py
@@ -34,8 +34,8 @@ from drt.config.models import DestinationConfig, LinearDestinationConfig, SyncOp
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
 from drt.destinations.row_errors import record_preview as _record_preview
+from drt.destinations.row_errors import record_row_error
 from drt.templates.renderer import render_template
 
 logger = logging.getLogger(__name__)
@@ -123,38 +123,32 @@ class LinearDestination:
                     result.success += 1
 
                 except httpx.HTTPStatusError as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=_record_preview(record),
-                            http_status=e.response.status_code,
-                            error_message=e.response.text[:500],
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        _record_preview(record),
+                        e,
+                        http_status=e.response.status_code,
+                        error_message=e.response.text[:500],
                     )
                     if sync_options.on_error == "fail":
                         break
                 except httpx.RequestError as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=_record_preview(record),
-                            http_status=None,
-                            error_message=f"Request error: {e}",
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        _record_preview(record),
+                        e,
+                        error_message=f"Request error: {e}",
                     )
                     if sync_options.on_error == "fail":
                         break
                 except Exception as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=_record_preview(record),
-                            http_status=None,
-                            error_message=str(e),
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        _record_preview(record),
+                        e,
                     )
                     if sync_options.on_error == "fail":
                         break

--- a/drt/destinations/mixpanel.py
+++ b/drt/destinations/mixpanel.py
@@ -60,7 +60,7 @@ from drt.config.models import (
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, RateLimiterBackend, resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 from drt.templates.renderer import render_template
 
 _MIXPANEL_HOSTS = {
@@ -358,12 +358,11 @@ def _add_row_error(
     http_status: int | None,
     message: str,
 ) -> None:
-    result.failed += 1
-    result.row_errors.append(
-        RowError(
-            batch_index=index,
-            record_preview=json.dumps(record, default=str)[:200],
-            http_status=http_status,
-            error_message=message,
-        )
+    record_row_error(
+        result,
+        index,
+        json.dumps(record, default=str)[:200],
+        Exception(message),
+        http_status=http_status,
+        error_message=message,
     )

--- a/drt/destinations/notion.py
+++ b/drt/destinations/notion.py
@@ -38,7 +38,7 @@ from drt.config.models import (
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 from drt.templates.renderer import render_template
 
 _NOTION_API = "https://api.notion.com/v1"
@@ -84,14 +84,12 @@ class NotionDestination:
                         rendered = render_template(config.properties_template, record)
                         properties = json.loads(rendered)
                     except (ValueError, json.JSONDecodeError) as e:
-                        result.failed += 1
-                        result.row_errors.append(
-                            RowError(
-                                batch_index=i,
-                                record_preview=json.dumps(record, default=str)[:200],
-                                http_status=None,
-                                error_message=f"properties_template error: {e}",
-                            )
+                        record_row_error(
+                            result,
+                            i,
+                            json.dumps(record, default=str)[:200],
+                            e,
+                            error_message=f"properties_template error: {e}",
                         )
                         if sync_options.on_error == "fail":
                             return result
@@ -122,26 +120,22 @@ class NotionDestination:
                     with_retry(do_create, retry_config)
                     result.success += 1
                 except httpx.HTTPStatusError as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record, default=str)[:200],
-                            http_status=e.response.status_code,
-                            error_message=e.response.text[:500],
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        json.dumps(record, default=str)[:200],
+                        e,
+                        http_status=e.response.status_code,
+                        error_message=e.response.text[:500],
                     )
                     if sync_options.on_error == "fail":
                         return result
                 except Exception as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record, default=str)[:200],
-                            http_status=None,
-                            error_message=str(e),
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        json.dumps(record, default=str)[:200],
+                        e,
                     )
                     if sync_options.on_error == "fail":
                         return result

--- a/drt/destinations/rest_api.py
+++ b/drt/destinations/rest_api.py
@@ -30,7 +30,7 @@ from drt.destinations.auth import AuthHandler
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import RowError, record_row_error
 from drt.templates.renderer import render_template
 
 logger = logging.getLogger(__name__)
@@ -167,15 +167,13 @@ class RestApiDestination:
                         # established the precedent: catch every exception a
                         # template can raise, or on_error: skip stops being
                         # effective for exactly the row that needs it.
-                        result.row_errors.append(
-                            RowError(
-                                batch_index=i,
-                                record_preview=json.dumps(record, default=str)[:200],
-                                http_status=None,
-                                error_message=f"Template error: {e}",
-                            )
+                        record_row_error(
+                            result,
+                            i,
+                            json.dumps(record, default=str)[:200],
+                            e,
+                            error_message=f"Template error: {e}",
                         )
-                        result.failed += 1
                         if sync_options.on_error == "fail":
                             return result
                         continue
@@ -200,27 +198,23 @@ class RestApiDestination:
                     with_retry(do_request, retry_config)
                     result.success += 1
                 except httpx.HTTPStatusError as e:
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record, default=str)[:200],
-                            http_status=e.response.status_code,
-                            error_message=e.response.text[:500],
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        json.dumps(record, default=str)[:200],
+                        e,
+                        http_status=e.response.status_code,
+                        error_message=e.response.text[:500],
                     )
-                    result.failed += 1
                     if sync_options.on_error == "fail":
                         return result
                 except Exception as e:
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record, default=str)[:200],
-                            http_status=None,
-                            error_message=str(e),
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        json.dumps(record, default=str)[:200],
+                        e,
                     )
-                    result.failed += 1
                     if sync_options.on_error == "fail":
                         return result
 
@@ -288,15 +282,14 @@ class RestApiDestination:
             if error is None:
                 result.success += 1
                 continue
-            result.row_errors.append(
-                RowError(
-                    batch_index=offset + local_index,
-                    record_preview=json.dumps(record, default=str)[:200],
-                    http_status=response.status_code,
-                    error_message=_batch_error_message(error),
-                )
+            record_row_error(
+                result,
+                offset + local_index,
+                json.dumps(record, default=str)[:200],
+                RuntimeError(),
+                http_status=response.status_code,
+                error_message=_batch_error_message(error),
             )
-            result.failed += 1
 
     def fetch_paginated(
         self,

--- a/drt/destinations/row_errors.py
+++ b/drt/destinations/row_errors.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
+from drt.destinations.base import SyncResult
+
 
 @dataclass
 class RowError:
@@ -17,6 +19,34 @@ class RowError:
     http_status: int | None
     error_message: str
     timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+def record_row_error(
+    result: SyncResult,
+    batch_index: int,
+    record_preview: str,
+    exc: Exception,
+    *,
+    http_status: int | None = None,
+    error_message: str | None = None,
+) -> None:
+    """Append the standard per-row RowError and increment result.failed.
+
+    Callers compute record_preview themselves (the basis varies -- a JSON
+    dict dump for most destinations, str() of an already-transformed bind
+    list for a few warehouse ones -- this function does not guess it) and
+    keep their own on_error control flow (break/continue/return/raise) --
+    this function only does the "record the failure" half.
+    """
+    result.failed += 1
+    result.row_errors.append(
+        RowError(
+            batch_index=batch_index,
+            record_preview=record_preview,
+            http_status=http_status,
+            error_message=error_message if error_message is not None else str(exc),
+        )
+    )
 
 
 def record_preview(record: dict[str, Any]) -> str:

--- a/drt/destinations/sendgrid.py
+++ b/drt/destinations/sendgrid.py
@@ -38,8 +38,8 @@ from drt.config.models import DestinationConfig, SendGridDestinationConfig, Sync
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
 from drt.destinations.row_errors import record_preview as _record_preview
+from drt.destinations.row_errors import record_row_error
 from drt.templates.renderer import render_template
 
 logger = logging.getLogger(__name__)
@@ -118,38 +118,32 @@ class SendGridDestination:
                     result.success += 1
 
                 except httpx.HTTPStatusError as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=_record_preview(record),
-                            http_status=e.response.status_code,
-                            error_message=e.response.text[:500],
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        _record_preview(record),
+                        e,
+                        http_status=e.response.status_code,
+                        error_message=e.response.text[:500],
                     )
                     if sync_options.on_error == "fail":
                         break
                 except httpx.RequestError as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=_record_preview(record),
-                            http_status=None,
-                            error_message=f"Request error: {e}",
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        _record_preview(record),
+                        e,
+                        error_message=f"Request error: {e}",
                     )
                     if sync_options.on_error == "fail":
                         break
                 except Exception as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=_record_preview(record),
-                            http_status=None,
-                            error_message=str(e),
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        _record_preview(record),
+                        e,
                     )
                     if sync_options.on_error == "fail":
                         break

--- a/drt/destinations/slack.py
+++ b/drt/destinations/slack.py
@@ -44,7 +44,7 @@ from drt.config.models import DestinationConfig, SlackDestinationConfig, SyncOpt
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 from drt.templates.renderer import render_template
 
 
@@ -90,26 +90,22 @@ class SlackDestination:
                     with_retry(do_post, retry_config)
                     result.success += 1
                 except httpx.HTTPStatusError as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record, default=str)[:200],
-                            http_status=e.response.status_code,
-                            error_message=e.response.text[:500],
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        json.dumps(record, default=str)[:200],
+                        e,
+                        http_status=e.response.status_code,
+                        error_message=e.response.text[:500],
                     )
                     if sync_options.on_error == "fail":
                         break
                 except Exception as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record, default=str)[:200],
-                            http_status=None,
-                            error_message=str(e),
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        json.dumps(record, default=str)[:200],
+                        e,
                     )
                     if sync_options.on_error == "fail":
                         break

--- a/drt/destinations/snowflake.py
+++ b/drt/destinations/snowflake.py
@@ -31,7 +31,7 @@ from typing import Any
 from drt.config.credentials import resolve_env
 from drt.config.models import DestinationConfig, SnowflakeDestinationConfig, SyncOptions
 from drt.destinations.base import SyncResult
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 from drt.destinations.sql_utils import tagged_cursor
 
 _SWAP_SUFFIX = "__drt_swap"
@@ -274,14 +274,11 @@ class SnowflakeDestination:
                             cur.execute(sql, _bind_row(row, columns, json_cols))
                             result.success += 1
                         except Exception as e:
-                            result.failed += 1
-                            result.row_errors.append(
-                                RowError(
-                                    batch_index=i,
-                                    record_preview=str(row)[:200],
-                                    http_status=None,
-                                    error_message=str(e),
-                                )
+                            record_row_error(
+                                result,
+                                i,
+                                str(row)[:200],
+                                e,
                             )
                             if sync_options.on_error == "fail":
                                 raise
@@ -329,14 +326,11 @@ class SnowflakeDestination:
                                     )
                                     result.success += 1
                                 except Exception as e:
-                                    result.failed += 1
-                                    result.row_errors.append(
-                                        RowError(
-                                            batch_index=idx,
-                                            record_preview=str(row)[:200],
-                                            http_status=None,
-                                            error_message=str(e),
-                                        )
+                                    record_row_error(
+                                        result,
+                                        idx,
+                                        str(row)[:200],
+                                        e,
                                     )
                                     if sync_options.on_error == "fail":
                                         raise
@@ -466,14 +460,11 @@ class SnowflakeDestination:
                 cur.execute(sql, _bind_row(row, columns, json_cols))
                 result.success += 1
             except Exception as e:
-                result.failed += 1
-                result.row_errors.append(
-                    RowError(
-                        batch_index=i,
-                        record_preview=str(row)[:200],
-                        http_status=None,
-                        error_message=str(e),
-                    )
+                record_row_error(
+                    result,
+                    i,
+                    str(row)[:200],
+                    e,
                 )
                 if sync_options.on_error == "fail":
                     raise

--- a/drt/destinations/teams.py
+++ b/drt/destinations/teams.py
@@ -45,7 +45,7 @@ from drt.config.models import DestinationConfig, SyncOptions, TeamsDestinationCo
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 from drt.templates.renderer import render_template
 
 
@@ -101,26 +101,22 @@ class TeamsDestination:
                     with_retry(do_post, retry_config)
                     result.success += 1
                 except httpx.HTTPStatusError as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record, default=str)[:200],
-                            http_status=e.response.status_code,
-                            error_message=e.response.text[:500],
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        json.dumps(record, default=str)[:200],
+                        e,
+                        http_status=e.response.status_code,
+                        error_message=e.response.text[:500],
                     )
                     if sync_options.on_error == "fail":
                         break
                 except Exception as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=json.dumps(record, default=str)[:200],
-                            http_status=None,
-                            error_message=str(e),
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        json.dumps(record, default=str)[:200],
+                        e,
                     )
                     if sync_options.on_error == "fail":
                         break

--- a/drt/destinations/twilio.py
+++ b/drt/destinations/twilio.py
@@ -35,7 +35,7 @@ from drt.config.models import (
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 from drt.templates.renderer import render_template
 
 # E.164 format: + followed by 1–15 digits
@@ -122,27 +122,23 @@ class TwilioDestination:
                     result.success += 1
 
                 except httpx.HTTPStatusError as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=str(record)[:200],
-                            http_status=e.response.status_code,
-                            error_message=e.response.text[:500],
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        str(record)[:200],
+                        e,
+                        http_status=e.response.status_code,
+                        error_message=e.response.text[:500],
                     )
                     if sync_options.on_error == "fail":
                         raise
 
                 except Exception as e:
-                    result.failed += 1
-                    result.row_errors.append(
-                        RowError(
-                            batch_index=i,
-                            record_preview=str(record)[:200],
-                            http_status=None,
-                            error_message=str(e),
-                        )
+                    record_row_error(
+                        result,
+                        i,
+                        str(record)[:200],
+                        e,
                     )
                     if sync_options.on_error == "fail":
                         raise

--- a/drt/destinations/zendesk.py
+++ b/drt/destinations/zendesk.py
@@ -41,7 +41,7 @@ from drt.config.models import DestinationConfig, RetryConfig, SyncOptions, Zende
 from drt.destinations.base import SyncResult
 from drt.destinations.rate_limiter import RateLimiter, RateLimiterBackend, resolve_rate_limiter
 from drt.destinations.retry import resolve_retry, with_retry
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import record_row_error
 from drt.templates.renderer import render_template
 
 _ZENDESK_API_TEMPLATE = "https://{subdomain}.zendesk.com/api/v2"
@@ -321,12 +321,11 @@ def _add_row_error(
     http_status: int | None,
     message: str,
 ) -> None:
-    result.failed += 1
-    result.row_errors.append(
-        RowError(
-            batch_index=index,
-            record_preview=json.dumps(record, default=str)[:200],
-            http_status=http_status,
-            error_message=message,
-        )
+    record_row_error(
+        result,
+        index,
+        json.dumps(record, default=str)[:200],
+        Exception(message),
+        http_status=http_status,
+        error_message=message,
     )

--- a/tests/unit/test_row_errors.py
+++ b/tests/unit/test_row_errors.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 
 from drt.destinations.base import SyncResult
-from drt.destinations.row_errors import RowError
+from drt.destinations.row_errors import RowError, record_row_error
 
 
 class TestRowError:
@@ -94,3 +94,33 @@ class TestSyncResultRowErrors:
     def test_row_errors_empty_on_success(self) -> None:
         result = SyncResult(success=5)
         assert result.row_errors == []
+
+
+class TestRecordRowError:
+    def test_increments_failed_and_uses_exception_message(self) -> None:
+        result = SyncResult(failed=2)
+
+        record_row_error(result, 4, '{"id": 7}', ValueError("invalid"))
+
+        assert result.failed == 3
+        assert len(result.row_errors) == 1
+        assert result.row_errors[0].batch_index == 4
+        assert result.row_errors[0].record_preview == '{"id": 7}'
+        assert result.row_errors[0].http_status is None
+        assert result.row_errors[0].error_message == "invalid"
+
+    def test_preserves_explicit_status_and_message(self) -> None:
+        result = SyncResult()
+
+        record_row_error(
+            result,
+            1,
+            "transformed row",
+            RuntimeError("fallback"),
+            http_status=422,
+            error_message="response body",
+        )
+
+        assert result.failed == 1
+        assert result.row_errors[0].http_status == 422
+        assert result.row_errors[0].error_message == "response body"


### PR DESCRIPTION
## Summary

Closes #722 (last remaining item of its cleanup cluster — identifier quoting, mirror-capability guards, and `RowCountable` Protocol were already done in #726/#730). Pure refactor, no behavior change.

The `try/except → result.failed += 1 → row_errors.append(RowError(...))` idiom was duplicated roughly 100 times across 27 `drt/destinations/*.py` files. `postgres.py`/`mysql.py` already dedupe this via `BaseSqlDestination._record_row_error`, but that's only reachable by `BaseSqlDestination` subclasses.

Added `record_row_error(result, batch_index, record_preview, exc, *, http_status=None, error_message=None)` to `drt/destinations/row_errors.py`. Deliberately takes `record_preview` as a **pre-computed string**, not the raw record — surveyed the actual call sites first and the basis genuinely varies (most destinations JSON-dump the record dict; a few warehouse ones `str()` an already-transformed positional bind list). `http_status`/`error_message` stay caller-determined too (REST destinations split `httpx.HTTPStatusError` — with a real status code and response text — from a generic `Exception` fallback; SQL/warehouse destinations have no status concept at all). The helper only centralizes the "record the failure" 3 lines; `on_error` control flow (`break`/`continue`/`return`/`raise`, whichever each site already used) is completely unchanged — verified by direct diff read at every site, not just by tests passing.

Migrated 46 call sites across 23 files. `lookup.py` and `salesforce_bulk.py` only assemble local/aggregate `RowError` lists (no compatible per-row boilerplate) and were correctly left alone.

**Deliberately not touched:**
- `drt/destinations/clickhouse.py` — PR #1023 is actively modifying this file's error handling; touching it here would guarantee a merge conflict. Follow-up once #1023 merges.
- `drt/destinations/postgres.py`, `mysql.py`, `sql_base.py` — already have their own working, tested `_record_row_error` method; left as-is rather than refactored to call the new free function, an unnecessary separate risk for already-correct code.

## Verification

- [x] `ruff check drt tests` / `mypy drt` — clean
- [x] Full `pytest tests/unit/ -q` (not a subset — this touches 23 files across the whole destination layer) — 3468 passed, 3 skipped, 0 unrelated failures (2 known-unrelated `test_cli_version.py` failures are a path-depth artifact of this session's worktree location, confirmed elsewhere this session to pass from a normal-depth checkout)
- [x] Spot-checked several migrated sites by hand against the pre-change diff (REST/HTTP two-branch sites like `slack.py`, warehouse bind-list sites like `databricks.py`) to confirm `record_preview` basis, `http_status`, `error_message`, and `on_error` control flow are all byte-for-byte preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)