### PR TITLE
fix(state): mark _filelock.py's Windows-only branches as no-cover

### DIFF
--- a/drt/state/_filelock.py
+++ b/drt/state/_filelock.py
@@ -16,7 +16,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-if os.name == "nt":
+if os.name == "nt":  # pragma: no cover - no Windows CI runner in this repo
     import msvcrt
 else:
     import fcntl
@@ -31,7 +31,7 @@ else:
 _WINDOWS_RETRY_DELAY_SECONDS = 0.05
 
 
-def _acquire_windows(lock_file: Any) -> None:
+def _acquire_windows(lock_file: Any) -> None:  # pragma: no cover - no Windows CI runner
     while True:
         lock_file.seek(0)
         try:
@@ -41,7 +41,7 @@ def _acquire_windows(lock_file: Any) -> None:
             time.sleep(_WINDOWS_RETRY_DELAY_SECONDS)
 
 
-def _release_windows(lock_file: Any) -> None:
+def _release_windows(lock_file: Any) -> None:  # pragma: no cover - no Windows CI runner
     lock_file.seek(0)
     msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
 
@@ -55,7 +55,7 @@ def advisory_lock(path: Path) -> Iterator[None]:
     # a+b creates the sidecar before locking and permits the one-byte Windows
     # locking convention. The sidecar deliberately remains after release.
     with lock_path.open("a+b") as lock_file:
-        if os.name == "nt":
+        if os.name == "nt":  # pragma: no cover - no Windows CI runner in this repo
             lock_file.seek(0)
             if not lock_file.read(1):
                 lock_file.write(b"\0")
@@ -67,7 +67,7 @@ def advisory_lock(path: Path) -> Iterator[None]:
         try:
             yield
         finally:
-            if os.name == "nt":
+            if os.name == "nt":  # pragma: no cover - no Windows CI runner in this repo
                 _release_windows(lock_file)
             else:
                 fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)


### PR DESCRIPTION
## Summary

Follow-up to #1031 — codecov flagged `drt/state/_filelock.py` at 85.19% patch coverage (16 lines missing). Unlike this session's other coverage flags (which turned out to be false alarms from refactor-shifted line numbers), this one is real: the Windows lock path is structurally unreachable in CI, which only runs on Linux/macOS. There's no Windows runner in this repo's CI, so this gap could never close by adding tests.

## What changed

Added `# pragma: no cover - no Windows CI runner in this repo` to `_acquire_windows()`, `_release_windows()`, and both `if os.name == "nt":` branches in `advisory_lock()`. Follows the existing convention already used elsewhere in this codebase for the same class of untestable-by-construction branches (driver-absent `ImportError` handlers in `drt/sources/*.py`, SDK invariants in `drt/state/gcs.py`/`s3.py`).

No behavior change — purely a coverage-accounting annotation.

## Verification

- Local coverage for `_filelock.py`: 18/18 statements, 100%
- `ruff check drt tests` — clean
- `mypy drt` — clean, 200 files
- `pytest tests/unit/ -q` — 3484 passed, 3 skipped, plus 2 known-unrelated `test_cli_version.py` failures (deep-scratchpad-path artifact)

## Test plan

- [x] Unit suite green
- [x] Coverage verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)