### PR TITLE
docs(state): document that advisory_lock/threading.Lock nesting order is load-bearing

### DIFF
--- a/drt/state/_filelock.py
+++ b/drt/state/_filelock.py
@@ -5,6 +5,17 @@ These advisory locks coordinate separate drt processes; each store's existing
 are needed. As with advisory ``flock`` generally, locking may be unreliable on
 NFS or other network filesystems whose server or mount configuration does not
 preserve the host OS's locking semantics.
+
+Nesting order is load-bearing: every call site holds ``advisory_lock()``
+*outside* its ``threading.Lock`` — ``with advisory_lock(path): with
+self._lock: ...`` — never the reverse. ``self._lock`` is one mutex shared
+across every sync name a store instance handles; if it were held while
+waiting on the OS lock (which can block for as long as another *process*
+holds it, unbounded), one contended sync would stall every other sync's
+``--threads N`` worker too, even though their own per-file locks are free.
+With the OS lock outside, a thread blocks only on the one file it's actually
+waiting for, and never holds the shared mutex while doing so — caught during
+review of a similar approach in #1012, credit to @Pawansingh3889.
 """
 
 from __future__ import annotations

--- a/drt/state/dlq.py
+++ b/drt/state/dlq.py
@@ -150,7 +150,8 @@ class LocalDlqStore:
     One JSONL file per sync (``<sync_name>.jsonl``). All mutating methods run
     under ``self._lock`` for threads sharing this instance and an OS-level
     sidecar lock for separate drt processes. Single-writer-at-a-time remains
-    the expected operational model.
+    the expected operational model. Lock nesting order is load-bearing — see
+    ``drt.state._filelock``.
     """
 
     def __init__(self, project_dir: Path = Path(".")) -> None:

--- a/drt/state/history.py
+++ b/drt/state/history.py
@@ -89,7 +89,10 @@ class LocalHistoryManager:
 
     Files live under ``<project_dir>/.drt/history/<sync_name>.jsonl``. All
     writes append a single JSON object per line. Reads return the most recent
-    N entries (newest first).
+    N entries (newest first). Mutating methods use ``self._lock`` for threads
+    sharing this instance and an OS-level sidecar lock for separate drt
+    processes — lock nesting order is load-bearing, see
+    ``drt.state._filelock``.
     """
 
     _MAX_ERRORS_PER_ENTRY = 5

--- a/drt/state/manager.py
+++ b/drt/state/manager.py
@@ -86,6 +86,7 @@ class LocalStateManager:
     All public methods are thread-safe via ``self._lock``. Mutations also use
     an OS-level sidecar lock to serialise read-modify-write cycles across drt
     processes. Single-writer-at-a-time remains the expected operational model.
+    Lock nesting order is load-bearing — see ``drt.state._filelock``.
     """
 
     def __init__(self, project_dir: Path = Path(".")) -> None:

--- a/drt/state/watermark.py
+++ b/drt/state/watermark.py
@@ -72,7 +72,7 @@ class LocalWatermarkStorage:
 
     Public methods are thread-safe via ``self._lock``. Mutations also use an
     OS-level sidecar lock to serialise read-modify-write cycles across drt
-    processes.
+    processes. Lock nesting order is load-bearing — see ``drt.state._filelock``.
     """
 
     def __init__(self, project_dir: Path) -> None:


### PR DESCRIPTION
## Summary

Prompted by @Pawansingh3889's review of his own PR #1012 (closed, superseded by #1031/#963 — [see the closing/reply thread](https://github.com/drt-hub/drt/pull/1012#issuecomment-5473540307)): his implementation held the shared per-instance `threading.Lock` **outside** the OS-level wait, so one sync contended with another process could stall every other sync's `--threads N` worker too, since they'd all block on the same shared mutex while one thread waits on the OS lock (which can block for as long as another process holds it).

The implementation that shipped on `main` already has the correct order (`advisory_lock(path)` outside, `self._lock` inside — a thread only ever blocks on the one file it's actually waiting for), but nothing said so explicitly. It was incidental to how the code happened to be written, not a documented invariant a future refactor would know to preserve.

## What changed

- `_filelock.py`'s module docstring now explains the required nesting order and why, once, in the shared primitive every store imports.
- Each of the four local stores' own class docstrings (`LocalStateManager`, `LocalHistoryManager`, `LocalDlqStore`, `LocalWatermarkStorage`) gets a one-line pointer to it, alongside their existing locking-behavior description.

No behavior change — documentation only.

## Test plan

- [x] `ruff check drt tests` / `mypy drt` clean
- [x] `tests/unit/test_local_state_concurrency.py` still green (docstring-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)