### PR TITLE
bug(config): write the BigQuery profile's location back on save

### DIFF
--- a/drt/config/credentials.py
+++ b/drt/config/credentials.py
@@ -580,6 +580,10 @@ def save_profile(
         }
         if profile.keyfile:
             entry["keyfile"] = profile.keyfile
+        # load_profile defaults this to "US", so writing it only when it differs
+        # keeps existing files byte-identical while still surviving the round trip.
+        if profile.location != "US":
+            entry["location"] = profile.location
     elif isinstance(profile, DuckDBProfile):
         entry = {"type": "duckdb", "database": profile.database}
     elif isinstance(profile, SQLiteProfile):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -345,6 +345,29 @@ def test_load_profile_bigquery_location_default(tmp_path: Path) -> None:
     assert loaded.location == "US"
 
 
+def test_save_profile_bigquery_location_round_trips(tmp_path: Path) -> None:
+    """A non-default location survived load but was dropped on save."""
+    save_profile(
+        "dev",
+        BigQueryProfile(
+            type="bigquery", project="p", dataset="d", location="asia-northeast1"
+        ),
+        config_dir=tmp_path,
+    )
+    assert load_profile("dev", config_dir=tmp_path).location == "asia-northeast1"
+
+
+def test_save_profile_bigquery_omits_the_default_location(tmp_path: Path) -> None:
+    """The default is written by load, so save leaves it out of the file."""
+    save_profile(
+        "dev",
+        BigQueryProfile(type="bigquery", project="p", dataset="d"),
+        config_dir=tmp_path,
+    )
+    assert "location" not in (tmp_path / "profiles.yml").read_text()
+    assert load_profile("dev", config_dir=tmp_path).location == "US"
+
+
 def test_load_profile_missing_file(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError, match="profiles.yml not found"):
         load_profile("dev", config_dir=tmp_path)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -349,9 +349,7 @@ def test_save_profile_bigquery_location_round_trips(tmp_path: Path) -> None:
     """A non-default location survived load but was dropped on save."""
     save_profile(
         "dev",
-        BigQueryProfile(
-            type="bigquery", project="p", dataset="d", location="asia-northeast1"
-        ),
+        BigQueryProfile(type="bigquery", project="p", dataset="d", location="asia-northeast1"),
         config_dir=tmp_path,
     )
     assert load_profile("dev", config_dir=tmp_path).location == "asia-northeast1"


### PR DESCRIPTION
Closes #1096

**Problem.** `load_profile` reads `location` (defaulting to `"US"`), but `save_profile`'s bigquery branch never wrote it. A `BigQueryProfile` with `location="asia-northeast1"` came back as `"US"` after a save/load round trip, silently.

**Change.** The guarded-write pattern already used for `keyfile`, as the issue suggests:

```python
if profile.location != "US":
    entry["location"] = profile.location
```

Writing it only when it differs from the default `load_profile` already supplies keeps existing `profiles.yml` files byte-identical, and nothing that never set a location gains a line.

**Verify.**

```
pytest tests/unit/test_config.py
```

164 passed. Two tests added beside the existing `test_load_profile_bigquery_location*` pair: the round trip that was broken, and that the default is still absent from the written file.

Two files, +18/-0. No other profile type touched.