### PR TITLE
docs(adr): amend ADR 0005 with warehouse write-grant opt-in research

### DIFF
--- a/docs/adr/0005-state-location-and-write-grants.md
+++ b/docs/adr/0005-state-location-and-write-grants.md
@@ -9,6 +9,35 @@
   corrections listed under [Follow-up issues](#follow-up-issues).
 - **Issues:** [#755](https://github.com/drt-hub/drt/issues/755),
   [#756](https://github.com/drt-hub/drt/issues/756)
+- **Amended:** 2026-09-05 — competitive research into how Hightouch, Segment,
+  RudderStack, Census, Polytomic, Rivery, dlt, and Meltano handle
+  warehouse-write opt-ins confirmed this ADR's core positions rather than
+  changing them: the tiered, reversible, non-paywalled design (Decisions 1 and
+  4) has no equivalent among the reverse-ETL vendors researched — Hightouch's
+  Basic→Lightning upgrade is explicitly one-way, and Segment/RudderStack
+  require write access unconditionally with no tiering at all. Two corrections
+  and one addition: (1) #755's and #920's core mechanisms (warehouse
+  snapshot-diff, SQL-queryable sync history) are **already shipped** by
+  Hightouch/Segment/RudderStack and Census/Hightouch respectively — they
+  should be scheduled and described as closing a table-stakes gap, not as
+  differentiation, correcting this ADR's original "none is warranted on this
+  axis" framing to be more precise: the *axis* was right, but #755/#920
+  specifically are catch-up, not the exception. (2) Genuine, currently
+  unclaimed differentiation exists one layer up the same write-access stack:
+  a warehouse-backed idempotency ledger for fire-and-forget destinations
+  ([#1099](https://github.com/drt-hub/drt/issues/1099), no researched vendor
+  offers this) and a compliance audit trail with owned retention/purge
+  ([#1100](https://github.com/drt-hub/drt/issues/1100) — Hightouch has the
+  same table shape in `hightouch_audit.Changelog` but frames unmanaged PII
+  retention as the *customer's* problem, which is exactly the gap #1100
+  closes as a product feature instead). (3) Postgres logical replication's
+  publication+slot create/drop symmetry is adopted as the concrete
+  reversibility precedent for Decision 4 — cleaner than anything found in the
+  reverse-ETL space itself, where scoped-schema designs (RudderStack,
+  Segment) isolate blast radius but ship no downgrade path at all. Full
+  research and issue-by-issue notes: [#755](https://github.com/drt-hub/drt/issues/755#issuecomment-5551408063),
+  [#920](https://github.com/drt-hub/drt/issues/920#issuecomment-5551408667),
+  [#960](https://github.com/drt-hub/drt/issues/960#issuecomment-5551409522).
 - **Relates to:** [ADR 0004](0004-streaming-and-event-triggered-syncs.md) — whose
   Tier 2 gate is #756, and whose #769 amendment this ADR corrects.
 - **Implementation:** none directly. This ADR sets the ordering and the
@@ -233,3 +262,8 @@ check this in, since it is the topology the failure mode targets.
    goal, so neither is quietly lost during implementation.
 4. **Re-scope the #769 cross-process residual** out of #756 per the correction
    above, and amend ADR 0004's gate table accordingly.
+5. **New issues from the 2026-09-05 amendment**: [#1099](https://github.com/drt-hub/drt/issues/1099)
+   (warehouse idempotency ledger) and [#1100](https://github.com/drt-hub/drt/issues/1100)
+   (compliance audit trail) — both gated on #960, both flagged as the
+   genuinely-unclaimed differentiation this ADR's "none is warranted" framing
+   didn't anticipate finding one layer up the stack.


### PR DESCRIPTION
## Summary

Docs-only change (no code). Amends [ADR 0005](https://github.com/drt-hub/drt/blob/main/docs/adr/0005-state-location-and-write-grants.md) with findings from a competitive-research pass into how other reverse-ETL/data tools (Hightouch, Segment, RudderStack, Census, Polytomic, Rivery, dlt, Meltano) handle optional elevated warehouse permissions, following a discussion about whether/how drt should offer an opt-in "grant drt write access to your source warehouse" tier.

## What the research found

- The ADR's core design (tiered, reversible, config-driven, not a paywall) has **no equivalent among researched vendors** — Hightouch's Basic→Lightning upgrade is a documented one-way door; Segment/RudderStack require write access unconditionally with no tiering at all.
- **#755 and #920's core mechanisms are already shipped elsewhere** (Hightouch/Segment/RudderStack all do warehouse snapshot-diff; Census/Hightouch both do SQL-queryable sync history) — these should be scheduled and described as closing a table-stakes gap, not as differentiation.
- **Genuine unclaimed differentiation exists one layer up**: a warehouse-backed idempotency ledger for fire-and-forget destinations, and a compliance audit trail with drt-owned retention/purge (vs. Hightouch's existing `Changelog` table, which leaves PII retention entirely to the customer).
- Postgres logical replication's publication+slot create/drop symmetry is the cleanest reversibility precedent found — adopted as the concrete model for ADR 0005 Decision 4.

## What changed

- ADR 0005: new dated amendment in the header (matching this repo's existing amendment pattern, see ADR 0004), plus a new Follow-up issues entry.
- Two new issues: #1099 (warehouse idempotency ledger), #1100 (compliance audit trail).
- Comment-only annotations (no issue body rewrites) on #755, #920, #960, #758, #761 — repositioning notes and forward-pointers, not scope changes.
- #1046 corrected and closed — its premise ("#760/#761/#896 block on #960") didn't hold up against those issues' own text; none of the three actually names #960 as a dependency.

## Test plan

N/A — documentation only, no code touched.